### PR TITLE
fix: change type `Build.actorDefinitions` to `Build.actorDefinition`

### DIFF
--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -123,7 +123,7 @@ export interface Build {
     usage?: BuildUsage;
     usageTotalUsd?: number;
     usageUsd?: BuildUsage;
-    actorDefinitions?: ActorDefinition;
+    actorDefinition?: ActorDefinition;
 }
 
 export interface BuildUsage {


### PR DESCRIPTION
It should be `actorDefinition` instead of `actorDefinitions`

I've checked in db and by calling:
```
curl -L 'https://api.apify.com/v2/actor-builds/Nxeu6qxhoEs90eHIH' \
-H 'Accept: application/json'
```
Response
```
    "gitBranchName": "master",
    "actorDefinition": {
      "actorSpecification": 1,
      "name": "rag-web-browser",
      "title": "RAG Web browser",
```