### PR TITLE
fix(actor): correctly set type for ActorTaggedBuilds

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -268,9 +268,7 @@ export interface ActorExampleRunInput {
     contentType: string;
 }
 
-export interface ActorTaggedBuilds {
-    latest: ActorTaggedBuild;
-}
+export type ActorTaggedBuilds = Record<string, ActorTaggedBuild>
 
 export interface ActorTaggedBuild {
     buildId?: string;


### PR DESCRIPTION
I have no idea why we had such a wrong type there.

1. There doesn't have to be `latest` tag
2. Tags are arbitrary strings