### PR TITLE
Fix RunCollectionListOptions status type

### DIFF
--- a/src/resource_clients/run_collection.ts
+++ b/src/resource_clients/run_collection.ts
@@ -40,5 +40,5 @@ export interface RunCollectionListOptions {
     limit?: number;
     offset?: number;
     desc?: boolean;
-    status?: keyof typeof ACT_JOB_STATUSES;
+    status?: (typeof ACT_JOB_STATUSES)[keyof typeof ACT_JOB_STATUSES];
 }


### PR DESCRIPTION
Fixes the problem with invalid type `RunCollectionListOptions` of `RunCollectionClient.list` parameter `options`

`'TIMING_OUT' | 'TIMED_OUT'` -> `'TIMING-OUT' | 'TIMED-OUT'`

effectively changes it from

`'READY' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'ABORTING' | 'ABORTED' | 'TIMING_OUT' | 'TIMED_OUT'`

to

`'READY' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'ABORTING' | 'ABORTED' | 'TIMING-OUT' | 'TIMED-OUT'`

The reason for the bug is simple — `ACT_JOB_STATUSES` has super misleading key names :)
see [ACT_JOB_STATUSES](https://github.com/apify/apify-shared-js/blob/37169fcbbd013ee45a6484adcf83ce1135057b4b/packages/consts/src/consts.ts#L30)