### PR TITLE
feat: add option to set timeout for request queue client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ===================
 - Added support for the (for now experimental) `view` parameter to the dataset items endpoints
 - For TypeScript users, the type for the fields that end in `At` (ex.: `createdAt`) have been correctly typed as a Date object instead of a string
+- Add option to set custom timeout for RequestQueue client calls.
 
 2.1.0 / 2022/01/26
 ===================

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -192,12 +192,11 @@ export class ApifyClient {
         ow(id, ow.string.nonEmpty);
         ow(options, ow.object.exactShape({
             clientKey: ow.optional.string.nonEmpty,
-            timeout: ow.optional.number,
+            timeoutSecs: ow.optional.number,
         }));
 
         const apiClientOptions = {
             id,
-            timeout: options.timeout,
             ...this._options(),
         };
         return new RequestQueueClient(apiClientOptions, options);

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -192,10 +192,12 @@ export class ApifyClient {
         ow(id, ow.string.nonEmpty);
         ow(options, ow.object.exactShape({
             clientKey: ow.optional.string.nonEmpty,
+            timeout: ow.optional.number,
         }));
 
         const apiClientOptions = {
             id,
+            timeout: options.timeout,
             ...this._options(),
         };
         return new RequestQueueClient(apiClientOptions, options);

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -18,6 +18,8 @@ import {
 export class RequestQueueClient extends ResourceClient {
     private clientKey?: string;
 
+    private timeout?: number;
+
     constructor(options: ApiClientSubResourceOptions, userOptions: RequestQueueUserOptions = {}) {
         super({
             resourcePath: 'request-queues',
@@ -25,6 +27,7 @@ export class RequestQueueClient extends ResourceClient {
         });
 
         this.clientKey = userOptions.clientKey;
+        this.timeout = userOptions.timeout;
     }
 
     /**
@@ -61,6 +64,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('head'),
             method: 'GET',
+            timeout: this.timeout,
             params: this._params({
                 limit: options.limit,
                 clientKey: this.clientKey,
@@ -88,6 +92,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('requests'),
             method: 'POST',
+            timeout: this.timeout,
             data: request,
             params: this._params({
                 forefront: options.forefront,
@@ -115,6 +120,7 @@ export class RequestQueueClient extends ResourceClient {
                 const response = await this.httpClient.call({
                     url: this._url('requests/batch'),
                     method: 'POST',
+                    timeout: this.timeout,
                     data: remainingRequests,
                     params: this._params({
                         forefront: options.forefront,
@@ -213,6 +219,7 @@ export class RequestQueueClient extends ResourceClient {
         const requestOpts: ApifyRequestConfig = {
             url: this._url(`requests/${id}`),
             method: 'GET',
+            timeout: this.timeout,
             params: this._params(),
         };
         try {
@@ -243,6 +250,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url(`requests/${request.id}`),
             method: 'PUT',
+            timeout: this.timeout,
             data: request,
             params: this._params({
                 forefront: options.forefront,
@@ -259,6 +267,7 @@ export class RequestQueueClient extends ResourceClient {
         await this.httpClient.call({
             url: this._url(`requests/${id}`),
             method: 'DELETE',
+            timeout: this.timeout,
             params: this._params({
                 clientKey: this.clientKey,
             }),
@@ -268,6 +277,7 @@ export class RequestQueueClient extends ResourceClient {
 
 export interface RequestQueueUserOptions {
     clientKey?: string;
+    timeout?: number;
 }
 
 export interface RequestQueue {

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -18,7 +18,7 @@ import {
 export class RequestQueueClient extends ResourceClient {
     private clientKey?: string;
 
-    private timeout?: number;
+    private timeoutMillis?: number;
 
     constructor(options: ApiClientSubResourceOptions, userOptions: RequestQueueUserOptions = {}) {
         super({
@@ -27,7 +27,7 @@ export class RequestQueueClient extends ResourceClient {
         });
 
         this.clientKey = userOptions.clientKey;
-        this.timeout = userOptions.timeout;
+        this.timeoutMillis = userOptions.timeoutSecs ? userOptions.timeoutSecs * 1e3 : undefined;
     }
 
     /**
@@ -64,7 +64,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('head'),
             method: 'GET',
-            timeout: this.timeout,
+            timeout: this.timeoutMillis,
             params: this._params({
                 limit: options.limit,
                 clientKey: this.clientKey,
@@ -92,7 +92,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url('requests'),
             method: 'POST',
-            timeout: this.timeout,
+            timeout: this.timeoutMillis,
             data: request,
             params: this._params({
                 forefront: options.forefront,
@@ -120,7 +120,7 @@ export class RequestQueueClient extends ResourceClient {
                 const response = await this.httpClient.call({
                     url: this._url('requests/batch'),
                     method: 'POST',
-                    timeout: this.timeout,
+                    timeout: this.timeoutMillis,
                     data: remainingRequests,
                     params: this._params({
                         forefront: options.forefront,
@@ -219,7 +219,7 @@ export class RequestQueueClient extends ResourceClient {
         const requestOpts: ApifyRequestConfig = {
             url: this._url(`requests/${id}`),
             method: 'GET',
-            timeout: this.timeout,
+            timeout: this.timeoutMillis,
             params: this._params(),
         };
         try {
@@ -250,7 +250,7 @@ export class RequestQueueClient extends ResourceClient {
         const response = await this.httpClient.call({
             url: this._url(`requests/${request.id}`),
             method: 'PUT',
-            timeout: this.timeout,
+            timeout: this.timeoutMillis,
             data: request,
             params: this._params({
                 forefront: options.forefront,
@@ -267,7 +267,7 @@ export class RequestQueueClient extends ResourceClient {
         await this.httpClient.call({
             url: this._url(`requests/${id}`),
             method: 'DELETE',
-            timeout: this.timeout,
+            timeout: this.timeoutMillis,
             params: this._params({
                 clientKey: this.clientKey,
             }),
@@ -277,7 +277,7 @@ export class RequestQueueClient extends ResourceClient {
 
 export interface RequestQueueUserOptions {
     clientKey?: string;
-    timeout?: number;
+    timeoutSecs?: number;
 }
 
 export interface RequestQueue {

--- a/test/request_queues.test.js
+++ b/test/request_queues.test.js
@@ -137,6 +137,18 @@ describe('Request Queue methods', () => {
             validateRequest({}, { queueId }, request);
         });
 
+        test('addRequest() respects over-ridden timeout', async () => {
+            const queueId = 'some-id';
+            const request = { url: 'http://example.com' };
+            let errorMessage;
+            try {
+                await client.requestQueue(queueId, { timeoutSecs: 0.001 }).addRequest(request);
+            } catch (e) {
+                errorMessage = e.toString();
+            }
+            expect(errorMessage).toEqual('Error: timeout of 1ms exceeded');
+        });
+
         test('addRequest() works with forefront param', async () => {
             const queueId = 'some-id';
             const request = { url: 'http://example.com' };
@@ -166,6 +178,18 @@ describe('Request Queue methods', () => {
             validateRequest({}, { queueId, requestId });
         });
 
+        test('getRequest() respects over-ridden timeout', async () => {
+            const queueId = 'some-id';
+            const requestId = 'xxx';
+            let errorMessage;
+            try {
+                await client.requestQueue(queueId, { timeoutSecs: 0.001 }).getRequest(requestId);
+            } catch (e) {
+                errorMessage = e.toString();
+            }
+            expect(errorMessage).toEqual('Error: timeout of 1ms exceeded');
+        });
+
         test('deleteRequest() works', async () => {
             const requestId = 'xxx';
             const queueId = '204';
@@ -177,6 +201,18 @@ describe('Request Queue methods', () => {
             const browserRes = await page.evaluate((qId, rId) => client.requestQueue(qId).deleteRequest(rId), queueId, requestId);
             expect(browserRes).toEqual(res);
             validateRequest({}, { queueId, requestId });
+        });
+
+        test('deleteRequest() respects over-ridden timeout', async () => {
+            const requestId = 'xxx';
+            const queueId = '204';
+            let errorMessage;
+            try {
+                await client.requestQueue(queueId, { timeoutSecs: 0.001 }).deleteRequest(requestId);
+            } catch (e) {
+                errorMessage = e.toString();
+            }
+            expect(errorMessage).toEqual('Error: timeout of 1ms exceeded');
         });
 
         test('updateRequest() works with forefront', async () => {
@@ -212,6 +248,19 @@ describe('Request Queue methods', () => {
             validateRequest({}, { queueId, requestId }, request);
         });
 
+        test('updateRequest() respects over-ridden timeout', async () => {
+            const queueId = 'some-id';
+            const requestId = 'xxx';
+            const request = { id: requestId, url: 'http://example.com' };
+            let errorMessage;
+            try {
+                await client.requestQueue(queueId, { timeoutSecs: 0.001 }).updateRequest(request);
+            } catch (e) {
+                errorMessage = e.toString();
+            }
+            expect(errorMessage).toEqual('Error: timeout of 1ms exceeded');
+        });
+
         test('listHead() works', async () => {
             const queueId = 'some-id';
             const options = { limit: 5 };
@@ -223,6 +272,18 @@ describe('Request Queue methods', () => {
             const browserRes = await page.evaluate((id, opts) => client.requestQueue(id).listHead(opts), queueId, options);
             expect(browserRes).toEqual(res);
             validateRequest(options, { queueId });
+        });
+
+        test('listHead() respects over-ridden timeout', async () => {
+            const queueId = 'some-id';
+            const options = { limit: 5 };
+            let errorMessage;
+            try {
+                await client.requestQueue(queueId, { timeoutSecs: 0.001 }).listHead(options);
+            } catch (e) {
+                errorMessage = e.toString();
+            }
+            expect(errorMessage).toEqual('Error: timeout of 1ms exceeded');
         });
 
         test.each([


### PR DESCRIPTION
The default timeout for API client (360 secs) is too high for some endpoints. Add an option to set timeout to request queue separately from the main API client timeout.