### PR TITLE
fix: correctly set default client headers

### DIFF
--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -99,7 +99,6 @@ export class HttpClient {
         // Clean all default headers because they only make a mess and their merging is difficult to understand and buggy.
         // And set our own default headers.
         this.axios.defaults.headers = {
-            Accept: 'application/json, */*',
             'X-Apify-Workflow-Key': this.workflowKey,
         };
 

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -97,10 +97,12 @@ export class HttpClient {
         });
 
         // Clean all default headers because they only make a mess and their merging is difficult to understand and buggy.
-        // And set our own default headers.
-        this.axios.defaults.headers = {
-            'X-Apify-Workflow-Key': this.workflowKey,
-        };
+        this.axios.defaults.headers = {};
+
+        // If workflow key is available, pass it as a header
+        if (this.workflowKey) {
+            this.axios.defaults.headers['X-Apify-Workflow-Key'] = this.workflowKey;
+        }
 
         if (isNode()) {
             // Works only in Node. Cannot be set in browser

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -70,10 +70,6 @@ export class HttpClient {
         }
 
         this.axios = axios.create({
-            headers: {
-                Accept: 'application/json, */*',
-                'X-Apify-Workflow-Key': this.workflowKey,
-            },
             httpAgent: this.httpAgent,
             httpsAgent: this.httpsAgent,
             paramsSerializer: (params) => {
@@ -100,9 +96,12 @@ export class HttpClient {
             maxContentLength: -1,
         });
 
-        // Clean all default headers because they only make a mess
-        // and their merging is difficult to understand and buggy.
-        this.axios.defaults.headers = {};
+        // Clean all default headers because they only make a mess and their merging is difficult to understand and buggy.
+        // And set our own default headers.
+        this.axios.defaults.headers = {
+            Accept: 'application/json, */*',
+            'X-Apify-Workflow-Key': this.workflowKey,
+        };
 
         if (isNode()) {
             // Works only in Node. Cannot be set in browser


### PR DESCRIPTION
The headers we thought we were passing were thrown away few lines afterwards.

I've only kept the `x-apify-workflow-key` header and dropped the `accept` one (it works without it).