### PR TITLE
feat: add new methods Dataset.getPublicItemsUrl & KeyValueStore.getPublicKeysUrl

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,8 @@ import zlib from 'node:zlib';
 import ow from 'ow';
 import type { JsonValue, TypedArray } from 'type-fest';
 
+import { createHmacSignature } from '@apify/utilities';
+
 import type { ApifyApiError } from './apify_api_error';
 import type {
     RequestQueueClientListRequestsOptions,
@@ -260,3 +262,38 @@ export function asArray<T>(value: T | T[]): T[] {
 export type Dictionary<T = unknown> = Record<PropertyKey, T>;
 
 export type DistributiveOptional<T, K extends keyof T> = T extends any ? Omit<T, K> & Partial<Pick<T, K>> : never;
+
+
+/**
+ * Creates a storage signature for a resource, which can be used to generate signed URLs for accessing the resource.
+ * The signature is created using HMAC with the provided secret key and includes the resource ID, expiration time, and version.
+ * 
+ * Note: expirationMillis is optional. If not provided, the signature will not expire.
+ */
+export function createStorageSignature({ 
+    resourceId,
+    urlSigningSecretKey,
+    expiresInMillis,
+    version = 0
+}: { resourceId: string, urlSigningSecretKey: string, expiresInMillis: number | undefined, version?: number }) {
+    const expiresAt = expiresInMillis ? new Date().getTime() + expiresInMillis : null;
+    const hmac = createHmacSignature(urlSigningSecretKey, `${version}.${expiresAt}.${resourceId}`);
+    return Buffer.from(`${version}.${expiresAt}.${hmac}`).toString('base64url');
+}
+
+/**
+ * Adds query parameters to a given URL based on the provided options object.
+ */
+export function applyQueryParamsToUrl(url: URL, options?: Record<string, string | number | boolean | string[] | undefined>) {
+    for (const [key, value] of Object.entries(options ?? {})) {
+        // skip undefined values
+        if (value === undefined) continue;
+        // join array values with a comma
+        if (Array.isArray(value)) {
+            url.searchParams.set(key, value.join(','));
+            continue;
+        }
+        url.searchParams.set(key, String(value));
+    }
+    return url;
+}

--- a/test/datasets.test.js
+++ b/test/datasets.test.js
@@ -327,5 +327,32 @@ describe('Dataset methods', () => {
             expect(browserRes).toEqual(res);
             validateRequest({}, { datasetId });
         });
+
+        describe('getPublicItemsUrl()', () => {
+            it('should include a signature in the URL when the caller has permission to access the signing secret key', async () => {
+                const datasetId = 'id-with-secret-key';
+                const res = await client.dataset(datasetId).getPublicItemsUrl();
+
+                expect(new URL(res).searchParams.get('signature')).toBeDefined();
+            });
+
+            it('should not include a signature in the URL when the caller lacks permission to access the signing secret key', async () => {
+                const datasetId = 'some-id';
+                const res = await client.dataset(datasetId).getPublicItemsUrl();
+
+                expect(new URL(res).searchParams.get('signature')).toBeNull();
+            });
+
+            it('includes provided options (e.g., limit and prefix) as query parameters', async () => {
+                const datasetId = 'id-with-secret-key';
+                const res = await client.dataset(datasetId).getPublicItemsUrl({ desc: true, limit: 10, offset: 5 });
+                const publicItemsUrl = new URL(res);
+
+                expect(publicItemsUrl.searchParams.get('desc')).toBe('true');
+                expect(publicItemsUrl.searchParams.get('limit')).toBe('10');
+                expect(publicItemsUrl.searchParams.get('offset')).toBe('5');
+                expect(publicItemsUrl.searchParams.get('signature')).toBeDefined();
+            });
+        });
     });
 });

--- a/test/key_value_stores.test.js
+++ b/test/key_value_stores.test.js
@@ -553,5 +553,31 @@ describe('Key-Value Store methods', () => {
             expect(browserRes).toBeUndefined();
             validateRequest({}, { storeId, key });
         });
+
+        describe('getPublicKeysUrl()', () => {
+            it('should include a signature in the URL when the caller has permission to access the signing secret key', async () => {
+                const storeId = 'id-with-secret-key';
+                const res = await client.keyValueStore(storeId).getPublicKeysUrl();
+
+                expect(new URL(res).searchParams.get('signature')).toBeDefined();
+            });
+
+            it('should not include a signature in the URL when the caller lacks permission to access the signing secret key', async () => {
+                const storeId = 'some-id';
+                const res = await client.keyValueStore(storeId).getPublicKeysUrl();
+
+                expect(new URL(res).searchParams.get('signature')).toBeNull();
+            });
+
+            it('includes provided options (e.g., limit and prefix) as query parameters', async () => {
+                const storeId = 'id-with-secret-key';
+                const res = await client.keyValueStore(storeId).getPublicKeysUrl({ limit: 10, prefix: 'prefix' });
+                const publicItemsUrl = new URL(res);
+
+                expect(publicItemsUrl.searchParams.get('limit')).toBe('10');
+                expect(publicItemsUrl.searchParams.get('prefix')).toBe('prefix');
+                expect(publicItemsUrl.searchParams.get('signature')).toBeDefined();
+            });
+        });
     });
 });

