### PR TITLE
fix: unnamed storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.0.4/ 2021/12/XX
+===================
+- Fix: Unnamed storages can now be created again.
+
 2.0.3 / 2021/11/18
 ===================
 - For TypeScript users, DatasetClients can now take in a generic type parameter that defines the data present in a dataset.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apify-client",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "Apify API client for JavaScript",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apify-client",
-	"version": "2.0.5",
+	"version": "2.0.4",
 	"description": "Apify API client for JavaScript",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/src/base/resource_collection_client.ts
+++ b/src/base/resource_collection_client.ts
@@ -31,11 +31,7 @@ export class ResourceCollectionClient extends ApiClient {
         return parseDateFields(pluckData(response.data)) as R;
     }
 
-    protected async _getOrCreate<R>(name = ''): Promise<R> {
-        // The default value of '' allows creating unnamed
-        // resources by passing the name= parameter with
-        // no value. It's useful and later will be supported
-        // in API properly by omitting the name= param entirely.
+    protected async _getOrCreate<R>(name?: string): Promise<R> {
         const response = await this.httpClient.call({
             url: this._url(),
             method: 'POST',

--- a/test/datasets.test.js
+++ b/test/datasets.test.js
@@ -52,7 +52,17 @@ describe('Dataset methods', () => {
             validateRequest(opts);
         });
 
-        test('getOrCreate() works', async () => {
+        test('getOrCreate() works without name', async () => {
+            const res = await client.datasets().getOrCreate();
+            expect(res.id).toEqual('get-or-create-dataset');
+            validateRequest();
+
+            const browserRes = await page.evaluate((n) => client.datasets().getOrCreate(n));
+            expect(browserRes).toEqual(res);
+            validateRequest();
+        });
+
+        test('getOrCreate() works with name', async () => {
             const name = 'some-id-2';
 
             const res = await client.datasets().getOrCreate(name);

--- a/test/key_value_stores.test.js
+++ b/test/key_value_stores.test.js
@@ -53,7 +53,17 @@ describe('Key-Value Store methods', () => {
             validateRequest(opts);
         });
 
-        test('getOrCreate() works', async () => {
+        test('getOrCreate() works without name', async () => {
+            const res = await client.keyValueStores().getOrCreate();
+            expect(res.id).toEqual('get-or-create-store');
+            validateRequest();
+
+            const browserRes = await page.evaluate((n) => client.keyValueStores().getOrCreate(n));
+            expect(browserRes).toEqual(res);
+            validateRequest();
+        });
+
+        test('getOrCreate() works with name', async () => {
             const name = 'some-id-2';
 
             const res = await client.keyValueStores().getOrCreate(name);

--- a/test/request_queues.test.js
+++ b/test/request_queues.test.js
@@ -52,7 +52,17 @@ describe('Request Queue methods', () => {
             validateRequest(opts);
         });
 
-        test('getOrCreate() works', async () => {
+        test('getOrCreate() works without name', async () => {
+            const res = await client.requestQueues().getOrCreate();
+            expect(res.id).toEqual('get-or-create-queue');
+            validateRequest();
+
+            const browserRes = await page.evaluate((n) => client.requestQueues().getOrCreate(n));
+            expect(browserRes).toEqual(res);
+            validateRequest();
+        });
+
+        test('getOrCreate() works with name', async () => {
             const name = 'some-id-2';
 
             const res = await client.requestQueues().getOrCreate(name);


### PR DESCRIPTION
Thanks to a change in API, we could not create unnamed storages with the Client anymore. This fixes it.