### PR TITLE
refactor: rename /openapi -> /openapi.json

### DIFF
--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -56,7 +56,7 @@ export class BuildClient extends ResourceClient {
     /**
      * https://docs.apify.com/api/v2/actor-build-openapi-specification-get
      */
-    async getOpenApiDefinition(): Promise<OpenApiSchema> {
+    async getOpenApiDefinition(): Promise<OpenApiDefinition> {
         const response = await this.httpClient.call({
             url: this._url('openapi.json'),
             method: 'GET',
@@ -156,7 +156,7 @@ export interface BuildOptions {
     diskMbytes?: number;
 }
 
-export interface OpenApiSchema {
+export interface OpenApiDefinition {
     openapi: string;
     info: {
         title: string

--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -56,9 +56,9 @@ export class BuildClient extends ResourceClient {
     /**
      * https://docs.apify.com/api/v2/actor-build-openapi-specification-get
      */
-    async getOpenApiSpecification(): Promise<OpenApiSpecification> {
+    async getOpenApiDefinition(): Promise<OpenApiSchema> {
         const response = await this.httpClient.call({
-            url: this._url('openapi-specification'),
+            url: this._url('openapi.json'),
             method: 'GET',
             params: this._params(),
         });
@@ -156,7 +156,7 @@ export interface BuildOptions {
     diskMbytes?: number;
 }
 
-export interface OpenApiSpecification {
+export interface OpenApiSchema {
     openapi: string;
     info: {
         title: string

--- a/test/builds.test.js
+++ b/test/builds.test.js
@@ -89,14 +89,14 @@ describe('Build methods', () => {
             validateRequest({}, { buildId });
         });
 
-        test('getOpenApiSpecification() works', async () => {
+        test('getOpenApiDefinition() works', async () => {
             const buildId = 'some-build-id';
 
-            const res = await client.build(buildId).getOpenApiSpecification();
-            expect(res.data.id).toEqual('build-openapi-specification');
+            const res = await client.build(buildId).getOpenApiDefinition();
+            expect(res.data.id).toEqual('build-openapi');
             validateRequest({}, { buildId });
 
-            const browserRes = await page.evaluate((bId) => client.build(bId).getOpenApiSpecification(), buildId);
+            const browserRes = await page.evaluate((bId) => client.build(bId).getOpenApiDefinition(), buildId);
             expect(browserRes).toEqual(res);
             validateRequest({}, { buildId });
         });

--- a/test/mock_server/routes/builds.js
+++ b/test/mock_server/routes/builds.js
@@ -9,7 +9,7 @@ const ROUTES = [
     { id: 'get-build', method: 'GET', path: '/:buildId', type: 'responseJsonMock' },
     { id: 'abort-build', method: 'POST', path: '/:buildId/abort' },
     { id: 'build-log', method: 'GET', path: '/:buildId/log', type: 'text' },
-    { id: 'build-openapi-specification', method: 'GET', path: '/:buildId/openapi-specification', type: 'responseJsonMock' },
+    { id: 'build-openapi', method: 'GET', path: '/:buildId/openapi.json', type: 'responseJsonMock' },
 ];
 
 addRoutes(builds, ROUTES);


### PR DESCRIPTION
Recently, we created new endpoints:

`/v2/acts/:actorId/builds/:buildId/openapi-specification`
`/v2/actor-builds/:buildId/openapi-specification`
Than we've received a feedback to rename endpoints to `/openapi.json`.

**This PR renames OpenAPI endpoints from `*/openapi-specification` to `*/openapi.json`*

More context [here](https://apify.slack.com/archives/C01VBUV81UZ/p1737975106009729)