### PR TITLE
[feat] Autogenerated Typescript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pids
 .idea
 yarn.lock
 package-lock.json
+types/*
+!types/index.d.ts

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "Apify API client for JavaScript",
   "main": "build/index.js",
+  "types": "types/index.d.ts",
   "keywords": [
     "apify",
     "api",
@@ -35,16 +36,18 @@
   },
   "homepage": "https://apify.com/docs/sdk/apify-client-js/latest",
   "files": [
-    "build"
+    "build",
+    "types"
   ],
   "scripts": {
     "build": "babel src --out-dir build",
     "build-doc": "npm run clean && npm run build && node ./node_modules/jsdoc/jsdoc.js --package ./package.json -c ./jsdoc/conf.json -d docs",
     "build-toc": "./node_modules/.bin/markdown-toc README.md -i",
+    "build-types": "./node_modules/.bin/tsc -p tsconfig.json",
     "test": "npm run build && nyc --reporter=html --reporter=text mocha --timeout 5000 --compilers js:babel-core/register --recursive",
-    "prepare": "npm run build-toc && npm run build",
+    "prepare": "npm run build-toc && npm run build-types && npm run build",
     "prepublishOnly": "(test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)) && npm test && npm run lint",
-    "clean": "rm -rf build && rm -rf docs",
+    "clean": "rm -rf build && rm -rf docs && find types/ -type f -name '*.d.ts' ! -name index.d.ts | xargs rm -f",
     "lint": "npm run build && eslint src test"
   },
   "dependencies": {
@@ -74,6 +77,7 @@
     "markdown-toc": "^1.2.0",
     "mocha": "^5.2.0",
     "nyc": "^13.0.1",
-    "sinon": "^6.3.1"
+    "sinon": "^6.3.1",
+    "typescript": "^3.7.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "lib": [
+            "es2017"
+        ],
+        "allowJs": true,
+        "checkJs": false,
+        "noEmit": false,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "strict": false,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "esModuleInterop": true,
+        "outDir": "types/"
+    },
+    "include": [
+        "src/*.js"
+    ],
+    "exclude": [
+        "src/index.js"
+    ]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,98 @@
+// TODO yin: Typescript declarations should be testable.
+//  One way would be to add typescript as devDependency to this project and write typescript tests right here.
+//  The other way would be similar to contributing typings to github.com/DefinitelyTyped: separate the declarations into
+//  a different project, run the tests there and have this project untouched by typescript.
+import acts from './acts';
+import tasks from './tasks';
+import crawlers from './crawlers';
+import keyValueStores from './key_value_stores';
+import datasets from './datasets';
+import logs from './logs';
+import users from './users';
+import webhooks from './webhooks';
+import webhookDispatches from './webhook_dispatches';
+import requestQueues from './request_queues';
+import ApifyClientError from './apify_error';
+
+export default ApifyClient;
+export {
+    acts,
+    tasks,
+    crawlers,
+    keyValueStores,
+    datasets,
+    requestQueues,
+    logs,
+    users,
+    webhooks,
+    webhookDispatches,
+    ApifyClientError
+}
+
+/**
+ * @param {string} [userId] - Your user ID at apify.com
+ * @param {string} [token] - Your API token at apify.com
+ * @param {number} [expBackOffMillis=500] - Wait time in milliseconds before repeating request to Apify API in a case of server
+ or rate limit error
+ * @param {number} [expBackOffMaxRepeats=8] - Maximum number of repeats in a case of error
+ * @param {Array<number>} [retryOnStatusCodes=[429]] - An array of status codes on which request gets retried. By default requests are retried
+ *                                                             only in a case of limit error (status code 429).
+ */
+declare interface ApifyClientOptions {
+    userId?: string
+    token?: string
+    expBackOffMillis?: number
+    expBackOffMaxRepeats?: number
+    retryOnStatusCodes?: Array<number>
+}
+
+/**
+ * @class ApifyClient
+ * @param {ApifyClientOptions} [options] - Global options for ApifyClient. You can globally configure here any method option from any namespace. For example
+ *                             if you are working with just one crawler then you can preset it's crawlerId here instead of passing it to each
+ *                             crawler's method.
+ * @description Basic usage of ApifyClient:
+ * ```javascript
+ * const ApifyClient = require('apify-client');
+ *
+ * const apifyClient = new ApifyClient({
+ *   userId: 'jklnDMNKLekk',
+ *   token: 'SNjkeiuoeD443lpod68dk',
+ * });
+ * ```
+ */
+declare class ApifyClient {
+    constructor(options: ApifyClientOptions);
+
+    /**
+     * Overrides options of ApifyClient instance.
+     * @param {ApifyClientOptions} options - See {@link ApifyClient} options object
+     */
+    setOptions(options: ApifyClientOptions);
+
+    /**
+     * Returns options of ApifyClient instance.
+     * @return {ApifyClientOptions} See {@link ApifyClient} constructor options
+     */
+    getOptions(): ApifyClientOptions;
+
+    /**
+     * An object that contains various statistics about the API operations.
+     */
+    stats: {
+        /**
+         * Number of Apify client function calls.
+         */
+        calls: number
+
+        /**
+         * Number of Apify API requests.
+         */
+        requests: number
+
+        /**
+         * Number of times the API returned 429 error. Spread based on number of retries.
+         */
+        rateLimitErrors: number
+    };
+}


### PR DESCRIPTION
Please, check to let me know about any problems.

**Motivation:**
`ApifyClient` is used throughout the Apify SDK and SDK exposes it to the user through `Apify.client`. It made more sense to add these typings/declarations than to remove annotation `@returns {ApifyClient}` from the `Apify.client`.

**Features:**
- [x] All except the main (public) declarations in `types/index.d.ts` are autogenerated.
- [x] Adds typescript ^3.7.4 as dev-dependency.
- [ ] Typescript compile-time and runtime tests.
- [ ] Checked manually to conform precisely to published `apify-client` docs.