### PR TITLE
fix: slowdown for big responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.1 / 2021/04/14
+===================
+- Fixed slow parsing of large responses due to a [bug in `axios`](https://github.com/axios/axios/issues/2829).
+
 1.1.0 / 2021/04/10
 ===================
 - Added timeout, memory, and build parameters to `client.run.resurrect()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-client",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Apify API client for JavaScript",
     "main": "src/index.js",
     "keywords": [

--- a/src/http_client.js
+++ b/src/http_client.js
@@ -70,8 +70,8 @@ class HttpClient {
             transformResponse: null,
             responseType: 'arraybuffer',
             timeout: this.timeoutMillis,
-            maxContentLength: Infinity,
-            maxBodyLength: Infinity,
+            maxContentLength: -1,
+            maxBodyLength: -1,
         });
 
         // Clean all default headers because they only make a mess


### PR DESCRIPTION
Thanks to a [bug in `axios`](https://github.com/axios/axios/issues/2829) downloading of large responses was extremely slow. Using a `-1` instead of `Infinity` as `maxContentLength` fixes the problem.