### PR TITLE
fix: signed storage URLs avoid adding expiresInSecs to query params

### DIFF
--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -197,18 +197,20 @@ export class DatasetClient<
 
         const dataset = await this.get();
 
+        const { expiresInSecs, ...queryOptions } = options;
+
         let createdItemsPublicUrl = new URL(this._url('items'));
 
         if (dataset?.urlSigningSecretKey) {
             const signature = createStorageContentSignature({
                 resourceId: dataset.id,
                 urlSigningSecretKey: dataset.urlSigningSecretKey,
-                expiresInMillis: options.expiresInSecs ? options.expiresInSecs * 1000 : undefined,
+                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
             });
             createdItemsPublicUrl.searchParams.set('signature', signature);
         }
 
-        createdItemsPublicUrl = applyQueryParamsToUrl(createdItemsPublicUrl, options);
+        createdItemsPublicUrl = applyQueryParamsToUrl(createdItemsPublicUrl, queryOptions);
 
         return createdItemsPublicUrl.toString();
     }

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -132,18 +132,20 @@ export class KeyValueStoreClient extends ResourceClient {
 
         const store = await this.get();
 
+        const { expiresInSecs, ...queryOptions } = options;
+
         let createdPublicKeysUrl = new URL(this._url('keys'));
 
         if (store?.urlSigningSecretKey) {
             const signature = createStorageContentSignature({
                 resourceId: store.id,
                 urlSigningSecretKey: store.urlSigningSecretKey,
-                expiresInMillis: options.expiresInSecs ? options.expiresInSecs * 1000 : undefined,
+                expiresInMillis: expiresInSecs ? expiresInSecs * 1000 : undefined,
             });
             createdPublicKeysUrl.searchParams.set('signature', signature);
         }
 
-        createdPublicKeysUrl = applyQueryParamsToUrl(createdPublicKeysUrl, options);
+        createdPublicKeysUrl = applyQueryParamsToUrl(createdPublicKeysUrl, queryOptions);
 
         return createdPublicKeysUrl.toString();
     }


### PR DESCRIPTION
I noticed that we also add `expiresInSecs` to query params when we generate signed URL, we want to avoid adding it.

This is not critical, can be released in the next release