### PR TITLE
chore: Use new workflow secrets

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
                 with:
-                    token: ${{ secrets.GH_TOKEN }}
+                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             -   name: Use Node.js 16
                 uses: actions/setup-node@v2-beta

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
             -   name: Build module
                 run: npm run build
             -   name: Publish to NPM
-                run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag ${{ env.RELEASE_TAG }}
+                run: NODE_AUTH_TOKEN=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }} npm publish --tag ${{ env.RELEASE_TAG }}
             - # Latest version is tagged by the release process so we only tag beta here.
                 name: Tag Version
                 if: env.RELEASE_TAG == 'beta'


### PR DESCRIPTION
This uses new secrets set on organization level instead of the repo-level secrets.