### PR TITLE
feat: add notifications field to Schedule

### DIFF
--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -81,6 +81,9 @@ export interface Schedule {
     nextRunAt: string;
     lastRunAt: string;
     actions: ScheduleAction[];
+    notifications: {
+        email: boolean;
+    }
 }
 
 export type ScheduleCreateOrUpdateData = Partial<
@@ -93,6 +96,7 @@ export type ScheduleCreateOrUpdateData = Partial<
         | 'isEnabled'
         | 'isExclusive'
         | 'description'
+        | 'notifications'
     > & {
         actions: DistributiveOptional<ScheduleAction, 'id'>[]
     }

--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -83,7 +83,7 @@ export interface Schedule {
     actions: ScheduleAction[];
     notifications: {
         email: boolean;
-    }
+    };
 }
 
 export type ScheduleCreateOrUpdateData = Partial<


### PR DESCRIPTION
Related to https://github.com/apify/apify-core/issues/15493

Adds a `notifications` field to the schedule, so that users can set whether they get notified when their scheduled run fails to start. 

The `notifications` object only has an `email` field for now, but we might want UI notifications at some point in the future, so I've done it this way.

From what I could find, this is all that needs doing, right? 

[This PR](https://github.com/apify/apify-core/pull/15693/files#diff-e443dce6de418714e39866eb1a4ca59f7d4ce49dcbc5cdc692ea07e1be36bacfR436) will add the bit that sends the notification