### PR TITLE
docs: switch to `@docusaurus/faster`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,6 +16,13 @@ module.exports = {
     favicon: 'img/favicon.ico',
     onBrokenLinks: /** @type {import('@docusaurus/types').ReportingSeverity} */ ('throw'),
     onBrokenMarkdownLinks: /** @type {import('@docusaurus/types').ReportingSeverity} */ ('throw'),
+    future: {
+        experimental_faster: true,
+        v4: {
+            removeLegacyPostBuildHeadAttribute: true,
+            useCssCascadeLayers: false,
+        },
+    },
     themes: [
         [
             '@apify/docs-theme',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
                 "@apify/docs-theme": "^1.0.181",
                 "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
                 "@docusaurus/core": "^3.7.0",
+                "@docusaurus/faster": "^3.8.1",
                 "@docusaurus/plugin-client-redirects": "^3.7.0",
                 "@docusaurus/preset-classic": "^3.7.0",
                 "clsx": "^2.0.0",
@@ -3743,6 +3744,29 @@
                 "node": ">=18.0"
             }
         },
+        "node_modules/@docusaurus/faster": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.1.tgz",
+            "integrity": "sha512-XYrj3qnTm+o2d5ih5drCq9s63GJoM8vZ26WbLG5FZhURsNxTSXgHJcx11Qo7nWPUStCQkuqk1HvItzscCUnd4A==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.8.1",
+                "@rspack/core": "^1.3.15",
+                "@swc/core": "^1.7.39",
+                "@swc/html": "^1.7.39",
+                "browserslist": "^4.24.2",
+                "lightningcss": "^1.27.0",
+                "swc-loader": "^0.2.6",
+                "tslib": "^2.6.0",
+                "webpack": "^5.95.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            },
+            "peerDependencies": {
+                "@docusaurus/types": "*"
+            }
+        },
         "node_modules/@docusaurus/logger": {
             "version": "3.8.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
@@ -4736,6 +4760,37 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.4.tgz",
+            "integrity": "sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.0.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.4.tgz",
+            "integrity": "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.3.tgz",
+            "integrity": "sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
@@ -5005,6 +5060,71 @@
                 "react": ">=16"
             }
         },
