### PR TITLE
docs: change subtitle

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
             /** @type { import('@apify/docs-theme/types').ThemeOptions } */
             {
                 subNavbar: {
-                    title: 'Apify Client JS',
+                    title: 'API client for JavaScript',
                     items: [
                         {
                             to: 'docs',


### PR DESCRIPTION
The new subtitle fits the Python version and the current `<title>` tags. 