### PR TITLE
Add missing getOrCreate validations

### DIFF
--- a/src/resource_clients/dataset_collection.js
+++ b/src/resource_clients/dataset_collection.js
@@ -40,6 +40,7 @@ class DatasetCollectionClient extends ResourceCollectionClient {
      * @return {Promise<object>}
      */
     async getOrCreate(name) {
+        ow(name, ow.optional.string);
         return this._getOrCreate(name);
     }
 }

--- a/src/resource_clients/key_value_store_collection.js
+++ b/src/resource_clients/key_value_store_collection.js
@@ -40,6 +40,7 @@ class KeyValueStoreCollectionClient extends ResourceCollectionClient {
      * @return {Promise<object>}
      */
     async getOrCreate(name) {
+        ow(name, ow.optional.string);
         return this._getOrCreate(name);
     }
 }

--- a/src/resource_clients/request_queue_collection.js
+++ b/src/resource_clients/request_queue_collection.js
@@ -40,6 +40,7 @@ class RequestQueueCollection extends ResourceCollectionClient {
      * @return {Promise<RequestQueue>}
      */
     async getOrCreate(name) {
+        ow(name, ow.optional.string);
         return this._getOrCreate(name);
     }
 }


### PR DESCRIPTION
`ow` argument checks were missing which caused weird errors when `{ name }` instead of `name` was provided.