### PR TITLE
fix: add missing `isApifyIntegration` field to `Webhook` type

### DIFF
--- a/src/resource_clients/webhook.ts
+++ b/src/resource_clients/webhook.ts
@@ -93,6 +93,7 @@ export interface Webhook {
     lastDispatch: string;
     stats: WebhookStats;
     shouldInterpolateStrings: boolean;
+    isApifyIntegration: boolean;
     headersTemplate?: string;
     description?: string;
 }
@@ -112,6 +113,7 @@ export type WebhookUpdateData = Partial<
         | 'requestUrl'
         | 'payloadTemplate'
         | 'shouldInterpolateStrings'
+        | 'isApifyIntegration'
         | 'headersTemplate'
         | 'description'
     >

--- a/src/resource_clients/webhook.ts
+++ b/src/resource_clients/webhook.ts
@@ -93,7 +93,7 @@ export interface Webhook {
     lastDispatch: string;
     stats: WebhookStats;
     shouldInterpolateStrings: boolean;
-    isApifyIntegration: boolean;
+    isApifyIntegration?: boolean;
     headersTemplate?: string;
     description?: string;
 }


### PR DESCRIPTION
This PR adds a missing field on the `Webhook` interface. As per the [documentation](https://docs.apify.com/platform/integrations/actors/integrating-actors-via-api), one can programmatically integrate actors together using the "create webhook" endpoint. The `isApifyIntegration` field helps the UI distinguish whether to render it as an ordinary HTTP webhook in the Apify console.