### PR TITLE
chore: add custom catching logic for `record-or-token-not-found` errors

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,6 @@ const PARSE_DATE_FIELDS_KEY_SUFFIX = 'At';
 const NOT_FOUND_STATUS_CODE = 404;
 const RECORD_NOT_FOUND_TYPE = 'record-not-found';
 const RECORD_OR_TOKEN_NOT_FOUND_TYPE = 'record-or-token-not-found';
-const NOT_FOUND_ON_S3 = '<Code>NoSuchKey</Code>';
 const MIN_GZIP_BYTES = 1024;
 
 export interface MaybeData<R> {
@@ -39,9 +38,7 @@ export function pluckData<R>(obj: MaybeData<R>): R {
  */
 export function catchNotFoundOrThrow(err: ApifyApiError): void {
     const isNotFoundStatus = err.statusCode === NOT_FOUND_STATUS_CODE;
-    const isNotFoundMessage = err.type === RECORD_NOT_FOUND_TYPE
-        || err.type === RECORD_OR_TOKEN_NOT_FOUND_TYPE
-        || err.message.includes(NOT_FOUND_ON_S3);
+    const isNotFoundMessage = err.type === RECORD_NOT_FOUND_TYPE || err.type === RECORD_OR_TOKEN_NOT_FOUND_TYPE;
     const isNotFoundError = isNotFoundStatus && isNotFoundMessage;
     if (!isNotFoundError) throw err;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,8 @@ import {
 const PARSE_DATE_FIELDS_MAX_DEPTH = 3; // obj.data.someArrayField.[x].field
 const PARSE_DATE_FIELDS_KEY_SUFFIX = 'At';
 const NOT_FOUND_STATUS_CODE = 404;
-const NOT_FOUND_TYPE = 'record-not-found';
+const RECORD_NOT_FOUND_TYPE = 'record-not-found';
+const RECORD_OR_TOKEN_NOT_FOUND_TYPE = 'record-or-token-not-found';
 const NOT_FOUND_ON_S3 = '<Code>NoSuchKey</Code>';
 const MIN_GZIP_BYTES = 1024;
 
@@ -38,7 +39,9 @@ export function pluckData<R>(obj: MaybeData<R>): R {
  */
 export function catchNotFoundOrThrow(err: ApifyApiError): void {
     const isNotFoundStatus = err.statusCode === NOT_FOUND_STATUS_CODE;
-    const isNotFoundMessage = err.type === NOT_FOUND_TYPE || err.message.includes(NOT_FOUND_ON_S3);
+    const isNotFoundMessage = err.type === RECORD_NOT_FOUND_TYPE
+        || err.type === RECORD_OR_TOKEN_NOT_FOUND_TYPE
+        || err.message.includes(NOT_FOUND_ON_S3);
     const isNotFoundError = isNotFoundStatus && isNotFoundMessage;
     if (!isNotFoundError) throw err;
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,12 +14,14 @@ describe('utils.pluckData()', () => {
 
 describe('utils.catchNotFoundOrThrow()', () => {
     test('works', () => {
-        const notFoundError = new ApifyApiError({ status: 404, data: { error: { type: 'record-not-found' } } });
+        const recordNotFoundError = new ApifyApiError({ status: 404, data: { error: { type: 'record-not-found' } } });
+        const recordOrTokenNotFoundError = new ApifyApiError({ status: 404, data: { error: { type: 'record-or-token-not-found' } } });
         const otherError = new ApifyApiError({ status: 404, data: { error: { type: 'page-not-found' } } });
         const internalError = new ApifyApiError({ status: 500, data: { error: { type: 'internal-error' } } });
         const otherGenericError = new Error('blabla');
 
-        expect(utils.catchNotFoundOrThrow(notFoundError)).toBeUndefined();
+        expect(utils.catchNotFoundOrThrow(recordNotFoundError)).toBeUndefined();
+        expect(utils.catchNotFoundOrThrow(recordOrTokenNotFoundError)).toBeUndefined();
         expect(() => utils.catchNotFoundOrThrow(otherError)).toThrowError(otherError);
         expect(() => utils.catchNotFoundOrThrow(internalError)).toThrowError(internalError);
         expect(() => utils.catchNotFoundOrThrow(otherGenericError)).toThrowError(otherGenericError);


### PR DESCRIPTION
We also want to return `undefined` when getting resources when we get a `record-or-token-not-found` error in addition to `record-not-found` errors.