### PR TITLE
Fix: Add `isDeprecated` to actor update type

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -277,6 +277,7 @@ export type ActorUpdateOptions = Partial<Pick<
     | 'name'
     | 'description'
     | 'isPublic'
+    | 'isDeprecated'
     | 'seoTitle'
     | 'seoDescription'
     | 'title'


### PR DESCRIPTION
The type was missing, but the deprecation logic is already present in the update method. We need this to correctly deprecate actors from console backend.