### PR TITLE
feat: add request queue requests list method

### DIFF
--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -464,7 +464,9 @@ export class RequestQueueClient extends ResourceClient {
      * @private
      * @experimental
      */
-    paginateRequests(options: RequestQueueClientPaginateRequestsOptions = {}): RequestQueueRequestsAsyncIterable<RequestQueueClientListRequestsResult> {
+    paginateRequests(
+        options: RequestQueueClientPaginateRequestsOptions = {},
+    ): RequestQueueRequestsAsyncIterable<RequestQueueClientListRequestsResult> {
         ow(options, ow.object.exactShape({
             limit: ow.optional.number,
             maxPageLimit: ow.optional.number,
@@ -530,7 +532,7 @@ export interface RequestQueueClientListRequestsOptions {
     exclusiveStartId?: string;
 }
 
-export interface RequestQueueClientRequestsOptions {
+export interface RequestQueueClientPaginateRequestsOptions {
     limit?: number;
     maxPageLimit?: number;
     exclusiveStartId?: string;
@@ -539,7 +541,7 @@ export interface RequestQueueClientRequestsOptions {
 export interface RequestQueueClientListRequestsResult {
     limit: number;
     exclusiveStartId?: string;
-    items: RequestQueueClientListItem[];
+    items: RequestQueueClientRequestSchema[];
 }
 
 export interface RequestQueueClientListAndLockHeadOptions {

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -639,4 +639,4 @@ export type RequestQueueClientGetRequestResult = Omit<RequestQueueClientListItem
 
 export type AllowedHttpMethods = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH'
 
-export type RequestQueueRequestsAsyncIterable<T> = AsyncIterable<T>;
+export type RequestQueueRequestsAsyncIterable<T> = AsyncIterable<T>

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -464,7 +464,7 @@ export class RequestQueueClient extends ResourceClient {
      * @private
      * @experimental
      */
-    paginateRequests(options: RequestQueueClientRequestsOptions = {}): RequestQueueRequestsAsyncIterable<RequestQueueClientListRequestsResult> {
+    paginateRequests(options: RequestQueueClientPaginateRequestsOptions = {}): RequestQueueRequestsAsyncIterable<RequestQueueClientListRequestsResult> {
         ow(options, ow.object.exactShape({
             limit: ow.optional.number,
             maxPageLimit: ow.optional.number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,7 +157,7 @@ export class PaginationIterator {
     private readonly exclusiveStartId?: string;
 
     constructor(options: any = {}) {
-        this.maxPageLimit = 100;
+        this.maxPageLimit = options.maxPageLimit;
         this.limit = options.limit;
         this.exclusiveStartId = options.exclusiveStartId;
         this.getPage = options.getPage;

--- a/test/mock_server/routes/request_queues.js
+++ b/test/mock_server/routes/request_queues.js
@@ -10,6 +10,7 @@ const ROUTES = [
     { id: 'delete-queue', method: 'DELETE', path: '/:queueId' },
     { id: 'update-queue', method: 'PUT', path: '/:queueId' },
     { id: 'add-request', method: 'POST', path: '/:queueId/requests/' },
+    { id: 'list-requests', method: 'GET', path: '/:queueId/requests/', type: 'responseJsonMock' },
     { id: 'update-request', method: 'PUT', path: '/:queueId/requests/:requestId' },
     { id: 'put-lock-request', method: 'PUT', path: '/:queueId/requests/:requestId/lock' },
     { id: 'delete-lock-request', method: 'DELETE', path: '/:queueId/requests/:requestId/lock' },


### PR DESCRIPTION
* New method to list requests
* New method to easily iterate all requests in queue
Example usage:
```
for await (const { items } of rqClient.paginateRequests()) {
  const rqsToDelete = items.filter(someFilter);
  await rqClient.batchDeleteRequests(rqsToDelete);
}
```