### PR TITLE
fix: revert back passing params using ApifyClient _params method

### DIFF
--- a/src/base/api_client.js
+++ b/src/base/api_client.js
@@ -6,6 +6,7 @@
  * @property {ApifyClient} options.apifyClient
  * @property {HttpClient} options.httpClient
  * @property {string} [options.id]
+ * @property {object} [options.params]
  * @private
  */
 
@@ -23,6 +24,7 @@ class ApiClient {
             httpClient,
             resourcePath,
             id,
+            params = {},
         } = options;
 
         this.id = id;
@@ -34,6 +36,7 @@ class ApiClient {
             : `${baseUrl}/${resourcePath}`;
         this.apifyClient = apifyClient;
         this.httpClient = httpClient;
+        this.params = params;
     }
 
     /**
@@ -46,6 +49,7 @@ class ApiClient {
             baseUrl: this._url(),
             apifyClient: this.apifyClient,
             httpClient: this.httpClient,
+            params: this._params(),
         };
         return { ...baseOptions, ...moreOptions };
     }
@@ -57,6 +61,15 @@ class ApiClient {
      */
     _url(path) {
         return path ? `${this.url}/${path}` : this.url;
+    }
+
+    /**
+     * @param {object} [endpointParams]
+     * @returns {object}
+     * @private
+     */
+    _params(endpointParams) {
+        return { ...this.params, ...endpointParams };
     }
 
     /**

--- a/src/base/resource_client.js
+++ b/src/base/resource_client.js
@@ -30,7 +30,7 @@ class ResourceClient extends ApiClient {
         const requestOpts = {
             url: this._url(),
             method: 'GET',
-            params: { ...options },
+            params: this._params(options),
         };
         try {
             const response = await this.httpClient.call(requestOpts);
@@ -48,6 +48,7 @@ class ResourceClient extends ApiClient {
         const response = await this.httpClient.call({
             url: this._url(),
             method: 'PUT',
+            params: this._params(),
             data: newFields,
         });
         return parseDateFields(pluckData(response.data));
@@ -62,6 +63,7 @@ class ResourceClient extends ApiClient {
             await this.httpClient.call({
                 url: this._url(),
                 method: 'DELETE',
+                params: this._params(),
             });
         } catch (err) {
             return catchNotFoundOrThrow(err);
@@ -100,7 +102,7 @@ class ResourceClient extends ApiClient {
             const requestOpts = {
                 url: this._url(),
                 method: 'GET',
-                params: { waitForFinish },
+                params: this._params({ waitForFinish }),
             };
             try {
                 const response = await this.httpClient.call(requestOpts);

--- a/src/base/resource_collection_client.js
+++ b/src/base/resource_collection_client.js
@@ -19,7 +19,7 @@ class ResourceCollectionClient extends ApiClient {
         const response = await this.httpClient.call({
             url: this._url(),
             method: 'GET',
-            params: options,
+            params: this._params(options),
         });
         return parseDateFields(pluckData(response.data));
     }
@@ -33,6 +33,7 @@ class ResourceCollectionClient extends ApiClient {
         const response = await this.httpClient.call({
             url: this._url(),
             method: 'POST',
+            params: this._params(),
             data: resource,
         });
         return parseDateFields(pluckData(response.data));
@@ -51,7 +52,7 @@ class ResourceCollectionClient extends ApiClient {
         const response = await this.httpClient.call({
             url: this._url(),
             method: 'POST',
-            params: { name },
+            params: this._params({ name }),
         });
         return parseDateFields(pluckData(response.data));
     }

--- a/src/resource_clients/actor.js
+++ b/src/resource_clients/actor.js
@@ -91,7 +91,7 @@ class ActorClient extends ResourceClient {
             url: this._url('runs'),
             method: 'POST',
             data: input,
-            params,
+            params: this._params(params),
             // Apify internal property. Tells the request serialization interceptor
             // to stringify functions to JSON, instead of omitting them.
             stringifyFunctions: true,
@@ -162,10 +162,10 @@ class ActorClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('builds'),
             method: 'POST',
-            params: {
+            params: this._params({
                 version: versionNumber,
                 ...options,
-            },
+            }),
         });
 
         return parseDateFields(pluckData(response.data));
@@ -184,7 +184,7 @@ class ActorClient extends ResourceClient {
 
         return new RunClient(this._subResourceOptions({
             id: 'last',
-            params: options,
+            params: this._params(options),
             resourcePath: 'runs',
         }));
     }

--- a/src/resource_clients/build.js
+++ b/src/resource_clients/build.js
@@ -40,6 +40,7 @@ class BuildClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('abort'),
             method: 'POST',
+            params: this._params(),
         });
 
         return parseDateFields(pluckData(response.data));

--- a/src/resource_clients/dataset.js
+++ b/src/resource_clients/dataset.js
@@ -71,7 +71,7 @@ class DatasetClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('items'),
             method: 'GET',
-            params: options,
+            params: this._params(options),
         });
         return this._createPaginationList(response);
     }
@@ -123,10 +123,10 @@ class DatasetClient extends ResourceClient {
         const { data } = await this.httpClient.call({
             url: this._url('items'),
             method: 'GET',
-            params: {
+            params: this._params({
                 format,
                 ...options,
-            },
+            }),
             forceBuffer: true,
         });
         return data;
@@ -151,6 +151,7 @@ class DatasetClient extends ResourceClient {
                 'content-type': 'application/json; charset=utf-8',
             },
             data: items,
+            params: this._params(),
             doNotRetryTimeouts: true, // see timeout handling in http-client
         });
     }

--- a/src/resource_clients/key_value_store.js
+++ b/src/resource_clients/key_value_store.js
@@ -64,7 +64,7 @@ class KeyValueStoreClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('keys'),
             method: 'GET',
-            params: options,
+            params: this._params(options),
         });
         return parseDateFields(pluckData(response.data));
     }
@@ -102,6 +102,7 @@ class KeyValueStoreClient extends ResourceClient {
         const requestOpts = {
             url: this._url(`records/${key}`),
             method: 'GET',
+            params: this._params(),
         };
 
         if (options.buffer) requestOpts.forceBuffer = true;
@@ -155,6 +156,7 @@ class KeyValueStoreClient extends ResourceClient {
         const uploadOpts = {
             url: this._url(`records/${key}`),
             method: 'PUT',
+            params: this._params(),
             data: value,
             headers: contentType && { 'content-type': contentType },
         };
@@ -173,6 +175,7 @@ class KeyValueStoreClient extends ResourceClient {
         await this.httpClient.call({
             url: this._url(`records/${key}`),
             method: 'DELETE',
+            params: this._params(),
         });
     }
 }

--- a/src/resource_clients/log.js
+++ b/src/resource_clients/log.js
@@ -25,6 +25,7 @@ class LogClient extends ResourceClient {
         const requestOpts = {
             url: this._url(),
             method: 'GET',
+            params: this._params(),
         };
         try {
             const response = await this.httpClient.call(requestOpts);
@@ -47,7 +48,7 @@ class LogClient extends ResourceClient {
         const requestOpts = {
             url: this._url(),
             method: 'GET',
-            params,
+            params: this._params(params),
             responseType: 'stream',
         };
 

--- a/src/resource_clients/request_queue.js
+++ b/src/resource_clients/request_queue.js
@@ -62,10 +62,10 @@ class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('head'),
             method: 'GET',
-            params: {
+            params: this._params({
                 limit: options.limit,
                 clientKey: this.clientKey,
-            },
+            }),
         });
         return parseDateFields(pluckData(response.data));
     }
@@ -89,10 +89,10 @@ class RequestQueueClient extends ResourceClient {
             url: this._url('requests'),
             method: 'POST',
             data: request,
-            params: {
+            params: this._params({
                 forefront: options.forefront,
                 clientKey: this.clientKey,
-            },
+            }),
         });
         return parseDateFields(pluckData(response.data));
     }
@@ -107,6 +107,7 @@ class RequestQueueClient extends ResourceClient {
         const requestOpts = {
             url: this._url(`requests/${id}`),
             method: 'GET',
+            params: this._params(),
         };
         try {
             const response = await this.httpClient.call(requestOpts);
@@ -135,10 +136,10 @@ class RequestQueueClient extends ResourceClient {
             url: this._url(`requests/${request.id}`),
             method: 'PUT',
             data: request,
-            params: {
+            params: this._params({
                 forefront: options.forefront,
                 clientKey: this.clientKey,
-            },
+            }),
         });
         return parseDateFields(pluckData(response.data));
     }
@@ -152,9 +153,9 @@ class RequestQueueClient extends ResourceClient {
         await this.httpClient.call({
             url: this._url(`requests/${id}`),
             method: 'DELETE',
-            params: {
+            params: this._params({
                 clientKey: this.clientKey,
-            },
+            }),
         });
     }
 }

--- a/src/resource_clients/run.js
+++ b/src/resource_clients/run.js
@@ -49,7 +49,7 @@ class RunClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('abort'),
             method: 'POST',
-            params: options,
+            params: this._params(options),
         });
 
         return parseDateFields(pluckData(response.data));
@@ -83,7 +83,7 @@ class RunClient extends ResourceClient {
             url: this._url('metamorph'),
             method: 'POST',
             data: input,
-            params,
+            params: this._params(params),
             // Apify internal property. Tells the request serialization interceptor
             // to stringify functions to JSON, instead of omitting them.
             stringifyFunctions: true,
@@ -116,7 +116,7 @@ class RunClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('resurrect'),
             method: 'POST',
-            params: options,
+            params: this._params(options),
         });
 
         return parseDateFields(pluckData(response.data));

--- a/src/resource_clients/schedule.js
+++ b/src/resource_clients/schedule.js
@@ -54,6 +54,7 @@ class ScheduleClient extends ResourceClient {
         const requestOpts = {
             url: this._url('log'),
             method: 'GET',
+            params: this._params(),
         };
         try {
             const response = await this.httpClient.call(requestOpts);

--- a/src/resource_clients/task.js
+++ b/src/resource_clients/task.js
@@ -87,7 +87,7 @@ class TaskClient extends ResourceClient {
             url: this._url('runs'),
             method: 'POST',
             data: input,
-            params,
+            params: this._params(params),
             // Apify internal property. Tells the request serialization interceptor
             // to stringify functions to JSON, instead of omitting them.
             stringifyFunctions: true,
@@ -138,6 +138,7 @@ class TaskClient extends ResourceClient {
         const requestOpts = {
             url: this._url('input'),
             method: 'GET',
+            params: this._params(),
         };
         try {
             const response = await this.httpClient.call(requestOpts);
@@ -155,6 +156,7 @@ class TaskClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('input'),
             method: 'PUT',
+            params: this._params(),
             data: newFields,
         });
         return response.data;
@@ -173,7 +175,7 @@ class TaskClient extends ResourceClient {
 
         return new RunClient(this._subResourceOptions({
             id: 'last',
-            params: options,
+            params: this._params(options),
             resourcePath: 'runs',
         }));
     }

--- a/src/resource_clients/webhook.js
+++ b/src/resource_clients/webhook.js
@@ -55,6 +55,7 @@ class WebhookClient extends ResourceClient {
         const request = {
             url: this._url('test'),
             method: 'POST',
+            params: this._params(),
         };
 
         try {

--- a/test/actors.test.js
+++ b/test/actors.test.js
@@ -273,8 +273,9 @@ describe('Actor methods', () => {
                 'log',
             ])('%s() works', async (method) => {
                 const actorId = 'some-actor-id';
+                const requestedStatus = 'SUCCEEDED';
 
-                const lastRunClient = client.actor(actorId).lastRun();
+                const lastRunClient = client.actor(actorId).lastRun({ status: requestedStatus });
                 const res = method === 'get'
                     ? await lastRunClient.get()
                     : await lastRunClient[method]().get();
@@ -284,7 +285,7 @@ describe('Actor methods', () => {
                 } else {
                     expect(res.id).toEqual(`last-run-${method}`);
                 }
-                validateRequest({}, { actorId });
+                validateRequest({ status: requestedStatus }, { actorId });
 
                 const browserRes = await page.evaluate((aId, mthd) => {
                     const lrc = client.actor(aId).lastRun();


### PR DESCRIPTION
I get back `this._params(options) because without it the internal sub-clients didn't get params from the parent client.

Sadly tests were not cover this case, so I updated the lastRun test to cover this case.

This reverts commit c766a50