### PR TITLE
feat: add support for `maxItems` in run options

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -329,7 +329,7 @@ export interface ActorStartOptions {
     webhooks?: readonly WebhookUpdateData[];
 
     /**
-     * Specifies maximum number of items that the actor run should process.
+     * Specifies maximum number of items that the actor run should return.
      * This is used by pay per result actors to limit the maximum number of results that will be charged to customer.
      * Value can be accessed in actor run using `APIFY_ACTOR_MAX_ITEMS` environment variable.
      */

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -66,7 +66,7 @@ export class ActorClient extends ResourceClient {
             timeout: ow.optional.number,
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
-            maxItems: ow.optional.number,
+            maxItems: ow.optional.number.not.negative,
         }));
 
         const { waitForFinish, timeout, memory, build, maxItems } = options;
@@ -117,6 +117,7 @@ export class ActorClient extends ResourceClient {
             timeout: ow.optional.number.not.negative,
             waitSecs: ow.optional.number.not.negative,
             webhooks: ow.optional.array.ofType(ow.object),
+            maxItems: ow.optional.number.not.negative,
         }));
 
         const { waitSecs, ...startOptions } = options;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -66,9 +66,10 @@ export class ActorClient extends ResourceClient {
             timeout: ow.optional.number,
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
+            maxItems: ow.optional.number,
         }));
 
-        const { waitForFinish, timeout, memory, build } = options;
+        const { waitForFinish, timeout, memory, build, maxItems } = options;
 
         const params = {
             waitForFinish,
@@ -76,6 +77,7 @@ export class ActorClient extends ResourceClient {
             memory,
             build,
             webhooks: stringifyWebhooksToBase64(options.webhooks),
+            maxItems,
         };
 
         const request: AxiosRequestConfig = {
@@ -324,6 +326,13 @@ export interface ActorStartOptions {
      * [ad hook webhooks documentation](https://docs.apify.com/webhooks/ad-hoc-webhooks) for detailed description.
      */
     webhooks?: readonly WebhookUpdateData[];
+
+    /**
+     * Specifies maximum number of items that the actor run should process.
+     * This is used by pay per result actors to limit the maximum number of results that will be charged to customer.
+     * Value can be accessed in actor run using `APIFY_ACTOR_MAX_ITEMS` environment variable.
+     */
+    maxItems?: number;
 }
 
 export interface ActorCallOptions extends Omit<ActorStartOptions, 'waitForFinish'> {

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -63,7 +63,7 @@ export class TaskClient extends ResourceClient {
             timeout: ow.optional.number,
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
-            maxItems: ow.optional.number,
+            maxItems: ow.optional.number.not.negative,
         }));
 
         const { waitForFinish, timeout, memory, build, maxItems } = options;
@@ -107,6 +107,7 @@ export class TaskClient extends ResourceClient {
             timeout: ow.optional.number.not.negative,
             waitSecs: ow.optional.number.not.negative,
             webhooks: ow.optional.array.ofType(ow.object),
+            maxItems: ow.optional.number.not.negative,
         }));
 
         const { waitSecs, ...startOptions } = options;

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -63,9 +63,10 @@ export class TaskClient extends ResourceClient {
             timeout: ow.optional.number,
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
+            maxItems: ow.optional.number,
         }));
 
