### PR TITLE
chore: update apify-shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.4 / 2021/06/01
+===================
+- use new `apify-shared` packages to reduce bundle size
+
 1.2.3 / 2021/05/27
 ===================
 - Fixed invalid max body length setting thanks to a transitive default in `axios`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-client",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Apify API client for JavaScript",
     "main": "src/index.js",
     "keywords": [
@@ -55,8 +55,9 @@
         "build-browser": "webpack"
     },
     "dependencies": {
+        "@apify/consts": "^1.0.0",
+        "@apify/log": "^1.0.0",
         "agentkeepalive": "^4.1.3",
-        "apify-shared": "^0.7.5",
         "async-retry": "^1.3.1",
         "axios": "^0.21.1",
         "content-type": "^1.0.4",

--- a/src/base/resource_client.js
+++ b/src/base/resource_client.js
@@ -1,4 +1,4 @@
-const { ACT_JOB_TERMINAL_STATUSES } = require('apify-shared/consts');
+const { ACT_JOB_TERMINAL_STATUSES } = require('@apify/consts');
 const ApiClient = require('./api_client');
 const {
     pluckData,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const ow = require('ow').default;
-const { ME_USER_NAME_PLACEHOLDER } = require('apify-shared/consts');
-const logger = require('apify-shared/log');
+const { ME_USER_NAME_PLACEHOLDER } = require('@apify/consts');
+const { default: logger } = require('@apify/log');
 
 const HttpClient = require('./http_client');
 const Statistics = require('./statistics');

--- a/src/resource_clients/actor.js
+++ b/src/resource_clients/actor.js
@@ -1,6 +1,4 @@
-const {
-    ACT_JOB_STATUSES,
-} = require('apify-shared/consts');
+const { ACT_JOB_STATUSES } = require('@apify/consts');
 const ow = require('ow').default;
 const ActorVersionClient = require('./actor_version');
 const ActorVersionCollectionClient = require('./actor_version_collection');

--- a/src/resource_clients/key_value_store.js
+++ b/src/resource_clients/key_value_store.js
@@ -1,5 +1,5 @@
 const ow = require('ow').default;
-const log = require('apify-shared/log');
+const { default: log } = require('@apify/log');
 const ResourceClient = require('../base/resource_client');
 const { isBuffer, isStream } = require('../utils');
 const {

--- a/src/resource_clients/run_collection.js
+++ b/src/resource_clients/run_collection.js
@@ -1,6 +1,4 @@
-const {
-    ACT_JOB_STATUSES,
-} = require('apify-shared/consts');
+const { ACT_JOB_STATUSES } = require('@apify/consts');
 const ow = require('ow').default;
 const ResourceCollectionClient = require('../base/resource_collection_client');
 

--- a/src/resource_clients/task.js
+++ b/src/resource_clients/task.js
@@ -1,5 +1,5 @@
 const ow = require('ow').default;
-const { ACT_JOB_STATUSES } = require('apify-shared/consts');
+const { ACT_JOB_STATUSES } = require('@apify/consts');
 const ResourceClient = require('../base/resource_client');
 const RunCollectionClient = require('./run_collection');
 const WebhookCollectionClient = require('./webhook_collection');

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -1,4 +1,4 @@
-const { ME_USER_NAME_PLACEHOLDER } = require('apify-shared/consts');
+const { ME_USER_NAME_PLACEHOLDER } = require('@apify/consts');
 const ApifyClient = require('../src');
 const mockServer = require('./mock_server/server');
 const { Browser, validateRequest, DEFAULT_QUERY } = require('./_helper');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
         ],
     },
     resolve: {
+        mainFields: ['browser', 'main', 'module'],
         extensions: ['*', '.js'],
     },
     node: {


### PR DESCRIPTION
Updates `apify-shared` to use only the needed packages (`log` and `consts`).