### PR TITLE
fix: add recordPublicUrl to KeyValueListItem type

### DIFF
--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -364,6 +364,7 @@ export interface KeyValueClientListKeysResult {
 export interface KeyValueListItem {
     key: string;
     size: number;
+    recordPublicUrl: string;
 }
 
 export interface KeyValueClientGetRecordOptions {


### PR DESCRIPTION
This PR updates `KeyValueListItem` type to include `recordPublicUrl`