### PR TITLE
fix: defaultBuild() returns BuildClient

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -11,6 +11,7 @@ import type { ActorVersion } from './actor_version';
 import { ActorVersionClient } from './actor_version';
 import { ActorVersionCollectionClient } from './actor_version_collection';
 import type { Build, BuildClientGetOptions } from './build';
+import { BuildClient } from './build';
 import { BuildCollectionClient } from './build_collection';
 import { RunClient } from './run';
 import { RunCollectionClient } from './run_collection';
@@ -168,14 +169,22 @@ export class ActorClient extends ResourceClient {
     /**
      * https://docs.apify.com/api/v2/act-build-default-get
      */
-    async defaultBuild(options: BuildClientGetOptions = {}): Promise<Build> {
+    async defaultBuild(options: BuildClientGetOptions = {}): Promise<BuildClient> {
         const response = await this.httpClient.call({
             url: this._url('builds/default'),
             method: 'GET',
             params: this._params(options),
         });
 
-        return cast(parseDateFields(pluckData(response.data)));
+        const { id } = pluckData<Build>(response.data);
+
+        return new BuildClient({
+            baseUrl: this.apifyClient.baseUrl,
+            httpClient: this.httpClient,
+            apifyClient: this.apifyClient,
+            id,
+            params: this._params(options),
+        });
     }
 
     /**

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -182,7 +182,7 @@ export class ActorClient extends ResourceClient {
             baseUrl: this.apifyClient.baseUrl,
             httpClient: this.httpClient,
             apifyClient: this.apifyClient,
-            id
+            id,
         });
     }
 

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -182,8 +182,7 @@ export class ActorClient extends ResourceClient {
             baseUrl: this.apifyClient.baseUrl,
             httpClient: this.httpClient,
             apifyClient: this.apifyClient,
-            id,
-            params: this._params(options),
+            id
         });
     }
 

--- a/test/actors.test.js
+++ b/test/actors.test.js
@@ -103,13 +103,17 @@ describe('Actor methods', () => {
         test('defaultBuild() works', async () => {
             const actorId = 'some-id';
 
-            const res = await client.actor(actorId).defaultBuild();
-            expect(res.id).toEqual('get-default-build');
-            validateRequest({}, { actorId });
+            const defaultBuildClient = await client.actor(actorId).defaultBuild();
+            const res = await defaultBuildClient.get();
+            await expect(res.id).toEqual('get-build');
+            validateRequest({}, { buildId: 'default-build-get' });
 
-            const browserRes = await page.evaluate((id) => client.actor(id).defaultBuild(), actorId);
+            const browserRes = await page.evaluate(async (id) => {
+                const dbc = await client.actor(id).defaultBuild();
+                return dbc.get();
+            }, actorId);
             expect(browserRes).toEqual(res);
-            validateRequest({}, { actorId });
+            validateRequest({}, { buildId: 'default-build-get' });
         });
 
         test('delete() works', async () => {

--- a/test/mock_server/routes/actors.js
+++ b/test/mock_server/routes/actors.js
@@ -23,7 +23,7 @@ const ROUTES = [
     { id: 'resurrect-run', method: 'POST', path: '/:actorId/runs/:runId/resurrect' },
     { id: 'list-builds', method: 'GET', path: '/:actorId/builds' },
     { id: 'build-actor', method: 'POST', path: '/:actorId/builds' },
-    { id: 'get-default-build', method: 'GET', path: '/:actorId/builds/default', type: 'responseJsonMock' },
+    { id: 'default-build-get', method: 'GET', path: '/:actorId/builds/default', type: 'responseJsonMock' },
     { id: 'get-build', method: 'GET', path: '/:actorId/builds/:buildId', type: 'responseJsonMock' },
     { id: 'abort-build', method: 'POST', path: '/:actorId/builds/:buildId/abort' },
     { id: 'list-actor-versions', method: 'GET', path: '/:actorId/versions' },


### PR DESCRIPTION
This PR updates the Actor.defaultBuild() method to return a BuildClient instance instead of a raw response object.