### PR TITLE
fix: add `eventData` to `WebhookDispatch` type

### DIFF
--- a/src/resource_clients/webhook_dispatch.ts
+++ b/src/resource_clients/webhook_dispatch.ts
@@ -30,6 +30,7 @@ export interface WebhookDispatch {
     eventType: WebhookEventType;
     calls: WebhookDispatchCall[];
     webhook: Pick<Webhook, 'requestUrl' | 'isAdHoc'>;
+    eventData: WebhookDispatchEventData | null;
 }
 
 export enum WebhookDispatchStatus {
@@ -45,3 +46,10 @@ export interface WebhookDispatchCall {
     responseStatus: number | null;
     responseBody: string | null;
 }
+
+export type WebhookDispatchEventData = {
+    actorRunId?: string;
+    actorId?: string;
+    actorTaskId?: string;
+    actorBuildId?: string;
+};


### PR DESCRIPTION
The field is returned from the API, but the type was missing it.

In case of `TEST` event, it's null.