### PR TITLE
fix: Rename option for new sortBy parameter

### DIFF
--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -47,7 +47,7 @@ export class ActorCollectionClient extends ResourceCollectionClient {
 
 export enum ActorListSortBy {
     CREATED_AT = 'createdAt',
-    LAST_RUN_STARTED_AT = 'lastRunStartedAt',
+    LAST_RUN_STARTED_AT = 'stats.lastRunStartedAt',
 }
 
 export interface ActorCollectionListOptions {


### PR DESCRIPTION
Renamed option for sortBy parameter from "lastRunStartedAt" to "stats.lastRunStartedAt" to fit the [TICKET](https://app.zenhub.com/workspaces/platform-team-5f6454160d9f82000fa6733f/issues/gh/apify/apify-core/20997) specifications. Will merge when the [apify-core PR](https://github.com/apify/apify-core/pull/21731) is deployed