### PR TITLE
Support streaming request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,14 @@ https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-lis
 
 #### [](#KeyValueStoreClient+setRecord) `keyValueStoreClient.setRecord(record)` ⇒ <code>Promise.&lt;void&gt;</code>
 
+The value in the record can be a stream object (detected by having the `.pipe`
+and `.on` methods). However, note that in that case following redirects or
+retrying the request if it fails (for example due to rate limiting) isn't
+possible. If you want to keep that behavior, you need to collect the whole
+stream contents into a Buffer and then send the full buffer. See [this
+StackOverflow answer](https://stackoverflow.com/a/14269536/7292139) for
+an example how to do that.
+
 https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
 
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"dependencies": {
 		"@apify/consts": "^1.4.0",
-		"@apify/log": "^1.1.1",
+		"@apify/log": "^2.1.0",
 		"agentkeepalive": "^4.1.4",
 		"async-retry": "^1.3.1",
 		"axios": "^0.21.1",

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -23,8 +23,6 @@ const { version } = dynamicRequire('../package.json');
 
 const RATE_LIMIT_EXCEEDED_STATUS_CODE = 429;
 
-let warnedAboutStreamNoRetry = false;
-
 export class HttpClient {
     stats: Statistics;
 
@@ -134,12 +132,8 @@ export class HttpClient {
     }
 
     private _informAboutStreamNoRetry() {
-        // using a module-global variable to only warn once per whole process
-        if (!warnedAboutStreamNoRetry) {
-            warnedAboutStreamNoRetry = true;
-            this.logger.warning('Request body was a stream - retrying will not work, as part of it was already consumed.');
-            this.logger.info('If you want the SDK to handle retries, collect the stream into a buffer before sending it.');
-        }
+        this.logger.warning('Request body was a stream - retrying will not work, as part of it was already consumed.');
+        this.logger.info('If you want the SDK to handle retries, collect the stream into a buffer before sending it.');
     }
 
     /**

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -148,6 +148,9 @@ export class HttpClient {
             const requestIsStream = isStream(config.data);
             try {
                 if (requestIsStream) {
+                    // Handling redirects is not possible without buffering - part of the stream has already been sent and can't be recovered
+                    // when server sends the redirect. Therefore we need to override this in Axios config to prevent it from buffering the body.
+                    // see also axios/axios#1045
                     config = { ...config, maxRedirects: 0 };
                 }
                 response = await this.axios.request(config);

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -133,7 +133,7 @@ export class HttpClient {
 
     private _informAboutStreamNoRetry() {
         this.logger.warningOnce('Request body was a stream - retrying will not work, as part of it was already consumed.');
-        this.logger.warningOnce('If you want the SDK to handle retries, collect the stream into a buffer before sending it.');
+        this.logger.warningOnce('If you want Apify client to handle retries for you, collect the stream into a buffer before sending it.');
     }
 
     /**

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -132,8 +132,8 @@ export class HttpClient {
     }
 
     private _informAboutStreamNoRetry() {
-        this.logger.warning('Request body was a stream - retrying will not work, as part of it was already consumed.');
-        this.logger.info('If you want the SDK to handle retries, collect the stream into a buffer before sending it.');
+        this.logger.warningOnce('Request body was a stream - retrying will not work, as part of it was already consumed.');
+        this.logger.warningOnce('If you want the SDK to handle retries, collect the stream into a buffer before sending it.');
     }
 
     /**

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -124,6 +124,14 @@ export class KeyValueStoreClient extends ResourceClient {
     }
 
     /**
+     * The value in the record can be a stream object (detected by having the `.pipe`
+     * and `.on` methods). However, note that in that case following redirects or
+     * retrying the request if it fails (for example due to rate limiting) isn't
+     * possible. If you want to keep that behavior, you need to collect the whole
+     * stream contents into a Buffer and then send the full buffer. See [this
+     * StackOverflow answer](https://stackoverflow.com/a/14269536/7292139) for
+     * an example how to do that.
+     *
      * https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
      */
     async setRecord(record: KeyValueStoreRecord<JsonValue>): Promise<void> {


### PR DESCRIPTION
As discussed in https://apifier.slack.com/archives/CD0SF6KD4/p1655891141193099

I'm still not completely convinced it is ok to switch the default behavior like this - maybe a warning could be issued for a few versions when a stream is passed for the first time during a run

Also any ideas on how to test this are welcome, but what I was doing so far is just run it with a stream of a biig (500 MB+) file and then observe memory usage of the `node` process