### PR TITLE
feat: extend status parameter to an array of possible statuses

### DIFF
--- a/src/resource_clients/run_collection.ts
+++ b/src/resource_clients/run_collection.ts
@@ -43,5 +43,7 @@ export interface RunCollectionListOptions {
     limit?: number;
     offset?: number;
     desc?: boolean;
-    status?: (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES] | (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES][];
+    status?:
+        | (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES]
+        | (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES][];
 }

--- a/test/runs.test.js
+++ b/test/runs.test.js
@@ -28,7 +28,7 @@ describe('Run methods', () => {
     });
     afterEach(async () => {
         client = null;
-        page.close().catch(() => { });
+        page.close().catch(() => {});
     });
 
     describe('runs()', () => {
@@ -331,7 +331,7 @@ describe('Run methods', () => {
 
             await expect(client.run(runId).charge()).rejects.toThrow(
                 'Expected `options` to be of type `object` but received type `undefined`\n' +
-                'Cannot convert undefined or null to object in object `options`',
+                    'Cannot convert undefined or null to object in object `options`',
             );
         });
     });


### PR DESCRIPTION
The `status` parameter in the Apify Core API has been extended on the following endpoints:

- `/v2/acts/:actorId/runs`
- `/v2/actor-runs`
- `/v2/actor-tasks/:actorTaskId/runs`

It is now a comma-separated string of possible statuses.

This PR updates the js client accordingly by modifying the `RunCollectionClient.list()` method to reflect the API change. Corresponding tests have also been extended.