### PR TITLE
feat: parse monthlyUsage.dailyServiceUsages[].date as Date

### DIFF
--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -35,7 +35,10 @@ export class UserClient extends ResourceClient {
         };
         try {
             const response = await this.httpClient.call(requestOpts);
-            return cast(parseDateFields(pluckData(response.data)));
+            return cast(parseDateFields(
+                pluckData(response.data),
+                // Convert  monthlyUsage.dailyServiceUsages[].date to Date (by default it's ignored by parseDateFields)
+                /* shouldParseField = */ (key) => key === 'date'));
         } catch (err) {
             catchNotFoundOrThrow(err as ApifyApiError);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,16 +59,16 @@ type ReturnJsonArray = Array<ReturnJsonValue>;
  * If the field cannot be converted to Date, it is left as is.
  */
 export function parseDateFields(input: JsonValue, shouldParseField: ((key: string) => boolean) | null = null, depth = 0): ReturnJsonValue {
-    const PARSE_DATE_FIELDS_KEY_SUFFIX = 'At';
-    const PARSE_DATE_FIELDS_MAX_DEPTH = 3; // obj.data.someArrayField.[x].field
+    const dateKeySuffix = 'At';
+    const maxTraverseDepth = 3; // obj.data.someArrayField.[x].field
 
-    if (depth > PARSE_DATE_FIELDS_MAX_DEPTH) return input as ReturnJsonValue;
+    if (depth > maxTraverseDepth) return input as ReturnJsonValue;
     if (Array.isArray(input)) return input.map((child) => parseDateFields(child, shouldParseField, depth + 1));
     if (!input || typeof input !== 'object') return input;
 
     return Object.entries(input).reduce((output, [k, v]) => {
         const isValObject = !!v && typeof v === 'object';
-        if (k.endsWith(PARSE_DATE_FIELDS_KEY_SUFFIX) || (shouldParseField && shouldParseField(k))) {
+        if (k.endsWith(dateKeySuffix) || (shouldParseField && shouldParseField(k))) {
             if (v) {
                 const d = new Date(v as string);
                 output[k] = Number.isNaN(d.getTime()) ? v as string : d;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -64,7 +64,7 @@ describe('utils.parseDateFields()', () => {
         expectDatesDame(parsed.data.foo[1].fooAt, date);
     });
 
-    test('doesn\'t parse falsy values', () => {
+    test('does not parse falsy values', () => {
         const original = { fooAt: null, barAt: '' };
         const parsed = utils.parseDateFields(JSON.parse(JSON.stringify(original)));
 
@@ -72,12 +72,45 @@ describe('utils.parseDateFields()', () => {
         expect(parsed.barAt).toEqual('');
     });
 
-    test('doesn\'t mangle non-date strings', () => {
+    test('does not mangle non-date strings', () => {
         const original = { fooAt: 'three days ago', barAt: '30+ days' };
         const parsed = utils.parseDateFields(original);
 
         expect(parsed.fooAt).toEqual('three days ago');
         expect(parsed.barAt).toEqual('30+ days');
+    });
+
+    test('ignores perfectly fine RFC 3339 date', () => {
+        const original = { fooAt: 'three days ago', date: '2024-02-18T00:00:00.000Z' };
+        const parsed = utils.parseDateFields(original);
+
+        expect(parsed.fooAt).toEqual('three days ago');
+        expect(parsed.date).toEqual('2024-02-18T00:00:00.000Z');
+    });
+
+    test('parses custom date field detected by matcher', () => {
+        const original = { fooAt: 'three days ago', date: '2024-02-18T00:00:00.000Z' };
+
+        const parsed = utils.parseDateFields(original, (key) => key === 'date');
+
+        expect(parsed.fooAt).toEqual('three days ago');
+        expect(parsed.date).toBeInstanceOf(Date);
+    });
+
+    test('parses custom nested date field detected by matcher', () => {
+        const original = { fooAt: 'three days ago', foo: { date: '2024-02-18T00:00:00.000Z' } };
+
+        const parsed = utils.parseDateFields(original, (key) => key === 'date');
+
+        expect(parsed.foo.date).toBeInstanceOf(Date);
+    });
+
+    test('does not mangle non-date strings even when detected by matcher', () => {
+        const original = { fooAt: 'three days ago', date: '30+ days' };
+        const parsed = utils.parseDateFields(original, (key) => key === 'date');
+
+        expect(parsed.fooAt).toEqual('three days ago');
+        expect(parsed.date).toEqual('30+ days');
     });
 });
 


### PR DESCRIPTION
This field does not end with "At", which means it is ignored by the existing parseDateFields helper. This PR adjusts this helper to support parsing other fields as well.

To avoid accidental braking changes by applying the new parser on all existing data structures, the helper now has a new optional shouldParseField() param to identify other fields to be parsed. Without this param, the helper behaves just like before.

The actual user-facing change (`typeof monthlyUsage.dailyServiceUsages[].date === Date`) was tested manually and will be covered by the integration tests in `apify-core`.