--- a/test/mock_server/routes/datasets.js
+++ b/test/mock_server/routes/datasets.js
@@ -7,7 +7,6 @@ const datasets = express.Router();
 const ROUTES = [
     { id: 'get-or-create-dataset', method: 'POST', path: '/' },
     { id: 'list-datasets', method: 'GET', path: '/' },
-    { id: 'get-dataset', method: 'GET', path: '/:datasetId' },
     { id: 'delete-dataset', method: 'DELETE', path: '/:datasetId' },
     { id: 'update-dataset', method: 'PUT', path: '/:datasetId' },
     { id: 'list-items', method: 'GET', path: '/:datasetId/items', type: 'responseJsonMock' },
@@ -16,5 +15,35 @@ const ROUTES = [
 ];
 
 addRoutes(datasets, ROUTES);
+
+/**
+ * GET /datasets/:datasetId
+ * Returns a specific dataset by its ID.
+ * If the dataset ID is 'id-with-secret-key', it returns a dataset with a URL signing secret key.
+ * If the dataset ID is '404', it returns a 404 error with a RECORD_NOT_FOUND type.
+ * Otherwise, it returns a dataset with an ID of 'get-dataset' (default).
+ */
+datasets.get('/:datasetId', (req, res) => {
+    const { datasetId } = req.params;
+
+    if (datasetId === 'id-with-secret-key') {
+        return res.json({
+            data: {
+                id: datasetId,
+                urlSigningSecretKey: 'a-real-secret-key-for-testing',
+            }
+        });
+    }
+
+    if (datasetId === '404') {
+        return res.status(404).json({ error: { type: 'record-not-found' } });
+    }
+
+    return res.json({
+        data: {
+            id: 'get-dataset',
+        }
+    });
+});
 
 module.exports = datasets;

--- a/test/mock_server/routes/key_value_stores.js
+++ b/test/mock_server/routes/key_value_stores.js
@@ -7,7 +7,6 @@ const keyValueStores = express.Router();
 const ROUTES = [
     { id: 'list-stores', method: 'GET', path: '/' },
     { id: 'get-or-create-store', method: 'POST', path: '/' },
-    { id: 'get-store', method: 'GET', path: '/:storeId' },
     { id: 'delete-store', method: 'DELETE', path: '/:storeId' },
     { id: 'update-store', method: 'PUT', path: '/:storeId' },
     { id: 'get-record', method: 'GET', path: '/:storeId/records/:key', type: 'responseJsonMock' },
@@ -23,5 +22,35 @@ const ROUTES = [
 ];
 
 addRoutes(keyValueStores, ROUTES);
+
+/**
+ * GET /key-value-stores/:storeId
+ * Returns a specific key-value store by its ID.
+ * If the store ID is 'id-with-secret-key', it returns a store with a URL signing secret key.
+ * If the store ID is '404', it returns a 404 error with a RECORD_NOT_FOUND type.
+ * Otherwise, it returns a store with an ID of 'get-store' (default).
+ */
+keyValueStores.get('/:storeId', (req, res) => {
+    const { storeId } = req.params;
+
+    if (storeId === 'id-with-secret-key') {
+        return res.json({
+            data: {
+                id: storeId,
+                urlSigningSecretKey: 'a-real-secret-key-for-testing',
+            }
+        });
+    }
+
+    if (storeId === '404') {
+        return res.status(404).json({ error: { type: 'record-not-found' } });
+    }
+
+    return res.json({
+        data: {
+            id: 'get-store',
+        }
+    });
+});
 
 module.exports = keyValueStores;


### PR DESCRIPTION
When storage resources (Datasets or Key-Value Stores) are set to Restricted, accessing or sharing their data externally becomes difficult due to limited permissions. This PR introduces functionality to generate signed URLs that allow controlled external access to these resources without adding token to the request.

This PR introduces methods to generate signed URLs for Dataset items and Key-Value Store records:
1. **Datasets**
`dataset(:datasetId).getPublicItemsUrl(options, expiresInMillis)`
→ Returns a signed URL like:
`/v2/datasets/:datasetId/items?signature=xxx`

2. Key-Value Stores
`keyValueStore(:storeId).getPublicKeysUrl(options, expiresInMillis)`
→ Returns a signed URL like:
`/v2/key-value-stores/:storeId/keys?signature=xxx`

🕒 Expiration:
The `expiresInMillis` parameter defines how long the signature is valid.
- If provided, the URL will expire after the specified time.
- If omitted, the URL will never expire.


Note: The signature is included only if the token has WRITE access to the storage. Otherwise, an unsigned URL is returned.

P.S. We're not yet exposing `urlSigningSecretKey` for datasets, it will be released after [PR](https://github.com/apify/apify-core/pull/22173) is merged.

[More context here](https://www.notion.so/apify/Signed-Dataset-Items-KV-store-record-URLs-224f39950a2280158a6bd82bc2e2ebb5?source=copy_link)