### PR TITLE
feat: Adding x-apify-workflow-key header

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"build-toc": "markdown-toc docs/README.hbs -i"
 	},
 	"dependencies": {
-		"@apify/consts": "^1.1.3",
+		"@apify/consts": "^1.4.0",
 		"@apify/log": "^1.1.1",
 		"agentkeepalive": "^4.1.4",
 		"async-retry": "^1.3.1",

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } f
 import retry, { RetryFunction } from 'async-retry';
 import KeepAliveAgent from 'agentkeepalive';
 import os from 'os';
+import { ENV_VARS } from '@apify/consts';
 import { Log } from '@apify/log';
 import { ApifyApiError } from './apify_api_error';
 import {
@@ -50,7 +51,7 @@ export class HttpClient {
         this.userProvidedRequestInterceptors = options.requestInterceptors;
         this.timeoutMillis = options.timeoutSecs * 1000;
         this.logger = options.logger;
-        this.workflowKey = options.workflowKey || process.env.APIFY_WORKFLOW_KEY;
+        this.workflowKey = options.workflowKey || process.env[ENV_VARS.WORKFLOW_KEY];
         this._onRequestRetry = this._onRequestRetry.bind(this);
 
         if (isNode()) {

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -40,6 +40,8 @@ export class HttpClient {
 
     axios: AxiosInstance;
 
+    workflowKey?: string;
+
     constructor(options: HttpClientOptions) {
         const { token } = options;
         this.stats = options.apifyClientStats;
@@ -48,6 +50,7 @@ export class HttpClient {
         this.userProvidedRequestInterceptors = options.requestInterceptors;
         this.timeoutMillis = options.timeoutSecs * 1000;
         this.logger = options.logger;
+        this.workflowKey = options.workflowKey || process.env.APIFY_WORKFLOW_KEY;
         this._onRequestRetry = this._onRequestRetry.bind(this);
 
         if (isNode()) {
@@ -67,6 +70,7 @@ export class HttpClient {
         this.axios = axios.create({
             headers: {
                 Accept: 'application/json, */*',
+                'X-Apify-Workflow-Key': this.workflowKey,
             },
             httpAgent: this.httpAgent,
             httpsAgent: this.httpsAgent,
@@ -252,4 +256,5 @@ export interface HttpClientOptions {
     timeoutSecs: number;
     logger: Log;
     token?: string;
+    workflowKey?: string;
 }


### PR DESCRIPTION
We need to pass this header from the worker env variable in order to be able to associate runs spun as a part of one flow.