### PR TITLE
Fixed: Omits query params for direct upload URL calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.4 / 2021/02/10
+===================
+- Omit query params for direct upload URL calls
+
 1.0.3 / 2021/01/29
 ===================
 - Removed limits on max content/body length.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-client",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Apify API client for JavaScript",
     "main": "src/index.js",
     "keywords": [

--- a/src/resource_clients/key_value_store.js
+++ b/src/resource_clients/key_value_store.js
@@ -167,14 +167,14 @@ class KeyValueStoreClient extends ResourceClient {
         // No need to keep original large value in memory
         value = maybeZippedValue;
 
-        const uploadUrl = this._shouldUseDirectUpload(value)
-            ? await this._getSignedUploadUrl(key, headers)
-            : this._url(`records/${key}`);
+        const shouldUseDirectUpload = this._shouldUseDirectUpload(value);
 
         const uploadOpts = {
-            url: uploadUrl,
+            url: shouldUseDirectUpload
+                ? await this._getSignedUploadUrl(key, headers)
+                : this._url(`records/${key}`),
             method: 'PUT',
-            params: this._params(),
+            params: shouldUseDirectUpload ? null : this._params(),
             data: value,
             headers,
         };

--- a/test/key_value_stores.test.js
+++ b/test/key_value_stores.test.js
@@ -415,7 +415,7 @@ describe('Key-Value Store methods', () => {
 
             const res = await client.keyValueStore(storeId).setRecord({ key, value });
             expect(res).toBeUndefined();
-            validateRequest({}, { code }, value, {
+            validateRequest(false, { code }, value, {
                 'content-type': contentType,
                 'content-encoding': 'gzip',
             });
@@ -425,7 +425,7 @@ describe('Key-Value Store methods', () => {
                 storeId, key, value,
             );
             expect(browserRes).toBeUndefined();
-            validateRequest({}, { code }, value, {
+            validateRequest(false, { code }, value, {
                 'content-type': contentType,
             });
         });


### PR DESCRIPTION
I found this problem during testing API. Before v1 released Apify query parameters were not included in direct upload URL calls.
