### PR TITLE
docs: bump `@apify/docusaurus-plugin-typedoc-api`

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@apify/docs-theme": "^1.0.131",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.2.4",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
                 "@docusaurus/core": "^3.5.2",
                 "@docusaurus/plugin-client-redirects": "^3.5.2",
                 "@docusaurus/preset-classic": "^3.5.2",
@@ -434,14 +434,15 @@
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.4.tgz",
-            "integrity": "sha512-k6v6F9EQL1xQ8D2q4eJ2gq5HImf6mIqliWD4LDLES0FmNIVr4yjVqgy2VsgH3MUPHoPaRhXwauSNuc1X1QzTuw==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.6.tgz",
+            "integrity": "sha512-M/rpRqbHZjL49xXtvdxdh/M7jSSR5lb3mjKERzKKnX6i92B5BRetL7Eb4qHre9QPQVijgzILhlhTi8otvr0LAw==",
             "license": "MIT",
             "dependencies": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",
                 "@docusaurus/types": "^3.5.2",
                 "@docusaurus/utils": "^3.5.2",
+                "@types/react": "^18.3.11",
                 "@vscode/codicons": "^0.0.35",
                 "marked": "^9.1.6",
                 "marked-smartypants": "^1.1.5",
@@ -456,6 +457,16 @@
                 "@docusaurus/mdx-loader": "^3.5.2",
                 "react": ">=18.0.0",
                 "typescript": "^5.0.0"
+            }
+        },
+        "node_modules/@apify/docusaurus-plugin-typedoc-api/node_modules/@types/react": {
+            "version": "18.3.11",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+            "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.0.2"
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api/node_modules/@vscode/codicons": {
@@ -22201,13 +22212,14 @@
             }
         },
         "@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.4.tgz",
-            "integrity": "sha512-k6v6F9EQL1xQ8D2q4eJ2gq5HImf6mIqliWD4LDLES0FmNIVr4yjVqgy2VsgH3MUPHoPaRhXwauSNuc1X1QzTuw==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.6.tgz",
+            "integrity": "sha512-M/rpRqbHZjL49xXtvdxdh/M7jSSR5lb3mjKERzKKnX6i92B5BRetL7Eb4qHre9QPQVijgzILhlhTi8otvr0LAw==",
             "requires": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",
                 "@docusaurus/types": "^3.5.2",
                 "@docusaurus/utils": "^3.5.2",
+                "@types/react": "^18.3.11",
                 "@vscode/codicons": "^0.0.35",
                 "marked": "^9.1.6",
                 "marked-smartypants": "^1.1.5",
@@ -22215,6 +22227,15 @@
                 "zx": "^8.1.4"
             },
             "dependencies": {
+                "@types/react": {
+                    "version": "18.3.11",
+                    "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+                    "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+                    "requires": {
+                        "@types/prop-types": "*",
+                        "csstype": "^3.0.2"
+                    }
+                },
                 "@vscode/codicons": {
                     "version": "0.0.35",
                     "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.35.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.131",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.4",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-client-redirects": "^3.5.2",
         "@docusaurus/preset-classic": "^3.5.2",


### PR DESCRIPTION
Solves https://github.com/apify/apify-client-js/issues/591 in `apify-client-js` documentation. Merges new features from upstream `docusaurus-plugin-typedoc-api`.