### PR TITLE
feat: list kv store keys by collection of prefix

### DIFF
--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -55,6 +55,8 @@ export class KeyValueStoreClient extends ResourceClient {
             ow.object.exactShape({
                 limit: ow.optional.number,
                 exclusiveStartKey: ow.optional.string,
+                collection: ow.optional.string,
+                prefix: ow.optional.string,
             }),
         );
 
@@ -253,6 +255,8 @@ export interface KeyValueClientUpdateOptions {
 export interface KeyValueClientListKeysOptions {
     limit?: number;
     exclusiveStartKey?: string;
+    collection?: string;
+    prefix?: string;
 }
 
 export interface KeyValueClientListKeysResult {

--- a/test/key_value_stores.test.js
+++ b/test/key_value_stores.test.js
@@ -129,6 +129,8 @@ describe('Key-Value Store methods', () => {
             const query = {
                 limit: 10,
                 exclusiveStartKey: 'fromKey',
+                collection: 'my-collection',
+                prefix: 'my-prefix',
             };
 
             const res = await client.keyValueStore(storeId).listKeys(query);


### PR DESCRIPTION
Add `collection` and `prefix` query params for listing key-value store keys based on https://github.com/apify/actor-whitepaper/blob/master/pages/KEY_VALUE_STORE_SCHEMA.md#api-implications

Api docs: https://github.com/apify/apify-docs/pull/1564
Api impl: https://github.com/apify/apify-core/pull/20726