### PR TITLE
fix: replace ReadableStream with Readable

### DIFF
--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -73,7 +73,7 @@ export class HttpClient {
             httpAgent: this.httpAgent,
             httpsAgent: this.httpsAgent,
             paramsSerializer: (params) => {
-                const formattedParams = Object.entries<string>(params)
+                const formattedParams: [string, string][] = Object.entries<string>(params)
                     .filter(([, value]) => value !== undefined)
                     .map(([key, value]) => {
                         const updatedValue = typeof value === 'boolean' ? Number(value) : value;

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -1,6 +1,7 @@
 import log from '@apify/log';
 import ow from 'ow';
 import { JsonValue } from 'type-fest';
+import { Readable } from 'stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
@@ -244,5 +245,5 @@ export interface KeyValueStoreRecord<T> {
 }
 
 export type ReturnTypeFromOptions<Options extends KeyValueClientGetRecordOptions> = Options['stream'] extends true
-    ? ReadableStream
+    ? Readable
     : Options['buffer'] extends true ? Buffer : JsonValue;

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -1,7 +1,7 @@
 import log from '@apify/log';
 import ow from 'ow';
 import { JsonValue } from 'type-fest';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -1,7 +1,7 @@
 import log from '@apify/log';
 import ow from 'ow';
 import { JsonValue } from 'type-fest';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream';
 import { ApifyApiError } from '../apify_api_error';
 import { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
@@ -42,7 +43,7 @@ export class LogClient extends ResourceClient {
      * Gets the log in a Readable stream format. Only works in Node.js.
      * https://docs.apify.com/api/v2#/reference/logs/log/get-log
      */
-    async stream(): Promise<ReadableStream | undefined> {
+    async stream(): Promise<Readable | undefined> {
         const params = {
             stream: true,
         };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import util from 'util';
 import zlib from 'zlib';
 import ow from 'ow';
 import type { TypedArray, JsonValue } from 'type-fest';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { ApifyApiError } from './apify_api_error';
 import { WebhookUpdateData } from './resource_clients/webhook';
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import util from 'util';
 import zlib from 'zlib';
 import ow from 'ow';
 import type { TypedArray, JsonValue } from 'type-fest';
+import { Readable } from 'stream';
 import { ApifyApiError } from './apify_api_error';
 import { WebhookUpdateData } from './resource_clients/webhook';
 import {
@@ -115,7 +116,7 @@ export function isBuffer(value: unknown): value is Buffer | ArrayBuffer | TypedA
     return ow.isValid(value, ow.any(ow.buffer, ow.arrayBuffer, ow.typedArray));
 }
 
-export function isStream(value: unknown): value is ReadableStream {
+export function isStream(value: unknown): value is Readable {
     return ow.isValid(value, ow.object.hasKeys('on', 'pipe'));
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import util from 'util';
 import zlib from 'zlib';
 import ow from 'ow';
 import type { TypedArray, JsonValue } from 'type-fest';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import { ApifyApiError } from './apify_api_error';
 import { WebhookUpdateData } from './resource_clients/webhook';
 import {

--- a/website/versioned_docs/version-2.8/api-typedoc.json
+++ b/website/versioned_docs/version-2.8/api-typedoc.json
@@ -7607,8 +7607,8 @@
 														"name": "any"
 													}
 												],
-												"name": "ReadableStream",
-												"qualifiedName": "ReadableStream",
+												"name": "Readable",
+												"qualifiedName": "Readable",
 												"package": "typescript"
 											}
 										]
@@ -33029,8 +33029,8 @@
 				},
 				"trueType": {
 					"type": "reference",
-					"name": "ReadableStream",
-					"qualifiedName": "ReadableStream",
+					"name": "Readable",
+					"qualifiedName": "Readable",
 					"package": "typescript"
 				},
 				"falseType": {


### PR DESCRIPTION
The first one is from DOM, the latter - Node. Also, added type for URLSearchParams arg as it's different in Node and won't accept string[][].

Tested by running build script and commenting out DOM in tsconfig libs

Closes #240 