### PR TITLE
fix: correct validation for Task call & start, and loosen up KeyValueStore getRecord options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-?.?.? / 2022/01/03
+2.0.6 / 2022/01/03
 ===================
 - For TypeScript users, the input type for Actor#start, Actor#call, Task#start and Task#call have been corrected
 (these methods expect an optional input of a string or an object, not an object or an array of objects)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 2.0.6 / 2022/01/03
 ===================
-- For TypeScript users, the input type for Actor#start, Actor#call, Task#start and Task#call have been corrected
-(these methods expect an optional input of a string or an object, not an object or an array of objects)
+- For TypeScript users, the input type for Task#start and Task#call have been corrected
+(these methods expect an optional input of an object, not an object or an array of objects)
 - For TypeScript users, the overloads for KeyValueStore#getRecord have been relaxed and their order has been corrected
-- Actor#start and Actor#call will now validate that the input, if present, is a string or an object
 
 2.0.5 / 2022/01/03
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+?.?.? / 2022/01/03
+===================
+- For TypeScript users, the input type for Actor#start, Actor#call, Task#start and Task#call have been corrected
+(these methods expect an optional input of a string or an object, not an object or an array of objects)
+- For TypeScript users, the overloads for KeyValueStore#getRecord have been relaxed and their order has been corrected
+- Actor#start and Actor#call will now validate that the input, if present, is a string or an object
+
 2.0.5 / 2022/01/03
 ===================
 - For TypeScript users, the `WebhookEventType` type was corrected to represent its correct value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apify-client",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "Apify API client for JavaScript",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -5,6 +5,7 @@ import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 import {
     cast,
+    Dictionary,
     parseDateFields,
     pluckData,
     stringifyWebhooksToBase64,
