### PR TITLE
feat: add "standard" handing for setStatusMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@apify/consts": "^2.9.0",
 				"@apify/log": "^2.2.6",
+				"@crawlee/types": "^3.3.0",
 				"agentkeepalive": "^4.2.1",
 				"async-retry": "^1.3.3",
 				"axios": "^0.21.1",
@@ -2082,10 +2083,9 @@
 			}
 		},
 		"node_modules/@crawlee/types": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.2.2.tgz",
-			"integrity": "sha512-dLywdixEg2HhcbLGm1502ohwEXlwn29s1LGTA0ZACkl5yY5VPfGtrq9AdBmHbwhKZEqPugPgq5AmEgwx6HqhaA==",
-			"dev": true,
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.3.0.tgz",
+			"integrity": "sha512-U6vye8eY3eIN5rNse/aAXjtj7+iYI7te1rUC5mIVAGDeEIsze6h6EVUmboeatyvqnOYrZPa03j/rATZK8j8S6g==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			},
@@ -14875,10 +14875,9 @@
 			}
 		},
 		"@crawlee/types": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.2.2.tgz",
-			"integrity": "sha512-dLywdixEg2HhcbLGm1502ohwEXlwn29s1LGTA0ZACkl5yY5VPfGtrq9AdBmHbwhKZEqPugPgq5AmEgwx6HqhaA==",
-			"dev": true,
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.3.0.tgz",
+			"integrity": "sha512-U6vye8eY3eIN5rNse/aAXjtj7+iYI7te1rUC5mIVAGDeEIsze6h6EVUmboeatyvqnOYrZPa03j/rATZK8j8S6g==",
 			"requires": {
 				"tslib": "^2.4.0"
 			}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	"dependencies": {
 		"@apify/consts": "^2.9.0",
 		"@apify/log": "^2.2.6",
+		"@crawlee/types": "^3.3.0",
 		"agentkeepalive": "^4.2.1",
 		"async-retry": "^1.3.3",
 		"axios": "^0.21.1",

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -1,7 +1,8 @@
 import ow from 'ow';
-import { ME_USER_NAME_PLACEHOLDER } from '@apify/consts';
+import { ME_USER_NAME_PLACEHOLDER, ENV_VARS } from '@apify/consts';
 import logger, { Log } from '@apify/log';
 
+import { SetStatusMessageOptions } from '@crawlee/types';
 import { HttpClient } from './http_client';
 import { Statistics } from './statistics';
 import { RequestInterceptorFunction } from './interceptors';
@@ -307,6 +308,15 @@ export class ApifyClient {
         return new WebhookDispatchClient({
             id,
             ...this._options(),
+        });
+    }
+
+    async setStatusMessage(message: string, options?: SetStatusMessageOptions): Promise<void> {
+        const runId = process.env[ENV_VARS.ACTOR_RUN_ID];
+        if (!runId) { throw new Error(`Environment variable ${ENV_VARS.ACTOR_RUN_ID} is not set!`); }
+        await this.run(runId).update({
+            statusMessage: message,
+            ...options,
         });
     }
 }


### PR DESCRIPTION
The `apify-client` package now provides a `setStatusMessage` method compliant with the newest `@crawlee/types` release.