### PR TITLE
feat: added getOpenApiSpecification() to BuildClient

### DIFF
--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -56,7 +56,7 @@ export class BuildClient extends ResourceClient {
     /**
      * https://docs.apify.com/api/v2/actor-build-openapi-specification-get
      */
-    async getOpenApiSpecification() {
+    async getOpenApiSpecification(): Promise<OpenApiSpecification> {
         const response = await this.httpClient.call({
             url: this._url('openapi-specification'),
             method: 'GET',
@@ -154,4 +154,59 @@ export interface BuildOptions {
     betaPackages?: boolean;
     memoryMbytes?: number;
     diskMbytes?: number;
+}
+
+export interface OpenApiSpecification {
+    openapi: string;
+    info: {
+        title: string
+        description?: string;
+        version?: string
+        'x-build-id': string
+    };
+    servers: { url: string }[]
+    paths: { [key: string]: { post: OpenApiOperation } };
+    components: {
+        schemas: {
+            [key: string]: object
+        }
+    }
+}
+
+interface OpenApiOperation {
+    operationId: string
+    'x-openai-isConsequential': boolean
+    summary: string
+    tags: string[]
+    requestBody: {
+        required: boolean;
+        content: {
+            'application/json': {
+                schema: {
+                    '$ref': string
+                }
+            }
+        }
+    }
+    parameters: {
+        name: string
+        in: string
+        required: boolean
+        schema: {
+            type: string;
+        }
+        description: string
+    }[]
+    responses: {
+        '200': {
+            description: string
+            content?: {
+                'application/json': {
+                    schema: {
+                        '$ref': string
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -54,6 +54,19 @@ export class BuildClient extends ResourceClient {
     }
 
     /**
+     * https://docs.apify.com/api/v2/actor-build-openapi-specification-get
+     */
+    async getOpenApiSpecification() {
+        const response = await this.httpClient.call({
+            url: this._url('openapi-specification'),
+            method: 'GET',
+            params: this._params(),
+        });
+
+        return response.data;
+    }
+
+    /**
      * Returns a promise that resolves with the finished Build object when the provided actor build finishes
      * or with the unfinished Build object when the `waitSecs` timeout lapses. The promise is NOT rejected
      * based on run status. You can inspect the `status` property of the Build object to find out its status.

--- a/test/builds.test.js
+++ b/test/builds.test.js
@@ -93,7 +93,7 @@ describe('Build methods', () => {
             const buildId = 'some-build-id';
 
             const res = await client.build(buildId).getOpenApiSpecification();
-            expect(res.id).toEqual('build-openapi-specification');
+            expect(res.data.id).toEqual('build-openapi-specification');
             validateRequest({}, { buildId });
 
             const browserRes = await page.evaluate((bId) => client.build(bId).getOpenApiSpecification(), buildId);

--- a/test/builds.test.js
+++ b/test/builds.test.js
@@ -89,6 +89,18 @@ describe('Build methods', () => {
             validateRequest({}, { buildId });
         });
 
+        test('getOpenApiSpecification() works', async () => {
+            const buildId = 'some-build-id';
+
+            const res = await client.build(buildId).getOpenApiSpecification();
+            expect(res.id).toEqual('build-openapi-specification');
+            validateRequest({}, { buildId });
+
+            const browserRes = await page.evaluate((bId) => client.build(bId).getOpenApiSpecification(), buildId);
+            expect(browserRes).toEqual(res);
+            validateRequest({}, { buildId });
+        });
+
         test('waitForFinish() works', async () => {
             const buildId = 'some-build-id';
             const waitSecs = 0.1;

--- a/test/mock_server/routes/builds.js
+++ b/test/mock_server/routes/builds.js
@@ -9,6 +9,7 @@ const ROUTES = [
     { id: 'get-build', method: 'GET', path: '/:buildId', type: 'responseJsonMock' },
     { id: 'abort-build', method: 'POST', path: '/:buildId/abort' },
     { id: 'build-log', method: 'GET', path: '/:buildId/log', type: 'text' },
+    { id: 'build-openapi-specification', method: 'GET', path: '/:buildId/openapi-specification', type: 'responseJsonMock' },
 ];
 
 addRoutes(builds, ROUTES);


### PR DESCRIPTION
Recently we've introduced new endpoint:
- `/v2/actor-builds/:buildId/openapi-specification`

**This PR adds this endpoint to BuildClient**

P.S. The link to the documentation is correct, but docs are not yet merged into production. I'll merge this PR after the docs are merged.