### PR TITLE
fix: ScheduleUpdateData type

### DIFF
--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -9,6 +9,7 @@ import {
     parseDateFields,
     catchNotFoundOrThrow,
     cast,
+    MakeOptional,
 } from '../utils';
 
 export class ScheduleClient extends ResourceClient {
@@ -91,8 +92,9 @@ export type ScheduleCreateOrUpdateData = Partial<
         | 'isEnabled'
         | 'isExclusive'
         | 'description'
-        | 'actions'
-    >
+    > & {
+        actions: MakeOptional<ScheduleAction, 'id'>[]
+    }
 >;
 
 export enum ScheduleActions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,3 +200,5 @@ export function cast<T>(input: unknown): T {
 }
 
 export type Dictionary<T = unknown> = Record<PropertyKey, T>;
+
+export type MakeOptional<T, U extends keyof T> = Pick<T, Exclude<keyof T, U>> & Partial<Pick<T, U>>;


### PR DESCRIPTION
`ScheduleUpdateData` enforces `id` key on `actions` prop, but it should be optional.

Following snippet should be OK:
```ts
await client.schedule(schedule.id).update({
  actions: [{
    type: ScheduleActions.RunActor,
    actorId: 'someId',
  }]
});
```

But I get this error:
```
Type '{ type: ScheduleActions.RunActor; actorId: string; }' is not assignable to type 'ScheduleAction'.
  Property 'id' is missing in type '{ type: ScheduleActions.RunActor; actorId: string; }' but required in type 'ScheduleActionRunActor'.ts(2322)
schedule.d.ts(47, 5): 'id' is declared here.
```