### PR TITLE
feat: add support for general resource access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.12.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@apify/consts": "^2.25.0",
+				"@apify/consts": "^2.39.0",
 				"@apify/log": "^2.2.6",
 				"@crawlee/types": "^3.3.0",
 				"agentkeepalive": "^4.2.1",
@@ -74,10 +74,9 @@
 			}
 		},
 		"node_modules/@apify/consts": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.38.0.tgz",
-			"integrity": "sha512-pP/sNuW+6ekdBZHLBy1alyzrxzcSc4xEhVgHx8Rwoyc7Q8nAA6Oybi7ChZv3KLToPITYCpSoSmopDoqrajld0A==",
-			"license": "Apache-2.0"
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.39.0.tgz",
+			"integrity": "sha512-rO9+uzv7kP5XNiz8K+cYcgDmLPK9WZQ9Xlg2VEa2YB5MXDVcBnStdZm4loX/vPPpAGK5ztQnpBnYlA8PURBcXQ=="
 		},
 		"node_modules/@apify/datastructures": {
 			"version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.12.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@apify/consts": "^2.39.0",
+				"@apify/consts": "^2.40.0",
 				"@apify/log": "^2.2.6",
 				"@crawlee/types": "^3.3.0",
 				"agentkeepalive": "^4.2.1",
@@ -74,9 +74,9 @@
 			}
 		},
 		"node_modules/@apify/consts": {
-			"version": "2.39.0",
-			"resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.39.0.tgz",
-			"integrity": "sha512-rO9+uzv7kP5XNiz8K+cYcgDmLPK9WZQ9Xlg2VEa2YB5MXDVcBnStdZm4loX/vPPpAGK5ztQnpBnYlA8PURBcXQ=="
+			"version": "2.40.0",
+			"resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.40.0.tgz",
+			"integrity": "sha512-2coaQ97ddsQ4+QRybqGbPE4irqfmkSaUPlbUPQvIcmT+PLdFT1t1iSU61Yy2T1UW5wN3K6UDAqFWNIqxxb0apg=="
 		},
 		"node_modules/@apify/datastructures": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"build:browser": "webpack"
 	},
 	"dependencies": {
-		"@apify/consts": "^2.39.0",
+		"@apify/consts": "^2.40.0",
 		"@apify/log": "^2.2.6",
 		"@crawlee/types": "^3.3.0",
 		"agentkeepalive": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"build:browser": "webpack"
 	},
 	"dependencies": {
-        "@apify/consts": "^2.39.0",
+		"@apify/consts": "^2.39.0",
 		"@apify/log": "^2.2.6",
 		"@crawlee/types": "^3.3.0",
 		"agentkeepalive": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"build:browser": "webpack"
 	},
 	"dependencies": {
-		"@apify/consts": "^2.25.0",
+        "@apify/consts": "^2.39.0",
 		"@apify/log": "^2.2.6",
 		"@crawlee/types": "^3.3.0",
 		"agentkeepalive": "^4.2.1",

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -1,7 +1,8 @@
 import type { AxiosRequestConfig } from 'axios';
 import ow from 'ow';
 
-import { ACT_JOB_STATUSES, META_ORIGINS, RUN_GENERAL_ACCESS } from '@apify/consts';
+import type { RUN_GENERAL_ACCESS } from '@apify/consts';
+import { ACT_JOB_STATUSES, META_ORIGINS } from '@apify/consts';
 
 import type { ActorVersion} from './actor_version';
 import { ActorVersionClient } from './actor_version';

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -1,7 +1,7 @@
 import type { AxiosRequestConfig } from 'axios';
 import ow from 'ow';
 
-import { ACT_JOB_STATUSES, META_ORIGINS } from '@apify/consts';
+import { ACT_JOB_STATUSES, META_ORIGINS, RUN_GENERAL_ACCESS } from '@apify/consts';
 
 import type { ActorVersion} from './actor_version';
 import { ActorVersionClient } from './actor_version';
@@ -386,6 +386,7 @@ export interface ActorRun extends ActorRunListItem {
     usageUsd?: ActorRunUsage;
     pricingInfo?: ActorRunPricingInfo;
     chargedEventCounts?: Record<string, number>;
+    generalAccess?: RUN_GENERAL_ACCESS | null,
 }
 
 export interface ActorRunUsage {

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -6,6 +6,7 @@ import { ResourceClient } from '../base/resource_client';
 import type { ApifyRequestConfig, ApifyResponse } from '../http_client';
 import type { PaginatedList} from '../utils';
 import { cast, catchNotFoundOrThrow, pluckData } from '../utils';
+import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 export class DatasetClient<
     Data extends Record<string | number, any> = Record<string | number, unknown>,
@@ -177,6 +178,7 @@ export interface Dataset {
     actRunId?: string;
     stats: DatasetStats;
     fields: string[];
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface DatasetStats {
@@ -189,6 +191,7 @@ export interface DatasetStats {
 export interface DatasetClientUpdateOptions {
     name?: string | null;
     title?: string;
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface DatasetClientListItemOptions {

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -1,12 +1,13 @@
 import ow from 'ow';
 
+import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
+
 import type { ApifyApiError } from '../apify_api_error';
 import type { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceClient } from '../base/resource_client';
 import type { ApifyRequestConfig, ApifyResponse } from '../http_client';
 import type { PaginatedList} from '../utils';
 import { cast, catchNotFoundOrThrow, pluckData } from '../utils';
-import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 export class DatasetClient<
     Data extends Record<string | number, any> = Record<string | number, unknown>,

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -1,6 +1,6 @@
 import ow from 'ow';
 
-import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
+import type { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 import type { ApifyApiError } from '../apify_api_error';
 import type { ApiClientSubResourceOptions } from '../base/api_client';

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -18,6 +18,7 @@ import {
     parseDateFields,
     pluckData,
 } from '../utils';
+import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 export class KeyValueStoreClient extends ResourceClient {
     /**
@@ -226,6 +227,7 @@ export interface KeyValueStore {
     actId?: string;
     actRunId?: string;
     stats?: KeyValueStoreStats;
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface KeyValueStoreStats {
@@ -239,6 +241,7 @@ export interface KeyValueStoreStats {
 export interface KeyValueClientUpdateOptions {
     name?: string | null;
     title?: string;
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface KeyValueClientListKeysOptions {

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -4,6 +4,7 @@ import ow from 'ow';
 import type { JsonValue } from 'type-fest';
 
 import log from '@apify/log';
+import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 import type { ApifyApiError } from '../apify_api_error';
 import type { ApiClientSubResourceOptions } from '../base/api_client';
@@ -18,7 +19,6 @@ import {
     parseDateFields,
     pluckData,
 } from '../utils';
-import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 export class KeyValueStoreClient extends ResourceClient {
     /**

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -3,8 +3,8 @@ import type { Readable } from 'node:stream';
 import ow from 'ow';
 import type { JsonValue } from 'type-fest';
 
+import type { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 import log from '@apify/log';
-import { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 
 import type { ApifyApiError } from '../apify_api_error';
 import type { ApiClientSubResourceOptions } from '../base/api_client';

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -1,10 +1,12 @@
 import ow from 'ow';
 import type { JsonObject } from 'type-fest';
 
+import type {
+    STORAGE_GENERAL_ACCESS
+} from '@apify/consts';
 import {
     MAX_PAYLOAD_SIZE_BYTES,
-    REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION,
-    STORAGE_GENERAL_ACCESS
+    REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION
 } from '@apify/consts';
 import log from '@apify/log';
 

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -1,7 +1,11 @@
 import ow from 'ow';
 import type { JsonObject } from 'type-fest';
 
-import { MAX_PAYLOAD_SIZE_BYTES, REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION } from '@apify/consts';
+import {
+    MAX_PAYLOAD_SIZE_BYTES,
+    REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION,
+    STORAGE_GENERAL_ACCESS
+} from '@apify/consts';
 import log from '@apify/log';
 
 import type { ApifyApiError } from '../apify_api_error';
@@ -485,6 +489,7 @@ export interface RequestQueue {
     actRunId?: string;
     hadMultipleClients: boolean;
     stats: RequestQueueStats;
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface RequestQueueStats {
@@ -498,6 +503,7 @@ export interface RequestQueueStats {
 export interface RequestQueueClientUpdateOptions {
     name?: string | null;
     title?: string;
+    generalAccess?: STORAGE_GENERAL_ACCESS | null,
 }
 
 export interface RequestQueueClientListHeadOptions {

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -14,6 +14,7 @@ import {
     parseDateFields,
     cast,
 } from '../utils';
+import { RUN_GENERAL_ACCESS } from '@apify/consts';
 
 const RUN_CHARGE_IDEMPOTENCY_HEADER = 'idempotency-key';
 
@@ -257,6 +258,7 @@ export interface RunMetamorphOptions {
 export interface RunUpdateOptions {
     statusMessage?: string;
     isStatusMessageTerminal?: boolean;
+    generalAccess?: RUN_GENERAL_ACCESS | null,
 }
 
 export interface RunResurrectOptions {

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -1,7 +1,7 @@
 import type { AxiosRequestConfig } from 'axios';
 import ow from 'ow';
 
-import { RUN_GENERAL_ACCESS } from '@apify/consts';
+import type { RUN_GENERAL_ACCESS } from '@apify/consts';
 
 import type { ActorRun } from './actor';
 import { DatasetClient } from './dataset';

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -1,6 +1,8 @@
 import type { AxiosRequestConfig } from 'axios';
 import ow from 'ow';
 
+import { RUN_GENERAL_ACCESS } from '@apify/consts';
+
 import type { ActorRun } from './actor';
 import { DatasetClient } from './dataset';
 import { KeyValueStoreClient } from './key_value_store';
@@ -14,7 +16,6 @@ import {
     parseDateFields,
     cast,
 } from '../utils';
-import { RUN_GENERAL_ACCESS } from '@apify/consts';
 
 const RUN_CHARGE_IDEMPOTENCY_HEADER = 'idempotency-key';
 


### PR DESCRIPTION
We plan to allow users to configure through API & clients how their storages and runs can be accessed — whether just the ID / name is sufficient to access the storage. This is controlled through the `generalAccess` resource property, which overrides account setting for the resource.

Full context in https://github.com/apify/apify-core/issues/19012.

This PR updates the client so that it can be used to get and update general access on datasets, key-value stores, request queues, and runs.

```typescript
const run = client.run(runId);

// Set general access to ANYONE_WITH_ID_CAN_READ which overrides the account setting.
await run.update({ generalAccess: RUN_GENERAL_ACCESS.ANYONE_WITH_ID_CAN_READ });

// Reset the general access so that it follows the account setting.
await run.update({ generalAccess: null });
```