### PR TITLE
feat: add user.updateLimits

### DIFF
--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -64,6 +64,19 @@ export class UserClient extends ResourceClient {
 
         return undefined;
     }
+
+    /**
+     * https://docs.apify.com/api/v2/#/reference/users/account-and-usage-limits
+     */
+    async updateLimits(limits: AccountLimitsUpdateOptions): Promise<void> {
+        const requestOpts: ApifyRequestConfig = {
+            url: this._url('limits'),
+            method: 'PUT',
+            params: this._params(),
+            data: limits,
+        };
+        await this.httpClient.call(requestOpts);
+    }
 }
 
 //
@@ -187,6 +200,8 @@ export interface AccountAndUsageLimits {
     limits: Limits;
     current: Current;
 }
+
+export type AccountLimitsUpdateOptions = Pick<Limits, 'maxMonthlyUsageUsd' | 'dataRetentionDays'>
 
 export interface MonthlyUsageCycle {
     startAt: Date;

--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -68,12 +68,12 @@ export class UserClient extends ResourceClient {
     /**
      * https://docs.apify.com/api/v2/#/reference/users/account-and-usage-limits
      */
-    async updateLimits(limits: AccountLimitsUpdateOptions): Promise<void> {
+    async updateLimits(options: LimitsUpdateOptions): Promise<void> {
         const requestOpts: ApifyRequestConfig = {
             url: this._url('limits'),
             method: 'PUT',
             params: this._params(),
-            data: limits,
+            data: options,
         };
         await this.httpClient.call(requestOpts);
     }
@@ -201,8 +201,6 @@ export interface AccountAndUsageLimits {
     current: Current;
 }
 
-export type AccountLimitsUpdateOptions = Pick<Limits, 'maxMonthlyUsageUsd' | 'dataRetentionDays'>
-
 export interface MonthlyUsageCycle {
     startAt: Date;
     endAt: Date;
@@ -221,6 +219,8 @@ export interface Limits {
     maxTeamAccountSeatCount: number;
     dataRetentionDays: number;
 }
+
+export type LimitsUpdateOptions = Pick<Limits, 'maxMonthlyUsageUsd' | 'dataRetentionDays'>
 
 export interface Current {
     monthlyUsageUsd: number;

--- a/test/mock_server/routes/users.js
+++ b/test/mock_server/routes/users.js
@@ -8,6 +8,7 @@ const ROUTES = [
     { id: 'get-user', method: 'GET', path: '/:userId' },
     { id: 'get-monthly-usage', method: 'GET', path: '/:userId/usage/monthly' },
     { id: 'get-limits', method: 'GET', path: '/:userId/limits' },
+    { id: 'update-limits', method: 'PUT', path: '/:userId/limits' },
 ];
 
 addRoutes(users, ROUTES);

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -82,5 +82,17 @@ describe('User methods', () => {
             expect(browserRes).toEqual(res);
             validateRequest({}, { userId });
         });
+
+        test('updateLimits() works', async () => {
+            const userId = 'me';
+
+            const res = await client.user(userId).updateLimits({ maxMonthlyUsageUsd: 1000 });
+            expect(res).toBeUndefined();
+            validateRequest({}, { userId }, { maxMonthlyUsageUsd: 1000 });
+
+            const browserRes = await page.evaluate((id) => client.user(id).updateLimits({ maxMonthlyUsageUsd: 1000 }), userId);
+            expect(browserRes).toBeUndefined();
+            validateRequest({}, { userId }, { maxMonthlyUsageUsd: 1000 });
+        });
     });
 });


### PR DESCRIPTION
Resolves #329 - add `updateLimits` function to `UserClient`, which does `PUT: /v2/users/:userId/limits`
Api docs PR here: https://github.com/apify/openapi/pull/103
Endpoint is already implemented, only api docs and client was missing