### PR TITLE
chore: invalidate CloudFront cache after docs deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,3 +65,8 @@ jobs:
 
             -   name: Deploy artifact to GitHub Pages
                 uses: actions/deploy-pages@v2
+
+            -   name: Invalidate CloudFront cache
+                run: gh workflow run invalidate.yaml --repo apify/apify-docs-private
+                env:
+                    GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
This makes sure that the CloudFront cache is invalidated after the docs are deployed to GitHub pages.