+        "node_modules/@module-federation/error-codes": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.15.0.tgz",
+            "integrity": "sha512-CFJSF+XKwTcy0PFZ2l/fSUpR4z247+Uwzp1sXVkdIfJ/ATsnqf0Q01f51qqSEA6MYdQi6FKos9FIcu3dCpQNdg==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.15.0.tgz",
+            "integrity": "sha512-dTPsCNum9Bhu3yPOcrPYq0YnM9eCMMMNB1wuiqf1+sFbQlNApF0vfZxooqz3ln0/MpgE0jerVvFsLVGfqvC9Ug==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.15.0",
+                "@module-federation/runtime-core": "0.15.0",
+                "@module-federation/sdk": "0.15.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-core": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.15.0.tgz",
+            "integrity": "sha512-RYzI61fRDrhyhaEOXH3AgIGlHiot0wPFXu7F43cr+ZnTi+VlSYWLdlZ4NBuT9uV6JSmH54/c+tEZm5SXgKR2sQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.15.0",
+                "@module-federation/sdk": "0.15.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.15.0.tgz",
+            "integrity": "sha512-kzFn3ObUeBp5vaEtN1WMxhTYBuYEErxugu1RzFUERD21X3BZ+b4cWwdFJuBDlsmVjctIg/QSOoZoPXRKAO0foA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.15.0",
+                "@module-federation/webpack-bundler-runtime": "0.15.0"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.15.0.tgz",
+            "integrity": "sha512-PWiYbGcJrKUD6JZiEPihrXhV3bgXdll4bV7rU+opV7tHaun+Z0CdcawjZ82Xnpb8MCPGmqHwa1MPFeUs66zksw==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.15.0.tgz",
+            "integrity": "sha512-i+3wu2Ljh2TmuUpsnjwZVupOVqV50jP0ndA8PSP4gwMKlgdGeaZ4VH5KkHAXGr2eiYUxYLMrJXz1+eILJqeGDg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.15.0",
+                "@module-federation/sdk": "0.15.0"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5116,6 +5236,185 @@
             },
             "peerDependencies": {
                 "react": ">=18"
+            }
+        },
+        "node_modules/@rspack/binding": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.4.6.tgz",
+            "integrity": "sha512-rRc6sbKWxhomxxJeqi4QS3S/2T6pKf4JwC/VHXs7KXw7lHXHa3yxPynmn3xHstL0H6VLaM5xQj87Wh7lQYRAPg==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.4.6",
+                "@rspack/binding-darwin-x64": "1.4.6",
+                "@rspack/binding-linux-arm64-gnu": "1.4.6",
+                "@rspack/binding-linux-arm64-musl": "1.4.6",
+                "@rspack/binding-linux-x64-gnu": "1.4.6",
+                "@rspack/binding-linux-x64-musl": "1.4.6",
+                "@rspack/binding-wasm32-wasi": "1.4.6",
+                "@rspack/binding-win32-arm64-msvc": "1.4.6",
+                "@rspack/binding-win32-ia32-msvc": "1.4.6",
+                "@rspack/binding-win32-x64-msvc": "1.4.6"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.4.6.tgz",
+            "integrity": "sha512-K37H8e58eY7zBHGeMVtT7m0Z5XvlNQX7YDuaxlbiA4hZxqeRoS5BMX/YOcDiGdNbSuqv+iG5GSckJ99YUI67Cw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.4.6.tgz",
+            "integrity": "sha512-3p5u9q/Q9MMVe+5XFJ/WiFrzNrrxUjJFR19kB1k/KMcf8ox982xWjnfJuBkET/k7Hn0EZL7L06ym447uIfAVAg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.4.6.tgz",
+            "integrity": "sha512-ZrrCn5b037ImZfZ3MShJrRw4d5M3Tq2rFJupr+SGMg7GTl2T6xEmo3ER/evHlT6e0ETi6tRWPxC9A1125jbSQA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.4.6.tgz",
+            "integrity": "sha512-0a30oR6ZmZrqmsOHQYrbZPCxAgnqAiqlbFozdhHs+Yu2bS7SDiLpdjMg0PHwLZT2+siiMWsLodFZlXRJE54oAQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.4.6.tgz",
+            "integrity": "sha512-u6pq1aq7bX+NABVDDTOzH64KMj1KJn8fUWO+FaX7Kr7PBjhmxNRs4OaWZjbXEY6COhMYEJZ04h4DhY+lRzcKjA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.4.6.tgz",
+            "integrity": "sha512-rjP/1dWKB828kzd4/QpDYNVasUAKDj0OeRJGh5L/RluSH3pEqhxm5FwvndpmFDv6m3iPekZ4IO26UrpGJmE9fw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-wasm32-wasi": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.4.6.tgz",
+            "integrity": "sha512-5M0g7TaWgCFQJr4NKYW2bTLbQJuAQIgZL7WmiDwotgscBJDQWJVBayFEsnM6PYX1Inmu6RNhQ44BKIYwwoSyYw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            }
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.4.6.tgz",
+            "integrity": "sha512-thPCdbh4O+uEAJ8AvXBWZIOW0ZopJAN3CX2zlprso8Cnhi4wDseTtrIxFQh7cTo6pR3xSZAIv/zHd+MMF8TImA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.4.6.tgz",
+            "integrity": "sha512-KQmm6c/ZfJKQ/TpzbY6J0pDvUB9kwTXzp+xl2FhGq2RXid8uyDS8ZqbeJA6LDxgttsmp4PRVJjMdLVYjZenfLw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.4.6.tgz",
+            "integrity": "sha512-WRRhCsJ+xcOmvzo/r/b2UTejPLnDEbaD/te1yQwHe97sUaFGr3u1Njk6lVYRTV6mEvUopEChb8yAq/S4dvaGLg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/core": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.4.6.tgz",
+            "integrity": "sha512-/OpJLv7dPEE7x/qCXGecRm9suNxz5w0Dheq2sh0TjTCUHodtMET3T+FlRWznBAlZeNuHLECDp0DWhchgS8BWuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.15.0",
+                "@rspack/binding": "1.4.6",
+                "@rspack/lite-tapable": "1.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/lite-tapable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
+            "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@shikijs/core": {
@@ -5513,6 +5812,403 @@
                 "url": "https://github.com/sponsors/gregberge"
             }
         },
