### PR TITLE
refactor!: rename expiresInMillis to expiresInSecs in create storage content URL

### DIFF
--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -170,13 +170,13 @@ export class DatasetClient<
      * If the client has permission to access the dataset's URL signing key,
      * the URL will include a signature which will allow the link to work even without authentication.
      *
-     * You can optionally control how long the signed URL should be valid using the `expiresInMillis` option.
-     * This value sets the expiration duration in milliseconds from the time the URL is generated.
+     * You can optionally control how long the signed URL should be valid using the `expiresInSecs` option.
+     * This value sets the expiration duration in seconds from the time the URL is generated.
      * If not provided, the URL will not expire.
      *
      * Any other options (like `limit` or `prefix`) will be included as query parameters in the URL.
      */
-    async createItemsPublicUrl(options: DatasetClientListItemOptions = {}, expiresInMillis?: number): Promise<string> {
+    async createItemsPublicUrl(options: DatasetClientListItemOptions = {}, expiresInSecs?: number): Promise<string> {
         ow(
             options,
             ow.object.exactShape({
@@ -202,7 +202,7 @@ export class DatasetClient<
             const signature = createStorageContentSignature({
                 resourceId: dataset.id,
                 urlSigningSecretKey: dataset.urlSigningSecretKey,
-                expiresInMillis,
+                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
             });
             createdItemsPublicUrl.searchParams.set('signature', signature);
         }

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -176,7 +176,7 @@ export class DatasetClient<
      *
      * Any other options (like `limit` or `prefix`) will be included as query parameters in the URL.
      */
-    async createItemsPublicUrl(options: DatasetClientListItemOptions = {}, expiresInSecs?: number): Promise<string> {
+    async createItemsPublicUrl(options: DatasetClientCreateItemsUrlOptions = {}): Promise<string> {
         ow(
             options,
             ow.object.exactShape({
@@ -191,6 +191,7 @@ export class DatasetClient<
                 skipHidden: ow.optional.boolean,
                 unwind: ow.optional.any(ow.string, ow.array.ofType(ow.string)),
                 view: ow.optional.string,
+                expiresInSecs: ow.optional.number,
             }),
         );
 
@@ -202,7 +203,7 @@ export class DatasetClient<
             const signature = createStorageContentSignature({
                 resourceId: dataset.id,
                 urlSigningSecretKey: dataset.urlSigningSecretKey,
-                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
+                expiresInMillis: options.expiresInSecs ? options.expiresInSecs * 1000 : undefined,
             });
             createdItemsPublicUrl.searchParams.set('signature', signature);
         }
@@ -269,6 +270,10 @@ export interface DatasetClientListItemOptions {
     skipHidden?: boolean;
     unwind?: string | string[]; // TODO: when doing a breaking change release, change to string[] only
     view?: string;
+}
+
+export interface DatasetClientCreateItemsUrlOptions extends DatasetClientListItemOptions {
+    expiresInSecs?: number;
 }
 
 export enum DownloadItemsFormat {

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -112,13 +112,13 @@ export class KeyValueStoreClient extends ResourceClient {
      * If the client has permission to access the key-value store's URL signing key,
      * the URL will include a signature which will allow the link to work even without authentication.
      *
-     * You can optionally control how long the signed URL should be valid using the `expiresInMillis` option.
-     * This value sets the expiration duration in milliseconds from the time the URL is generated.
+     * You can optionally control how long the signed URL should be valid using the `expiresInSecs` option.
+     * This value sets the expiration duration in seconds from the time the URL is generated.
      * If not provided, the URL will not expire.
      *
      * Any other options (like `limit` or `prefix`) will be included as query parameters in the URL.
      */
-    async createKeysPublicUrl(options: KeyValueClientListKeysOptions = {}, expiresInMillis?: number) {
+    async createKeysPublicUrl(options: KeyValueClientListKeysOptions = {}, expiresInSecs?: number) {
         ow(
             options,
             ow.object.exactShape({
@@ -137,7 +137,7 @@ export class KeyValueStoreClient extends ResourceClient {
             const signature = createStorageContentSignature({
                 resourceId: store.id,
                 urlSigningSecretKey: store.urlSigningSecretKey,
-                expiresInMillis,
+                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
             });
             createdPublicKeysUrl.searchParams.set('signature', signature);
         }

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -118,7 +118,7 @@ export class KeyValueStoreClient extends ResourceClient {
      *
      * Any other options (like `limit` or `prefix`) will be included as query parameters in the URL.
      */
-    async createKeysPublicUrl(options: KeyValueClientListKeysOptions = {}, expiresInSecs?: number) {
+    async createKeysPublicUrl(options: KeyValueClientCreateKeysUrlOptions = {}) {
         ow(
             options,
             ow.object.exactShape({
@@ -126,6 +126,7 @@ export class KeyValueStoreClient extends ResourceClient {
                 exclusiveStartKey: ow.optional.string,
                 collection: ow.optional.string,
                 prefix: ow.optional.string,
+                expiresInSecs: ow.optional.number,
             }),
         );
 
@@ -137,7 +138,7 @@ export class KeyValueStoreClient extends ResourceClient {
             const signature = createStorageContentSignature({
                 resourceId: store.id,
                 urlSigningSecretKey: store.urlSigningSecretKey,
-                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
+                expiresInMillis: options.expiresInSecs ? options.expiresInSecs * 1000 : undefined,
             });
             createdPublicKeysUrl.searchParams.set('signature', signature);
         }
@@ -350,6 +351,10 @@ export interface KeyValueClientListKeysOptions {
     exclusiveStartKey?: string;
     collection?: string;
     prefix?: string;
+}
+
+export interface KeyValueClientCreateKeysUrlOptions extends KeyValueClientListKeysOptions {
+    expiresInSecs?: number;
 }
 
 export interface KeyValueClientListKeysResult {


### PR DESCRIPTION
This PR changes `expiresInMillis` to `expiresInSecs` and moves it to options in create storage content URLs:
- `KeyValueStore.createKeysPublicUrl(options)`
- `Dataset.createItemsPublicUrl(options)`


Note: I'm aware that this can potentially be breaking change, but we suppose that no one started using it yet.

More context: https://apify.slack.com/archives/C01VBUV81UZ/p1756111935325179