### PR TITLE
fix(actor): add missing 'pricingInfos' field to Actor object

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -271,6 +271,7 @@ export interface Actor {
     modifiedAt: Date;
     stats: ActorStats;
     versions: ActorVersion[];
+    pricingInfos?: ActorRunPricingInfo[];
     defaultRunOptions: ActorDefaultRunOptions;
     exampleRunInput?: ActorExampleRunInput;
     isDeprecated?: boolean;


### PR DESCRIPTION
The object should be identical as the one in the run:

https://docs.apify.com/api/v2/act-get
vs
https://docs.apify.com/api/v2/act-run-get