### PR TITLE
feat: Add `charge` method to the run client for "pay per event"

### DIFF
--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -154,7 +154,7 @@ export class RunClient extends ResourceClient {
         const count = options.count ?? 1;
         /** To avoid duplicates during the same milisecond, doesn't need to by crypto-secure. */
         const randomSuffix = (Math.random() + 1).toString(36).slice(3, 8);
-        const idempotencyKey = options.idempotencyKey ?? `${this.id}-${options.eventName}-${randomSuffix}`;
+        const idempotencyKey = options.idempotencyKey ?? `${this.id}-${options.eventName}-${Date.now()}-${randomSuffix}`;
 
         const request: AxiosRequestConfig = {
             url: this._url('charge'),

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -261,6 +261,7 @@ export interface RunResurrectOptions {
 }
 
 export type RunChargeOptions = {
+    /** Name of the event to charge. Must be defined in the Actor's pricing info else the API will throw. */
     eventName: string;
     /** Defaults to 1 */
     count?: number;

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -13,6 +13,7 @@ import {
     parseDateFields,
     cast,
 } from '../utils';
+import { ApifyResponse } from '../http_client';
 
 const RUN_CHARGE_IDEMPOTENCY_HEADER = 'idempotency-key';
 
@@ -143,7 +144,7 @@ export class RunClient extends ResourceClient {
     /**
      * TODO: docs
      */
-    async charge(options: RunChargeOptions): Promise<number> {
+    async charge(options: RunChargeOptions): Promise<ApifyResponse<Record<string, never>>> {
         ow(options, ow.object.exactShape({
             eventName: ow.string,
             count: ow.optional.number,
@@ -165,7 +166,7 @@ export class RunClient extends ResourceClient {
             },
         };
         const response = await this.httpClient.call(request);
-        return response.status;
+        return response;
     }
 
     /**

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -152,7 +152,9 @@ export class RunClient extends ResourceClient {
         }));
 
         const count = options.count ?? 1;
-        const idempotencyKey = options.idempotencyKey ?? `${this.id}-${options.eventName}-${Date.now()}`;
+        /** To avoid duplicates during the same milisecond, doesn't need to by crypto-secure. */
+        const randomSuffix = (Math.random() + 1).toString(36).slice(3, 8);
+        const idempotencyKey = options.idempotencyKey ?? `${this.id}-${options.eventName}-${randomSuffix}`;
 
         const request: AxiosRequestConfig = {
             url: this._url('charge'),

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -142,13 +142,14 @@ export class RunClient extends ResourceClient {
     }
 
     /**
-     * TODO: docs
+     * TODO: docs url
+     * https://github.com/apify/apify-client-js/issues/614
      */
     async charge(options: RunChargeOptions): Promise<ApifyResponse<Record<string, never>>> {
         ow(options, ow.object.exactShape({
             eventName: ow.string,
             count: ow.optional.number,
-            idempotencyKey: ow.optional.number,
+            idempotencyKey: ow.optional.string,
         }));
 
         const count = options.count ?? 1;

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -142,8 +142,7 @@ export class RunClient extends ResourceClient {
     }
 
     /**
-     * TODO: docs url
-     * https://github.com/apify/apify-client-js/issues/614
+     * https://docs.apify.com/api/v2#/reference/actor-runs/charge-run/charge-run
      */
     async charge(options: RunChargeOptions): Promise<ApifyResponse<Record<string, never>>> {
         ow(options, ow.object.exactShape({

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -8,12 +8,12 @@ import { LogClient } from './log';
 import { RequestQueueClient } from './request_queue';
 import { ApiClientOptionsWithOptionalResourcePath } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
+import type { ApifyResponse } from '../http_client';
 import {
     pluckData,
     parseDateFields,
     cast,
 } from '../utils';
-import { ApifyResponse } from '../http_client';
 
 const RUN_CHARGE_IDEMPOTENCY_HEADER = 'idempotency-key';
 

--- a/test/mock_server/routes/runs.js
+++ b/test/mock_server/routes/runs.js
@@ -15,6 +15,7 @@ const ROUTES = [
     { id: 'run-keyValueStore', method: 'GET', path: '/:runId/key-value-store' },
     { id: 'run-requestQueue', method: 'GET', path: '/:runId/request-queue' },
     { id: 'run-log', method: 'GET', path: '/:runId/log', type: 'text' },
+    { id: 'run-charge', method: 'POST', path: '/:runId/charge' },
 ];
 
 addRoutes(runs, ROUTES);

--- a/test/runs.test.js
+++ b/test/runs.test.js
@@ -288,7 +288,7 @@ describe('Run methods', () => {
             const runId = 'some-run-id';
 
             const res = await client.run(runId).charge({ eventName: 'some-event' });
-            expect(res).toEqual(200);
+            expect(res.status).toEqual(200);
 
             await expect(client.run(runId).charge()).rejects.toThrow('Expected argument to be of type `object` but received type `undefined`');
         });

--- a/test/runs.test.js
+++ b/test/runs.test.js
@@ -283,5 +283,14 @@ describe('Run methods', () => {
             expect(browserRes).toEqual(res);
             validateRequest({}, { runId });
         });
+
+        test('charge() works', async () => {
+            const runId = 'some-run-id';
+
+            const res = await client.run(runId).charge({ eventName: 'some-event' });
+            expect(res).toEqual(200);
+
+            await expect(client.run(runId).charge()).rejects.toThrow('Expected argument to be of type `object` but received type `undefined`');
+        });
     });
 });


### PR DESCRIPTION
Resolves https://github.com/apify/apify-core/issues/18592 by adding the PPE charge endpoint to JS client.

The idempotency key creation was taken from an actor by the store team.
Issue to add docs URL https://github.com/apify/apify-client-js/issues/614