### PR TITLE
feat: added data property to API error object

### DIFF
--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -62,12 +62,18 @@ export class ApifyApiError extends Error {
     originalStack: string;
 
     /**
+     * Additional data provided by the API about the error
+     */
+    data?: Record<string, unknown>;
+
+    /**
      * @hidden
      */
     constructor(response: AxiosResponse, attempt: number) {
         let message!: string;
         let type: string | undefined;
         let responseData = response.data;
+        let errorData: Record<string, unknown> | undefined;
 
         // Some methods (e.g. downloadItems) set up forceBuffer on request response. If this request failed
         // the body buffer needs to parse to get the correct error.
@@ -83,6 +89,7 @@ export class ApifyApiError extends Error {
             const { error } = responseData;
             message = error.message;
             type = error.type;
+            errorData = error.data;
         } else if (responseData) {
             let dataString;
             try {
@@ -106,6 +113,8 @@ export class ApifyApiError extends Error {
 
         this.originalStack = stack.slice(stack.indexOf('\n'));
         this.stack = this._createApiStack();
+
+        this.data = errorData;
     }
 
     private _safelyParsePathFromResponse(response: AxiosResponse) {

--- a/test/apify_api_error.test.js
+++ b/test/apify_api_error.test.js
@@ -4,13 +4,16 @@ const { ApifyClient } = require('../src/index');
 
 describe('ApifyApiError', () => {
     const browser = new Browser();
+    let server;
 
     beforeAll(async () => {
         await browser.start();
+        server = await mockServer.start();
     });
 
     afterAll(async () => {
         await browser.cleanUpBrowser();
+        await mockServer.close();
     });
 
     test('should carry all the information', async () => {
@@ -65,8 +68,6 @@ describe('ApifyApiError', () => {
     });
 
     test('should carry additional error data if provided', async () => {
-        const server = await mockServer.start();
-
         const datasetId = '400'; // check add_routes.js to see details of this mock
         const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);
         const clientConfig = {

--- a/test/apify_api_error.test.js
+++ b/test/apify_api_error.test.js
@@ -1,4 +1,5 @@
-const { Browser } = require('./_helper');
+const { Browser, DEFAULT_OPTIONS } = require('./_helper');
+const mockServer = require('./mock_server/server');
 const { ApifyClient } = require('../src/index');
 
 describe('ApifyApiError', () => {
@@ -61,5 +62,57 @@ describe('ApifyApiError', () => {
         expect(error.path).toMatch(`/v2/${error.resourcePath}`);
         expect(error.httpMethod).toEqual('get');
         expect(error.attempt).toEqual(1);
+    });
+
+    test('should carry additional error data if provided', async () => {
+        const server = await mockServer.start();
+
+        const datasetId = '400'; // check add_routes.js to see details of this mock
+        const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);
+        const clientConfig = {
+            baseUrl: `http://localhost:${server.address().port}`,
+            maxRetries: 0,
+            ...DEFAULT_OPTIONS,
+        };
+
+        // Works in node
+        try {
+            const client = new ApifyClient(clientConfig);
+            await client.dataset(datasetId).pushItems(data);
+            throw new Error('wrong error');
+        } catch (err) {
+            expect(err.name).toEqual('ApifyApiError');
+            expect(err.type).toEqual('schema-validation-error');
+            expect(err.data).toEqual({
+                invalidItems: {
+                    0: [`should have required property 'name'`],
+                },
+            });
+        }
+
+        // Works in browser
+        const page = await browser.getInjectedPage();
+        const error = await page.evaluate(async (cConfig, dId, d) => {
+            const client = new window.Apify.ApifyClient(cConfig);
+            const datasetClient = client.dataset(dId);
+            try {
+                await datasetClient.pushItems(d);
+                throw new Error('wrong error');
+            } catch (err) {
+                const serializableErr = {};
+                Object.getOwnPropertyNames(err).forEach((prop) => {
+                    serializableErr[prop] = err[prop];
+                });
+                serializableErr.resourcePath = datasetClient.resourcePath;
+                return serializableErr;
+            }
+        }, clientConfig, datasetId, data);
+        expect(error.name).toEqual('ApifyApiError');
+        expect(error.type).toEqual('schema-validation-error');
+        expect(error.data).toEqual({
+            invalidItems: {
+                0: [`should have required property 'name'`],
+            },
+        });
     });
 });

--- a/test/apify_api_error.test.js
+++ b/test/apify_api_error.test.js
@@ -3,17 +3,20 @@ const mockServer = require('./mock_server/server');
 const { ApifyClient } = require('../src/index');
 
 describe('ApifyApiError', () => {
+    let baseUrl;
     const browser = new Browser();
-    let server;
 
     beforeAll(async () => {
         await browser.start();
-        server = await mockServer.start();
+        const server = await mockServer.start();
+        baseUrl = `http://localhost:${server.address().port}`;
     });
 
     afterAll(async () => {
-        await browser.cleanUpBrowser();
-        await mockServer.close();
+        await Promise.all([
+            mockServer.close(),
+            browser.cleanUpBrowser(),
+        ]);
     });
 
     test('should carry all the information', async () => {
@@ -71,7 +74,7 @@ describe('ApifyApiError', () => {
         const datasetId = '400'; // check add_routes.js to see details of this mock
         const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);
         const clientConfig = {
-            baseUrl: `http://localhost:${server.address().port}`,
+            baseUrl,
             maxRetries: 0,
             ...DEFAULT_OPTIONS,
         };

--- a/test/mock_server/routes/add_routes.js
+++ b/test/mock_server/routes/add_routes.js
@@ -40,7 +40,20 @@ const HANDLERS = {
             let payload = {};
             if (responseStatusCode === 200) payload = { data: { id } };
             else if (responseStatusCode === 204) payload = null;
-            else if (responseStatusCode === 404) {
+            else if (responseStatusCode === 400) {
+                // This is not ideal, what if we have more endpoints which can return 400?
+                payload = {
+                    error: {
+                        type: 'schema-validation-error',
+                        message: 'Schema validation failed',
+                        data: {
+                            invalidItems: {
+                                0: [`should have required property 'name'`],
+                            },
+                        },
+                    },
+                };
+            } else if (responseStatusCode === 404) {
                 payload = {
                     error: {
                         type: 'record-not-found',


### PR DESCRIPTION
This update is needed because in API we will be adding a new data field to the API error, which will be used during dataset validation.

https://github.com/apify/apify-docs/pull/1079