### PR TITLE
feat: Add support for the `view` parameter in dataset items client

### DIFF
--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -54,6 +54,7 @@ export class DatasetClient<
             skipEmpty: ow.optional.boolean,
             skipHidden: ow.optional.boolean,
             unwind: ow.optional.string,
+            view: ow.optional.string,
         }));
 
         const response = await this.httpClient.call({
@@ -86,6 +87,7 @@ export class DatasetClient<
             skipHeaderRow: ow.optional.boolean,
             skipHidden: ow.optional.boolean,
             unwind: ow.optional.string,
+            view: ow.optional.string,
             xmlRoot: ow.optional.string,
             xmlRow: ow.optional.string,
         }));
@@ -174,6 +176,7 @@ export interface DatasetClientListItemOptions {
     skipEmpty?: boolean;
     skipHidden?: boolean;
     unwind?: string;
+    view?: string,
 }
 
 export enum DownloadItemsFormat {


### PR DESCRIPTION
I'm working on adding the `view` parameter to the dataset items API, and it would help me out if I could use it from the client instead of having to call the API manually.