### PR TITLE
feat: allow `unwind` param to `DatasetClient.listItems()` to be an array

### DIFF
--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -181,7 +181,7 @@ export interface DatasetClientListItemOptions {
     offset?: number;
     skipEmpty?: boolean;
     skipHidden?: boolean;
-    unwind?: string | string[];
+    unwind?: string | string[]; // TODO: when doing a breaking change release, change to string[] only
     view?: string,
 }
 

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -55,7 +55,7 @@ export class DatasetClient<
             offset: ow.optional.number,
             skipEmpty: ow.optional.boolean,
             skipHidden: ow.optional.boolean,
-            unwind: ow.optional.string,
+            unwind: ow.optional.any(ow.string, ow.array.ofType(ow.string)),
             view: ow.optional.string,
         }));
 
@@ -89,7 +89,7 @@ export class DatasetClient<
             skipEmpty: ow.optional.boolean,
             skipHeaderRow: ow.optional.boolean,
             skipHidden: ow.optional.boolean,
-            unwind: ow.optional.string,
+            unwind: ow.any(ow.optional.string, ow.optional.array.ofType(ow.string)),
             view: ow.optional.string,
             xmlRoot: ow.optional.string,
             xmlRow: ow.optional.string,
@@ -181,7 +181,7 @@ export interface DatasetClientListItemOptions {
     offset?: number;
     skipEmpty?: boolean;
     skipHidden?: boolean;
-    unwind?: string;
+    unwind?: string | string[];
     view?: string,
 }
 


### PR DESCRIPTION
We're adding an option to unwind multiple fields when listing the dataset items. This adds an option to `DatasetClient` to pass those multiple fields in the `unwind` parameter.