-        const { waitForFinish, timeout, memory, build } = options;
+        const { waitForFinish, timeout, memory, build, maxItems } = options;
 
         const params = {
             waitForFinish,
@@ -73,6 +74,7 @@ export class TaskClient extends ResourceClient {
             memory,
             build,
             webhooks: stringifyWebhooksToBase64(options.webhooks),
+            maxItems,
         };
 
         const request: ApifyRequestConfig = {

--- a/test/actors.test.js
+++ b/test/actors.test.js
@@ -220,7 +220,6 @@ describe('Actor methods', () => {
             const data = { id: runId, actId: actorId, status: 'SUCCEEDED' };
             const body = { data };
             const waitSecs = 1;
-            const maxItems = 100;
 
             mockServer.setResponse({ body });
             const res = await client.actor(actorId).call(input, {
@@ -229,7 +228,6 @@ describe('Actor methods', () => {
                 timeout,
                 build,
                 waitSecs,
-                maxItems,
             });
 
             expect(res).toEqual(data);
@@ -238,7 +236,6 @@ describe('Actor methods', () => {
                 timeout,
                 memory,
                 build,
-                maxItems,
             }, { actorId }, { some: 'body' }, { 'content-type': contentType });
 
             const callBrowserRes = await page.evaluate(
@@ -248,7 +245,6 @@ describe('Actor methods', () => {
                     timeout,
                     build,
                     waitSecs,
-                    maxItems,
                 },
             );
             expect(callBrowserRes).toEqual(res);
@@ -257,8 +253,33 @@ describe('Actor methods', () => {
                 timeout,
                 memory,
                 build,
-                maxItems,
             }, { actorId }, { some: 'body' }, { 'content-type': contentType });
+        });
+
+        test('call() works with maxItems', async () => {
+            const actorId = 'some-id';
+            const runId = 'started-run-id';
+            const data = { id: runId, actId: actorId, status: 'SUCCEEDED' };
+            const body = { data };
+            const waitSecs = 1;
+            const maxItems = 100;
+
+            mockServer.setResponse({ body });
+            const res = await client.actor(actorId).call(undefined, { waitSecs, maxItems });
+
+            expect(res).toEqual(data);
+            validateRequest({ waitForFinish: waitSecs }, { runId });
+            validateRequest({ maxItems }, { actorId });
+
+            const callBrowserRes = await page.evaluate(
+                (id, i, opts) => client.actor(id).call(i, opts), actorId, undefined, {
+                    waitSecs,
+                    maxItems,
+                },
+            );
+            expect(callBrowserRes).toEqual(res);
+            validateRequest({ waitForFinish: waitSecs }, { runId });
+            validateRequest({ maxItems }, { actorId });
         });
 
         test('build() works', async () => {

--- a/test/actors.test.js
+++ b/test/actors.test.js
@@ -197,6 +197,18 @@ describe('Actor methods', () => {
             validateRequest({ webhooks: stringifyWebhooksToBase64(webhooks) }, { actorId });
         });
 
+        test('start() with max items works', async () => {
+            const actorId = 'some-id';
+
+            const res = await client.actor(actorId).start(undefined, { maxItems: 100 });
+            expect(res.id).toEqual('run-actor');
+            validateRequest({ maxItems: 100 }, { actorId });
+
+            const browserRes = await page.evaluate((id, opts) => client.actor(id).start(undefined, opts), actorId, { maxItems: 100 });
+            expect(browserRes).toEqual(res);
+            validateRequest({ maxItems: 100 }, { actorId });
+        });
+
         test('call() works', async () => {
             const actorId = 'some-id';
             const contentType = 'application/x-www-form-urlencoded';

--- a/test/actors.test.js
+++ b/test/actors.test.js
@@ -220,6 +220,7 @@ describe('Actor methods', () => {
             const data = { id: runId, actId: actorId, status: 'SUCCEEDED' };
             const body = { data };
             const waitSecs = 1;
+            const maxItems = 100;
 
             mockServer.setResponse({ body });
             const res = await client.actor(actorId).call(input, {
@@ -228,6 +229,7 @@ describe('Actor methods', () => {
                 timeout,
                 build,
                 waitSecs,
+                maxItems,
             });
 
             expect(res).toEqual(data);
@@ -236,6 +238,7 @@ describe('Actor methods', () => {
                 timeout,
                 memory,
                 build,
+                maxItems,
             }, { actorId }, { some: 'body' }, { 'content-type': contentType });
 
             const callBrowserRes = await page.evaluate(
@@ -245,6 +248,7 @@ describe('Actor methods', () => {
                     timeout,
                     build,
                     waitSecs,
+                    maxItems,
                 },
             );
             expect(callBrowserRes).toEqual(res);
@@ -253,6 +257,7 @@ describe('Actor methods', () => {
                 timeout,
                 memory,
                 build,
+                maxItems,
             }, { actorId }, { some: 'body' }, { 'content-type': contentType });
         });
 

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -271,11 +271,13 @@ describe('Task methods', () => {
             const data = { id: runId, actId, status: 'SUCCEEDED' };
             const body = { data };
             const waitSecs = 1;
+            const maxItems = 100;
 
             const query = {
                 timeout,
                 memory,
                 build,
+                maxItems,
             };
 
             mockServer.setResponse({ body });
@@ -284,6 +286,7 @@ describe('Task methods', () => {
                 timeout,
                 build,
                 waitSecs,
+                maxItems,
             });
             expect(res).toEqual(data);
 
@@ -297,6 +300,7 @@ describe('Task methods', () => {
                     timeout,
                     build,
                     waitSecs,
+                    maxItems,
                 },
             );
             expect(callBrowserRes).toEqual(res);
@@ -305,6 +309,7 @@ describe('Task methods', () => {
                 timeout,
                 memory,
                 build,
+                maxItems,
             }, { taskId }, { some: 'body' });
         });
 

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -271,13 +271,11 @@ describe('Task methods', () => {
             const data = { id: runId, actId, status: 'SUCCEEDED' };
             const body = { data };
             const waitSecs = 1;
-            const maxItems = 100;
 
             const query = {
                 timeout,
                 memory,
                 build,
-                maxItems,
             };
 
             mockServer.setResponse({ body });
@@ -286,7 +284,6 @@ describe('Task methods', () => {
                 timeout,
                 build,
                 waitSecs,
-                maxItems,
             });
             expect(res).toEqual(data);
 
@@ -300,7 +297,6 @@ describe('Task methods', () => {
                     timeout,
                     build,
                     waitSecs,
-                    maxItems,
                 },
             );
             expect(callBrowserRes).toEqual(res);
@@ -309,8 +305,40 @@ describe('Task methods', () => {
                 timeout,
                 memory,
                 build,
-                maxItems,
             }, { taskId }, { some: 'body' });
+        });
+
+        test('call() works with maxItems', async () => {
+            const taskId = 'some-task-id';
+            const actId = 'started-actor-id';
+            const runId = 'started-run-id';
+            const data = { id: runId, actId, status: 'SUCCEEDED' };
+            const body = { data };
+            const waitSecs = 1;
+            const maxItems = 100;
+
+            const query = { maxItems };
+
+            mockServer.setResponse({ body });
+            const res = await client.task(taskId).call(undefined, {
+                waitSecs,
+                maxItems,
+            });
+            expect(res).toEqual(data);
+
+            expect(res).toEqual(data);
+            validateRequest({ waitForFinish: waitSecs }, { runId });
+            validateRequest(query, { taskId });
+
+            const callBrowserRes = await page.evaluate(
+                (id, i, opts) => client.task(id).call(i, opts), taskId, undefined, {
+                    waitSecs,
+                    maxItems,
+                },
+            );
+            expect(callBrowserRes).toEqual(res);
+            validateRequest({ waitForFinish: waitSecs }, { runId });
+            validateRequest({ maxItems }, { taskId });
         });
 
         test('webhooks().list() works', async () => {

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -249,7 +249,7 @@ describe('Task methods', () => {
             validateRequest(query, { taskId });
         });
 
-        test('start() works with maxItems', async() => {
+        test('start() works with maxItems', async () => {
             const taskId = 'some-id';
             const res = await client.task(taskId).start(undefined, { maxItems: 100 });
             expect(res.id).toEqual('run-task');

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -249,6 +249,17 @@ describe('Task methods', () => {
             validateRequest(query, { taskId });
         });
 
+        test('start() works with maxItems', async() => {
+            const taskId = 'some-id';
+            const res = await client.task(taskId).start(undefined, { maxItems: 100 });
+            expect(res.id).toEqual('run-task');
+            validateRequest({ maxItems: 100 }, { taskId });
+
+            const browserRes = await page.evaluate((id, opts) => client.task(id).start(undefined, opts), taskId, { maxItems: 100 });
+            expect(browserRes).toEqual(res);
+            validateRequest({ maxItems: 100 }, { taskId });
+        });
+
         test('call() works', async () => {
             const taskId = 'some-task-id';
             const input = { some: 'body' };


### PR DESCRIPTION
This adds support for optional `maxItems` param to `start` and `call` methods on actors and tasks. 

This param will be used by pay per result actors to limit max items that will be charged to customer.

Should be merged after https://github.com/apify/apify-worker/pull/734 is released.