+        "node_modules/@swc/core": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.14.tgz",
+            "integrity": "sha512-CJSn2vstd17ddWIHBsjuD4OQnn9krQfaq6EO+w9YfId5DKznyPmzxAARlOXG99cC8/3Kli8ysKy6phL43bSr0w==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.23"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.12.14",
+                "@swc/core-darwin-x64": "1.12.14",
+                "@swc/core-linux-arm-gnueabihf": "1.12.14",
+                "@swc/core-linux-arm64-gnu": "1.12.14",
+                "@swc/core-linux-arm64-musl": "1.12.14",
+                "@swc/core-linux-x64-gnu": "1.12.14",
+                "@swc/core-linux-x64-musl": "1.12.14",
+                "@swc/core-win32-arm64-msvc": "1.12.14",
+                "@swc/core-win32-ia32-msvc": "1.12.14",
+                "@swc/core-win32-x64-msvc": "1.12.14"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.17"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.14.tgz",
+            "integrity": "sha512-HNukQoOKgMsHSETj8vgGGKK3SEcH7Cz6k4bpntCxBKNkO3sH7RcBTDulWGGHJfZaDNix7Rw2ExUVWtLZlzkzXg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.12.14.tgz",
+            "integrity": "sha512-4Ttf3Obtk3MvFrR0e04qr6HfXh4L1Z+K3dRej63TAFuYpo+cPXeOZdPUddAW73lSUGkj+61IHnGPoXD3OQYy4Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.14.tgz",
+            "integrity": "sha512-zhJOH2KWjtQpzJ27Xjw/RKLVOa1aiEJC2b70xbCwEX6ZTVAl8tKbhkZ3GMphhfVmLJ9gf/2UQR58oxVnsXqX5Q==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.14.tgz",
+            "integrity": "sha512-akUAe1YrBqZf1EDdUxahQ8QZnJi8Ts6Ya0jf6GBIMvnXL4Y6QIuvKTRwfNxy7rJ+x9zpzP1Vlh14ZZkSKZ1EGA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.14.tgz",
+            "integrity": "sha512-ZkOOIpSMXuPAjfOXEIAEQcrPOgLi6CaXvA5W+GYnpIpFG21Nd0qb0WbwFRv4K8BRtl993Q21v0gPpOaFHU+wdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.14.tgz",
+            "integrity": "sha512-71EPPccwJiJUxd2aMwNlTfom2mqWEWYGdbeTju01tzSHsEuD7E6ePlgC3P3ngBqB3urj41qKs87z7zPOswT5Iw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.14.tgz",
+            "integrity": "sha512-nImF1hZJqKTcl0WWjHqlelOhvuB9rU9kHIw/CmISBUZXogjLIvGyop1TtJNz0ULcz2Oxr3Q2YpwfrzsgvgbGkA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.14.tgz",
+            "integrity": "sha512-sABFQFxSuStFoxvEWZUHWYldtB1B4A9eDNFd4Ty50q7cemxp7uoscFoaCqfXSGNBwwBwpS5EiPB6YN4y6hqmLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.14.tgz",
+            "integrity": "sha512-KBznRB02NASkpepRdWIK4f1AvmaJCDipKWdW1M1xV9QL2tE4aySJFojVuG1+t0tVDkjRfwcZjycQfRoJ4RjD7Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.14.tgz",
+            "integrity": "sha512-SymoP2CJHzrYaFKjWvuQljcF7BkTpzaS1vpywv7K9EzdTb5N8qPDvNd+PhWUqBz9JHBhbJxpaeTDQBXF/WWPmw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@swc/html": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.12.14.tgz",
+            "integrity": "sha512-UmIz+HiWgn63XkIv8ihUgOQTFijcbNtvwVdWdpbqvpbaXQGI6mS0DQz+T9ZxnlndDJkW0J5l1zkOxw39w4bU2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "@swc/html-darwin-arm64": "1.12.14",
+                "@swc/html-darwin-x64": "1.12.14",
+                "@swc/html-linux-arm-gnueabihf": "1.12.14",
+                "@swc/html-linux-arm64-gnu": "1.12.14",
+                "@swc/html-linux-arm64-musl": "1.12.14",
+                "@swc/html-linux-x64-gnu": "1.12.14",
+                "@swc/html-linux-x64-musl": "1.12.14",
+                "@swc/html-win32-arm64-msvc": "1.12.14",
+                "@swc/html-win32-ia32-msvc": "1.12.14",
+                "@swc/html-win32-x64-msvc": "1.12.14"
+            }
+        },
+        "node_modules/@swc/html-darwin-arm64": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.12.14.tgz",
+            "integrity": "sha512-qbZBSd2oalqBxGfVwpgT9I7gaCleL05XjuatMZIca94QhvLp0+FhCNqujrdq6Ggcrlk8IVoxtsVS5GTeDH5jAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-darwin-x64": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.12.14.tgz",
+            "integrity": "sha512-ekxCbFri6wGlh48sGSZmKgDqq3viGU29Vqw9MWBGuPFJ1S2PchoLan9ex94Za84sasn6Xirf/ylzDhqZQ9611A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm-gnueabihf": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.12.14.tgz",
+            "integrity": "sha512-xV7J8fC1U4f3H0bpeBckCTHTG8oqGFOfWxgLk5//1ZBtCAncRzrdjNkZ1kOd0bsUBFj438wW+aJ/VtrMQiBhZQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-gnu": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.12.14.tgz",
+            "integrity": "sha512-wjUyMqxYSp/NGEXwdyEVfE/P/1DNt090KGEM/UbH55i1oyIYqq4T+FJacn7ITtypJp4lYQ7s7Bb5bB/BX+TZ1w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-musl": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.12.14.tgz",
+            "integrity": "sha512-odpXvMMKZ6dhCPxbWmr6P2QJzE2RcSdZdgmleFF+CMNEc8tG6UHrIpc5Vezcf5vUc4OGseqAFjFM+ZcDBKj4rg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-gnu": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.12.14.tgz",
+            "integrity": "sha512-oLqGIB9u7X+SI0Zu2kxAOgAzEOr53n030esUcXzwGRn0BzCxAF2NaQav9HwKrCboQfK3SDtVGx/7Hy7metgacA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-musl": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.12.14.tgz",
+            "integrity": "sha512-90eIBQ2x73DgfHNuG7X8Us2yx3gSnUUYWXm5qc76qOg1KgwLzNYzFOMks7D6R8IwwWxTZLiS3ty9MnTMlkSLXg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-arm64-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.12.14.tgz",
+            "integrity": "sha512-rnVKeOnnhBAiNOqrUf3KsJGaJe+dy0Dq+Ghia4E6Xr2nmBLV+lXgurFeFS8yPNBJrGvRB7Z0JG8siSBJULdYrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-ia32-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.12.14.tgz",
+            "integrity": "sha512-ERuyVbpgh5GQApyawrbx9mPkTsd+XfSbPUEbF75WbhY04C0sBMqmncA5u3ezpaKTQZP0A/ZPJoTRXcNqh4tADw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-x64-msvc": {
+            "version": "1.12.14",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.12.14.tgz",
+            "integrity": "sha512-ji7lXLL5Os5SQfnF0YKprhnrSki+4OgkkjPYNcjoYs6gFfXg+U9h2p88uSx8K6OkmbUkkAQ2xRHzAYCQFo39BQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.23",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
+            "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            }
+        },
         "node_modules/@szmarczak/http-timer": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -5532,6 +6228,16 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@types/body-parser": {