@@ -56,8 +57,8 @@ export class ActorClient extends ResourceClient {
      * Starts an actor and immediately returns the Run object.
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
-    async start(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
-        // input can be anything, pointless to validate
+    async start(input?: string | Dictionary, options: ActorStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.any(ow.object, ow.string));
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,
@@ -104,8 +105,8 @@ export class ActorClient extends ResourceClient {
      * It waits indefinitely, unless the `waitSecs` option is provided.
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
-    async call(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
-        // input can be anything, pointless to validate
+    async call(input?: string | Dictionary, options: ActorStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.any(ow.object, ow.string));
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -5,7 +5,6 @@ import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 import {
     cast,
-    Dictionary,
     parseDateFields,
     pluckData,
     stringifyWebhooksToBase64,
@@ -57,8 +56,7 @@ export class ActorClient extends ResourceClient {
      * Starts an actor and immediately returns the Run object.
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
-    async start(input?: string | Dictionary, options: ActorStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.any(ow.object, ow.string));
+    async start(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,
@@ -105,8 +103,7 @@ export class ActorClient extends ResourceClient {
      * It waits indefinitely, unless the `waitSecs` option is provided.
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
-    async call(input?: string | Dictionary, options: ActorStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.any(ow.object, ow.string));
+    async call(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -57,6 +57,8 @@ export class ActorClient extends ResourceClient {
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
     async start(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
+        // input can be anything, so no point in validating it. E.g. if you set content-type to application/pdf
+        // then it will process input as a buffer.
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,
@@ -104,6 +106,8 @@ export class ActorClient extends ResourceClient {
      * https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
      */
     async call(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
+        // input can be anything, so no point in validating it. E.g. if you set content-type to application/pdf
+        // then it will process input as a buffer.
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             contentType: ow.optional.string,

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -83,11 +83,6 @@ export class KeyValueStoreClient extends ResourceClient {
         options: Options
     ): Promise<KeyValueStoreRecord<ReturnTypeFromOptions<Options>> | undefined>;
 
-    async getRecord<Options extends KeyValueClientGetRecordOptions = KeyValueClientGetRecordOptions>(
-        key: string,
-        options: Options
-    ): Promise<KeyValueStoreRecord<ReturnTypeFromOptions<Options>> | undefined>;
-
     async getRecord(key: string, options: KeyValueClientGetRecordOptions = {}): Promise<KeyValueStoreRecord<unknown> | undefined> {
         ow(key, ow.string);
         ow(options, ow.object.exactShape({

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -78,15 +78,15 @@ export class KeyValueStoreClient extends ResourceClient {
      */
     async getRecord(key: string): Promise<KeyValueStoreRecord<JsonValue> | undefined>;
 
-    async getRecord<Options extends KeyValueClientGetRecordOptions>(
+    async getRecord<Options extends KeyValueClientGetRecordOptions = KeyValueClientGetRecordOptions>(
         key: string,
         options: Options
-    ): Promise<KeyValueStoreRecord<Options['stream'] extends true ? ReadableStream : JsonValue> | undefined>;
+    ): Promise<KeyValueStoreRecord<ReturnTypeFromOptions<Options>> | undefined>;
 
-    async getRecord<Options extends KeyValueClientGetRecordOptions>(
+    async getRecord<Options extends KeyValueClientGetRecordOptions = KeyValueClientGetRecordOptions>(
         key: string,
         options: Options
-    ): Promise<KeyValueStoreRecord<Options['buffer'] extends true ? Buffer : JsonValue> | undefined>;
+    ): Promise<KeyValueStoreRecord<ReturnTypeFromOptions<Options>> | undefined>;
 
     async getRecord(key: string, options: KeyValueClientGetRecordOptions = {}): Promise<KeyValueStoreRecord<unknown> | undefined> {
         ow(key, ow.string);
@@ -237,3 +237,7 @@ export interface KeyValueStoreRecord<T> {
     value: T;
     contentType?: string;
 }
+
+export type ReturnTypeFromOptions<Options extends KeyValueClientGetRecordOptions> = Options['stream'] extends true
+    ? ReadableStream
+    : Options['buffer'] extends true ? Buffer : JsonValue;

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -78,9 +78,15 @@ export class KeyValueStoreClient extends ResourceClient {
      */
     async getRecord(key: string): Promise<KeyValueStoreRecord<JsonValue> | undefined>;
 
-    async getRecord(key: string, options: { buffer: true }): Promise<KeyValueStoreRecord<Buffer> | undefined>;
+    async getRecord<Options extends KeyValueClientGetRecordOptions>(
+        key: string,
+        options: Options
+    ): Promise<KeyValueStoreRecord<Options['stream'] extends true ? ReadableStream : JsonValue> | undefined>;
 
-    async getRecord(key: string, options: { stream: true }): Promise<KeyValueStoreRecord<ReadableStream> | undefined>;
+    async getRecord<Options extends KeyValueClientGetRecordOptions>(
+        key: string,
+        options: Options
+    ): Promise<KeyValueStoreRecord<Options['buffer'] extends true ? Buffer : JsonValue> | undefined>;
 
     async getRecord(key: string, options: KeyValueClientGetRecordOptions = {}): Promise<KeyValueStoreRecord<unknown> | undefined> {
         ow(key, ow.string);

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -55,8 +55,8 @@ export class TaskClient extends ResourceClient {
      * Starts a task and immediately returns the Run object.
      * https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
      */
-    async start(input: string | Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.any(ow.object, ow.string));
+    async start(input: Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.object);
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             memory: ow.optional.number,
@@ -97,8 +97,8 @@ export class TaskClient extends ResourceClient {
      * It waits indefinitely, unless the `waitSecs` option is provided.
      * https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
      */
-    async call(input: string | Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.any(ow.object, ow.string));
+    async call(input: Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.object);
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             memory: ow.optional.number,

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -55,8 +55,8 @@ export class TaskClient extends ResourceClient {
      * Starts a task and immediately returns the Run object.
      * https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
      */
-    async start(input: Dictionary | Dictionary[], options: TaskStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.object);
+    async start(input: string | Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.any(ow.object, ow.string));
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             memory: ow.optional.number,
@@ -94,8 +94,8 @@ export class TaskClient extends ResourceClient {
      * It waits indefinitely, unless the `waitSecs` option is provided.
      * https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
      */
-    async call(input: Dictionary | Dictionary[], options: TaskStartOptions = {}): Promise<ActorRun> {
-        ow(input, ow.optional.object);
+    async call(input: string | Dictionary, options: TaskStartOptions = {}): Promise<ActorRun> {
+        ow(input, ow.optional.any(ow.object, ow.string));
         ow(options, ow.object.exactShape({
             build: ow.optional.string,
             memory: ow.optional.number,

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -83,6 +83,9 @@ export class TaskClient extends ResourceClient {
             // Apify internal property. Tells the request serialization interceptor
             // to stringify functions to JSON, instead of omitting them.
             stringifyFunctions: true,
+            headers: {
+                'Content-Type': 'application/json',
+            },
         };
 
         const response = await this.httpClient.call(request);

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -161,7 +161,7 @@ describe('Task methods', () => {
             validateRequest(query, { taskId });
         });
 
-        test('start() works with pre-stringified JSON', async () => {
+        test.skip('start() works with pre-stringified JSON', async () => {
             const taskId = 'some-id2';
             const input = { foo: 'bar' };
             const body = JSON.stringify(input);

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -145,6 +145,41 @@ describe('Task methods', () => {
             validateRequest({}, { taskId });
         });
 
+        test('start() with query parameters works', async () => {
+            const taskId = 'some-id';
+            const query = {
+                waitForFinish: 100,
+                memory: 512,
+            };
+
+            const res = await client.task(taskId).start(undefined, query);
+            expect(res.id).toEqual('run-task');
+            validateRequest(query, { taskId });
+
+            const browserRes = await page.evaluate((id, q) => client.task(id).start(undefined, q), taskId, query);
+            expect(browserRes).toEqual(res);
+            validateRequest(query, { taskId });
+        });
+
+        test('start() works with pre-stringified JSON', async () => {
+            const taskId = 'some-id2';
+            const input = { foo: 'bar' };
+            const body = JSON.stringify(input);
+
+            const query = {
+                waitForFinish: 100,
+                memory: 512,
+            };
+
+            const res = await client.task(taskId).start(body, query);
+            expect(res.id).toEqual('run-task');
+            validateRequest(query, { taskId }, input);
+
+            const browserRes = await page.evaluate((id, i, opts) => client.task(id).start(i, opts), taskId, input, query);
+            expect(browserRes).toEqual(res);
+            validateRequest(query, { taskId }, input);
+        });
+
         test('start() works with input and options overrides', async () => {
             const taskId = 'some-id';
             const input = { foo: 'bar' };


### PR DESCRIPTION
I'm not entirely sure if this is a breaking change or not, so I'm awaiting your thoughts on it. This PR aligns types closer to what the API wants as well as relaxes the types for KeyValueStore#getRecord.

I have the changelog prepared, just have to change the version number once I know which is the correct one to change it to