### PR TITLE
feat(request-queue): Add queueHasLockedRequests and clientKey into RequestQueueClientListAndLockHeadResult

### DIFF
--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -534,6 +534,8 @@ export interface RequestQueueClientListAndLockHeadOptions {
 
 export interface RequestQueueClientListAndLockHeadResult extends RequestQueueClientListHeadResult {
     lockSecs: number;
+    queueHasLockedRequests: boolean;
+    clientKey: string;
 }
 
 export interface RequestQueueClientListItem {


### PR DESCRIPTION
Based on latest changes in API, updating type for RequestQueueClientListAndLockHeadResult.

* `queueHasLockedRequests` - newly added parameter in response
* `clientKey` - this was there in past, just missing in type