@@ -8288,6 +8994,15 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/detect-node": {
@@ -11385,6 +12100,234 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+            "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-darwin-arm64": "1.30.1",
+                "lightningcss-darwin-x64": "1.30.1",
+                "lightningcss-freebsd-x64": "1.30.1",
+                "lightningcss-linux-arm-gnueabihf": "1.30.1",
+                "lightningcss-linux-arm64-gnu": "1.30.1",
+                "lightningcss-linux-arm64-musl": "1.30.1",
+                "lightningcss-linux-x64-gnu": "1.30.1",
+                "lightningcss-linux-x64-musl": "1.30.1",
+                "lightningcss-win32-arm64-msvc": "1.30.1",
+                "lightningcss-win32-x64-msvc": "1.30.1"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+            "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+            "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+            "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+            "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+            "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+            "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+            "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+            "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+            "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+            "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lilconfig": {
@@ -21920,6 +22863,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/swc-loader": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
+            "integrity": "sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==",
+            "license": "MIT",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.147",
+                "webpack": ">=2"
             }
         },
         "node_modules/tabbable": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,10 +7,10 @@
             "dependencies": {
                 "@apify/docs-theme": "^1.0.181",
                 "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
-                "@docusaurus/core": "^3.7.0",
+                "@docusaurus/core": "^3.8.1",
                 "@docusaurus/faster": "^3.8.1",
-                "@docusaurus/plugin-client-redirects": "^3.7.0",
-                "@docusaurus/preset-classic": "^3.7.0",
+                "@docusaurus/plugin-client-redirects": "^3.8.1",
+                "@docusaurus/preset-classic": "^3.8.1",
                 "clsx": "^2.0.0",
                 "docusaurus-gtm-plugin": "^0.0.2",
                 "prop-types": "^15.8.1",

--- a/website/package.json
+++ b/website/package.json
@@ -29,6 +29,7 @@
         "@apify/docs-theme": "^1.0.181",
         "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
         "@docusaurus/core": "^3.7.0",
+        "@docusaurus/faster": "^3.8.1",
         "@docusaurus/plugin-client-redirects": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "clsx": "^2.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -28,10 +28,10 @@
     "dependencies": {
         "@apify/docs-theme": "^1.0.181",
         "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
-        "@docusaurus/core": "^3.7.0",
+        "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
-        "@docusaurus/plugin-client-redirects": "^3.7.0",
-        "@docusaurus/preset-classic": "^3.7.0",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
         "clsx": "^2.0.0",
         "docusaurus-gtm-plugin": "^0.0.2",
         "prop-types": "^15.8.1",


### PR DESCRIPTION
Switching to SWC from `babel` seems to fix the crashing API documentation issue

closes https://github.com/apify/apify-docs/issues/1686