### PR TITLE
feat(client): Add maxCostPerRun param

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -336,6 +336,8 @@ export interface ActorStartOptions {
      * Value can be accessed in actor run using `ACTOR_MAX_PAID_DATASET_ITEMS` environment variable.
      */
     maxItems?: number;
+
+    // TODO(PPE): add maxCostPerRun after finished
 }
 
 export interface ActorCallOptions extends Omit<ActorStartOptions, 'waitForFinish'> {

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -68,9 +68,10 @@ export class ActorClient extends ResourceClient {
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
             maxItems: ow.optional.number.not.negative,
+            maxCostPerRun: ow.optional.number.not.negative,
         }));
 
-        const { waitForFinish, timeout, memory, build, maxItems } = options;
+        const { waitForFinish, timeout, memory, build, maxItems, maxCostPerRun } = options;
 
         const params = {
             waitForFinish,
@@ -79,6 +80,7 @@ export class ActorClient extends ResourceClient {
             build,
             webhooks: stringifyWebhooksToBase64(options.webhooks),
             maxItems,
+            maxCostPerRun,
         };
 
         const request: AxiosRequestConfig = {
@@ -119,6 +121,7 @@ export class ActorClient extends ResourceClient {
             waitSecs: ow.optional.number.not.negative,
             webhooks: ow.optional.array.ofType(ow.object),
             maxItems: ow.optional.number.not.negative,
+            maxCostPerRun: ow.optional.number.not.negative,
         }));
 
         const { waitSecs, ...startOptions } = options;
@@ -333,6 +336,11 @@ export interface ActorStartOptions {
      * Value can be accessed in actor run using `ACTOR_MAX_PAID_DATASET_ITEMS` environment variable.
      */
     maxItems?: number;
+    /**
+     * [ALFA] - Not yet implemented, does nothing now.
+     * Specifies maximum cost that the actor run should reach.
+     */
+    maxCostPerRun?: number;
 }
 
 export interface ActorCallOptions extends Omit<ActorStartOptions, 'waitForFinish'> {

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -336,11 +336,6 @@ export interface ActorStartOptions {
      * Value can be accessed in actor run using `ACTOR_MAX_PAID_DATASET_ITEMS` environment variable.
      */
     maxItems?: number;
-    /**
-     * [ALFA] - Not yet implemented, does nothing now.
-     * Specifies maximum cost that the actor run should reach.
-     */
-    maxCostPerRun?: number;
 }
 
 export interface ActorCallOptions extends Omit<ActorStartOptions, 'waitForFinish'> {

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -65,9 +65,10 @@ export class TaskClient extends ResourceClient {
             waitForFinish: ow.optional.number,
             webhooks: ow.optional.array.ofType(ow.object),
             maxItems: ow.optional.number.not.negative,
+            maxCostPerRun: ow.optional.number.not.negative,
         }));
 
-        const { waitForFinish, timeout, memory, build, maxItems } = options;
+        const { waitForFinish, timeout, memory, build, maxItems, maxCostPerRun } = options;
 
         const params = {
             waitForFinish,
@@ -76,6 +77,7 @@ export class TaskClient extends ResourceClient {
             build,
             webhooks: stringifyWebhooksToBase64(options.webhooks),
             maxItems,
+            maxCostPerRun,
         };
 
         const request: ApifyRequestConfig = {
@@ -109,6 +111,7 @@ export class TaskClient extends ResourceClient {
             waitSecs: ow.optional.number.not.negative,
             webhooks: ow.optional.array.ofType(ow.object),
             maxItems: ow.optional.number.not.negative,
+            maxCostPerRun: ow.optional.number.not.negative,
         }));
 
         const { waitSecs, ...startOptions } = options;


### PR DESCRIPTION
Adds `maxCostPerRun` parameter to client - currently not doing anything, but not failing if it is received.