### PR TITLE
fix(schedule): expose other fields when id optional

### DIFF
--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -9,7 +9,7 @@ import {
     parseDateFields,
     catchNotFoundOrThrow,
     cast,
-    MakeOptional,
+    DistributiveOmit,
 } from '../utils';
 
 export class ScheduleClient extends ResourceClient {
@@ -93,7 +93,7 @@ export type ScheduleCreateOrUpdateData = Partial<
         | 'isExclusive'
         | 'description'
     > & {
-        actions: MakeOptional<ScheduleAction, 'id'>[]
+        actions: DistributiveOmit<ScheduleAction, 'id'>[]
     }
 >;
 

--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -9,7 +9,7 @@ import {
     parseDateFields,
     catchNotFoundOrThrow,
     cast,
-    DistributiveOmit,
+    DistributiveOptional,
 } from '../utils';
 
 export class ScheduleClient extends ResourceClient {
@@ -93,7 +93,7 @@ export type ScheduleCreateOrUpdateData = Partial<
         | 'isExclusive'
         | 'description'
     > & {
-        actions: DistributiveOmit<ScheduleAction, 'id'>[]
+        actions: DistributiveOptional<ScheduleAction, 'id'>[]
     }
 >;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,4 +201,4 @@ export function cast<T>(input: unknown): T {
 
 export type Dictionary<T = unknown> = Record<PropertyKey, T>;
 
-export type MakeOptional<T, U extends keyof T> = Pick<T, Exclude<keyof T, U>> & Partial<Pick<T, U>>;
+export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,4 +201,4 @@ export function cast<T>(input: unknown): T {
 
 export type Dictionary<T = unknown> = Record<PropertyKey, T>;
 
-export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+export type DistributiveOptional<T, K extends keyof T> = T extends any ? Omit<T, K> & Partial<Pick<T, K>> : never;


### PR DESCRIPTION
This PR appears to follow-up on https://github.com/apify/apify-client-js/pull/276 which made it so `id` was optional ✅ but did so in a way that removed the remainder of the required fields from the type definition ❌, e.g. `actorTaskId` was no longer recognized as a valid property as of v2.8.2

Because `ScheduleAction` is defined as a union of different types, we must use [distributive conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) to capture the specific properties of the individual subtypes correctly.