### PR TITLE
fix(docs): Fix docs for resource clients to hide constructor

### DIFF
--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -19,7 +19,6 @@ const CLIENT_METHOD_REGEX = /at( async)? ([A-Za-z]+(Collection)?Client)\._?([A-Z
  * errors and internal errors, which are automatically retried, or validation
  * errors, which are thrown immediately, because a correction by the user is
  * needed.
- * @hideconstructor
  */
 export class ApifyApiError extends Error {
     override name: string;
@@ -61,6 +60,9 @@ export class ApifyApiError extends Error {
      */
     originalStack: string;
 
+    /**
+     * @hidden
+     */
     constructor(response: AxiosResponse, attempt: number) {
         let message!: string;
         let type: string | undefined;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -18,10 +18,10 @@ import { RunCollectionClient } from './run_collection';
 import { WebhookUpdateData } from './webhook';
 import { WebhookCollectionClient } from './webhook_collection';
 
-/**
- * @hideconstructor
- */
 export class ActorClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'acts',

--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -5,10 +5,10 @@ import { PaginatedList } from '../utils';
 import { Actor } from './actor';
 import { ActorVersion } from './actor_version';
 
-/**
- * @hideconstructor
- */
 export class ActorCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'acts',

--- a/src/resource_clients/actor_env_var.ts
+++ b/src/resource_clients/actor_env_var.ts
@@ -3,10 +3,10 @@ import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 import { ActorEnvironmentVariable } from './actor_version';
 
-/**
- * @hideconstructor
- */
 export class ActorEnvVarClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'env-vars',

--- a/src/resource_clients/actor_env_var_collection.ts
+++ b/src/resource_clients/actor_env_var_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { ActorEnvironmentVariable } from './actor_version';
 
-/**
- * @hideconstructor
- */
 export class ActorEnvVarCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'env-vars',

--- a/src/resource_clients/actor_version.ts
+++ b/src/resource_clients/actor_version.ts
@@ -4,10 +4,10 @@ import { ResourceClient } from '../base/resource_client';
 import { ActorEnvVarClient } from './actor_env_var';
 import { ActorEnvVarCollectionClient } from './actor_env_var_collection';
 
-/**
- * @hideconstructor
- */
 export class ActorVersionClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'versions',

--- a/src/resource_clients/actor_version_collection.ts
+++ b/src/resource_clients/actor_version_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { ActorVersion, FinalActorVersion } from './actor_version';
 
-/**
- * @hideconstructor
- */
 export class ActorVersionCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'versions',

--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -8,10 +8,10 @@ import {
     pluckData,
 } from '../utils';
 
-/**
- * @hideconstructor
- */
 export class BuildClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'actor-builds',

--- a/src/resource_clients/build_collection.ts
+++ b/src/resource_clients/build_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { Build } from './build';
 
-/**
- * @hideconstructor
- */
 export class BuildCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientOptions) {
         super({
             ...options,

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -4,12 +4,12 @@ import { ResourceClient } from '../base/resource_client';
 import { ApifyResponse } from '../http_client';
 import { cast, PaginatedList } from '../utils';
 
-/**
- * @hideconstructor
- */
 export class DatasetClient<
     Data extends Record<string | number, any> = Record<string | number, unknown>
 > extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'datasets',

--- a/src/resource_clients/dataset_collection.ts
+++ b/src/resource_clients/dataset_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { Dataset } from './dataset';
 
-/**
- * @hideconstructor
- */
 export class DatasetCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'datasets',

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -15,10 +15,10 @@ import {
     pluckData,
 } from '../utils';
 
-/**
- * @hideconstructor
- */
 export class KeyValueStoreClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'key-value-stores',

--- a/src/resource_clients/key_value_store_collection.ts
+++ b/src/resource_clients/key_value_store_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { KeyValueStore } from './key_value_store';
 
-/**
- * @hideconstructor
- */
 export class KeyValueStoreCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'key-value-stores',

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -7,10 +7,10 @@ import {
     catchNotFoundOrThrow,
 } from '../utils';
 
-/**
- * @hideconstructor
- */
 export class LogClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'logs',

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -20,14 +20,14 @@ const DEFAULT_UNPROCESSED_RETRIES_BATCH_ADD_REQUESTS = 3;
 const DEFAULT_MIN_DELAY_BETWEEN_UNPROCESSED_REQUESTS_RETRIES_MILLIS = 500;
 const DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT = 1000;
 
-/**
- * @hideconstructor
- */
 export class RequestQueueClient extends ResourceClient {
     private clientKey?: string;
 
     private timeoutMillis?: number;
 
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions, userOptions: RequestQueueUserOptions = {}) {
         super({
             resourcePath: 'request-queues',

--- a/src/resource_clients/request_queue_collection.ts
+++ b/src/resource_clients/request_queue_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { RequestQueue } from './request_queue';
 
-/**
- * @hideconstructor
- */
 export class RequestQueueCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'request-queues',

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -13,10 +13,10 @@ import {
 import { ApiClientOptionsWithOptionalResourcePath } from '../base/api_client';
 import { ActorRun } from './actor';
 
-/**
- * @hideconstructor
- */
 export class RunClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientOptionsWithOptionalResourcePath) {
         super({
             ...options,

--- a/src/resource_clients/run_collection.ts
+++ b/src/resource_clients/run_collection.ts
@@ -5,10 +5,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { ActorRunListItem } from './actor';
 
-/**
- * @hideconstructor
- */
 export class RunCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'runs',

--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -11,10 +11,10 @@ import {
     cast,
 } from '../utils';
 
-/**
- * @hideconstructor
- */
 export class ScheduleClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'schedules',

--- a/src/resource_clients/schedule_collection.ts
+++ b/src/resource_clients/schedule_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { Schedule, ScheduleCreateOrUpdateData } from './schedule';
 
-/**
- * @hideconstructor
- */
 export class ScheduleCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'schedules',

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -17,10 +17,10 @@ import { RunClient } from './run';
 import { RunCollectionClient } from './run_collection';
 import { WebhookCollectionClient } from './webhook_collection';
 
-/**
- * @hideconstructor
- */
 export class TaskClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'actor-tasks',

--- a/src/resource_clients/task_collection.ts
+++ b/src/resource_clients/task_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { Task, TaskUpdateData } from './task';
 
-/**
- * @hideconstructor
- */
 export class TaskCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'actor-tasks',

--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -1,10 +1,10 @@
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 
-/**
- * @hideconstructor
- */
 export class UserClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'users',

--- a/src/resource_clients/webhook.ts
+++ b/src/resource_clients/webhook.ts
@@ -13,10 +13,10 @@ import { ApifyApiError } from '../apify_api_error';
 import { WebhookDispatch } from './webhook_dispatch';
 import { ApifyRequestConfig } from '../http_client';
 
-/**
- * @hideconstructor
- */
 export class WebhookClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'webhooks',

--- a/src/resource_clients/webhook_collection.ts
+++ b/src/resource_clients/webhook_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { Webhook, WebhookUpdateData } from './webhook';
 
-/**
- * @hideconstructor
- */
 export class WebhookCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'webhooks',

--- a/src/resource_clients/webhook_dispatch.ts
+++ b/src/resource_clients/webhook_dispatch.ts
@@ -2,10 +2,10 @@ import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 import { Webhook, WebhookEventType } from './webhook';
 
-/**
- * @hideconstructor
- */
 export class WebhookDispatchClient extends ResourceClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'webhook-dispatches',

--- a/src/resource_clients/webhook_dispatch_collection.ts
+++ b/src/resource_clients/webhook_dispatch_collection.ts
@@ -4,10 +4,10 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import { PaginatedList } from '../utils';
 import { WebhookDispatch } from './webhook_dispatch';
 
-/**
- * @hideconstructor
- */
 export class WebhookDispatchCollectionClient extends ResourceCollectionClient {
+    /**
+     * @hidden
+     */
     constructor(options: ApiClientSubResourceOptions) {
         super({
             resourcePath: 'webhook-dispatches',


### PR DESCRIPTION
The old tag was presented in docs which was not nice.

![image](https://github.com/apify/apify-client-js/assets/11837643/d3de1407-ab1f-4863-a06c-cb46125b5a8a)
