### PR TITLE
Move prettier into devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "axios": "^1.6.7",
                 "content-type": "^1.0.5",
                 "ow": "^0.28.2",
-                "prettier": "^3.5.3",
                 "tslib": "^2.5.0",
                 "type-fest": "^4.0.0"
             },
@@ -49,6 +48,7 @@
                 "gen-esm-wrapper": "^1.1.2",
                 "globals": "^16.0.0",
                 "jest": "^29.4.3",
+                "prettier": "^3.5.3",
                 "process": "^0.11.10",
                 "puppeteer": "^24.0.0",
                 "rimraf": "^6.0.0",
@@ -11994,6 +11994,7 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
             "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "axios": "^1.6.7",
         "content-type": "^1.0.5",
         "ow": "^0.28.2",
-        "prettier": "^3.5.3",
         "tslib": "^2.5.0",
         "type-fest": "^4.0.0"
     },
@@ -102,6 +101,7 @@
         "gen-esm-wrapper": "^1.1.2",
         "globals": "^16.0.0",
         "jest": "^29.4.3",
+        "prettier": "^3.5.3",
         "process": "^0.11.10",
         "puppeteer": "^24.0.0",
         "rimraf": "^6.0.0",


### PR DESCRIPTION
prettier is just for formatting - so it should go into devDependencies. This takes out the transitive dependency on prettier `^3.5.3` which occurs b/c it is not in devDependencies.