### PR TITLE
feat: Add unlockRequests endpoint to RequestQueue client

### DIFF
--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -504,6 +504,22 @@ export class RequestQueueClient extends ResourceClient {
     }
 
     /**
+     * https://docs.apify.com/api/v2/request-queue-requests-unlock-post
+     */
+    async unlockRequests(): Promise<RequestQueueClientUnlockRequestsResult> {
+        const response = await this.httpClient.call({
+            url: this._url('requests/unlock'),
+            method: 'POST',
+            timeout: this.timeoutMillis,
+            params: this._params({
+                clientKey: this.clientKey,
+            }),
+        });
+
+        return cast(parseDateFields(pluckData(response.data)));
+    }
+
+    /**
      * https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
      *
      * Usage:
@@ -674,6 +690,10 @@ interface UnprocessedRequest {
     uniqueKey: string;
     url: string;
     method?: AllowedHttpMethods;
+}
+
+export interface RequestQueueClientUnlockRequestsResult {
+    unlockedCount: number;
 }
 
 export interface RequestQueueClientBatchRequestsOperationResult {

--- a/test/mock_server/routes/request_queues.js
+++ b/test/mock_server/routes/request_queues.js
@@ -16,6 +16,7 @@ const ROUTES = [
     { id: 'put-lock-request', method: 'PUT', path: '/:queueId/requests/:requestId/lock' },
     { id: 'delete-lock-request', method: 'DELETE', path: '/:queueId/requests/:requestId/lock' },
     { id: 'batch-insert', method: 'POST', path: '/:queueId/requests/batch', type: 'dummyBatchOperation' },
+    { id: 'unlockRequests', method: 'POST', path: '/:queueId/requests/unlock' },
     { id: 'batch-delete', method: 'DELETE', path: '/:queueId/requests/batch', type: 'dummyBatchOperation' },
     { id: 'get-request', method: 'GET', path: '/:queueId/requests/:requestId' },
     { id: 'delete-request', method: 'DELETE', path: '/:queueId/requests/:requestId' },

--- a/test/mock_server/routes/request_queues.js
+++ b/test/mock_server/routes/request_queues.js
@@ -16,7 +16,7 @@ const ROUTES = [
     { id: 'put-lock-request', method: 'PUT', path: '/:queueId/requests/:requestId/lock' },
     { id: 'delete-lock-request', method: 'DELETE', path: '/:queueId/requests/:requestId/lock' },
     { id: 'batch-insert', method: 'POST', path: '/:queueId/requests/batch', type: 'dummyBatchOperation' },
-    { id: 'unlockRequests', method: 'POST', path: '/:queueId/requests/unlock' },
+    { id: 'unlock-requests', method: 'POST', path: '/:queueId/requests/unlock' },
     { id: 'batch-delete', method: 'DELETE', path: '/:queueId/requests/batch', type: 'dummyBatchOperation' },
     { id: 'get-request', method: 'GET', path: '/:queueId/requests/:requestId' },
     { id: 'delete-request', method: 'DELETE', path: '/:queueId/requests/:requestId' },

--- a/test/request_queues.test.js
+++ b/test/request_queues.test.js
@@ -170,7 +170,7 @@ describe('Request Queue methods', () => {
             const queueId = 'some-id';
 
             const res = await client.requestQueue(queueId).unlockRequests();
-            expect(res.id).toEqual('unlockRequests');
+            expect(res.id).toEqual('unlock-requests');
             validateRequest({}, { queueId });
 
             const browserRes = await page.evaluate((id) => client.requestQueue(id).unlockRequests(), queueId);

--- a/test/request_queues.test.js
+++ b/test/request_queues.test.js
@@ -166,6 +166,18 @@ describe('Request Queue methods', () => {
             validateRequest({ forefront }, { queueId }, request);
         });
 
+        test('unlockRequests() works', async () => {
+            const queueId = 'some-id';
+
+            const res = await client.requestQueue(queueId).unlockRequests();
+            expect(res.id).toEqual('unlockRequests');
+            validateRequest({}, { queueId });
+
+            const browserRes = await page.evaluate((id) => client.requestQueue(id).unlockRequests(), queueId);
+            expect(browserRes).toEqual(res);
+            validateRequest({}, { queueId });
+        })
+
         test('getRequest() works', async () => {
             const queueId = 'some-id';
             const requestId = 'xxx';

--- a/test/request_queues.test.js
+++ b/test/request_queues.test.js
@@ -176,7 +176,7 @@ describe('Request Queue methods', () => {
             const browserRes = await page.evaluate((id) => client.requestQueue(id).unlockRequests(), queueId);
             expect(browserRes).toEqual(res);
             validateRequest({}, { queueId });
-        })
+        });
 
         test('getRequest() works', async () => {
             const queueId = 'some-id';


### PR DESCRIPTION
Implement the `unlockRequests` method in the RequestQueue client to support the new API endpoint. Update the mock server and tests to include the endpoint.