### PR TITLE
chore: updated incorect RunCollectionClient list status type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,7 +1570,7 @@ https://docs.apify.com/api/v2#/reference/actors/run-collection/get-list-of-runs
 | [options.limit] | <code>number</code> |
 | [options.offset] | <code>number</code> |
 | [options.desc] | <code>boolean</code> |
-| [options.status] | <code>boolean</code> |
+| [options.status] | <code>string</code> |
 
 
 * * *

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -20,7 +20,7 @@ export class InvalidResponseBodyError extends Error {
 
     response: AxiosResponse;
 
-    cause: Error;
+    declare cause: Error;
 
     constructor(response: AxiosResponse, cause: Error) {
         super(`Response body could not be parsed.\nCause:${cause.message}`);


### PR DESCRIPTION
Fixing incorrect type for run collection list status. For more info: https://apifier.slack.com/archives/C0L33UM7Z/p1646217864275879

Had to do it manually as the `build_docs` script is not working see issue: 
https://github.com/apify/apify-client-js/issues/236