### PR TITLE
fix: axios maxBodyLength option not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.3 / 2021/05/27
+===================
+- Fixed invalid max body length setting thanks to a transitive default in `axios`.
+
 1.2.2 / 2021/04/20
 ===================
 - Fixed double stringification of JSON inputs in `.start()`, `.call()` and `.metamorph()` functions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-client",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Apify API client for JavaScript",
     "main": "src/index.js",
     "keywords": [

--- a/src/http_client.js
+++ b/src/http_client.js
@@ -70,8 +70,12 @@ class HttpClient {
             transformResponse: null,
             responseType: 'arraybuffer',
             timeout: this.timeoutMillis,
+            // maxBodyLength needs to be Infinity, because -1 falls back to a 10 MB default
+            // from an axios subdependency - 'follow-redirects'
+            maxBodyLength: Infinity,
+            // maxContentLength must be -1, because Infinity will cause axios to run super slow
+            // thanks to a bug that's now fixed, but not released yet https://github.com/axios/axios/pull/3738
             maxContentLength: -1,
-            maxBodyLength: -1,
         });
 
         // Clean all default headers because they only make a mess


### PR DESCRIPTION
Code says it all.

```js
// maxBodyLength needs to be Infinity, because -1 falls back to a 10 MB default
// from an axios subdependency - 'follow-redirects'
maxBodyLength: Infinity,
// maxContentLength must be -1, because Infinity will cause axios to run super slow
// thanks to a bug that's now fixed, but not released yet https://github.com/axios/axios/pull/3738
maxContentLength: -1,
```