### PR TITLE
fix: presigned resource urls shouldn't follow `baseUrl`

### DIFF
--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -42,6 +42,8 @@ const DEFAULT_TIMEOUT_SECS = 360;
 export class ApifyClient {
     baseUrl: string;
 
+    publicBaseUrl: string;
+
     token?: string;
 
     stats: Statistics;
@@ -55,6 +57,7 @@ export class ApifyClient {
             options,
             ow.object.exactShape({
                 baseUrl: ow.optional.string,
+                publicBaseUrl: ow.optional.string,
                 maxRetries: ow.optional.number,
                 minDelayBetweenRetriesMillis: ow.optional.number,
                 requestInterceptors: ow.optional.array,
@@ -66,6 +69,7 @@ export class ApifyClient {
 
         const {
             baseUrl = 'https://api.apify.com',
+            publicBaseUrl = 'https://api.apify.com',
             maxRetries = 8,
             minDelayBetweenRetriesMillis = 500,
             requestInterceptors = [],
@@ -75,6 +79,10 @@ export class ApifyClient {
 
         const tempBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl;
         this.baseUrl = `${tempBaseUrl}/v2`;
+        const tempPublicBaseUrl = publicBaseUrl.endsWith('/')
+            ? publicBaseUrl.slice(0, publicBaseUrl.length - 1)
+            : publicBaseUrl;
+        this.publicBaseUrl = `${tempPublicBaseUrl}/v2`;
         this.token = token;
         this.stats = new Statistics();
         this.logger = logger.child({ prefix: 'ApifyClient' });
@@ -93,6 +101,7 @@ export class ApifyClient {
     private _options() {
         return {
             baseUrl: this.baseUrl,
+            publicBaseUrl: this.publicBaseUrl,
             apifyClient: this,
             httpClient: this.httpClient,
         };
@@ -347,6 +356,8 @@ export class ApifyClient {
 export interface ApifyClientOptions {
     /** @default https://api.apify.com */
     baseUrl?: string;
+    /** @default https://api.apify.com */
+    publicBaseUrl?: string;
     /** @default 8 */
     maxRetries?: number;
     /** @default 500 */

--- a/src/base/api_client.ts
+++ b/src/base/api_client.ts
@@ -4,6 +4,7 @@ import type { HttpClient } from '../http_client';
 /** @private */
 export interface ApiClientOptions {
     baseUrl: string;
+    publicBaseUrl: string;
     resourcePath: string;
     apifyClient: ApifyClient;
     httpClient: HttpClient;
@@ -25,6 +26,8 @@ export abstract class ApiClient {
 
     baseUrl: string;
 
+    publicBaseUrl: string;
+
     resourcePath: string;
 
     url: string;
@@ -36,11 +39,12 @@ export abstract class ApiClient {
     params?: Record<string, unknown>;
 
     constructor(options: ApiClientOptions) {
-        const { baseUrl, apifyClient, httpClient, resourcePath, id, params = {} } = options;
+        const { baseUrl, publicBaseUrl, apifyClient, httpClient, resourcePath, id, params = {} } = options;
 
         this.id = id;
         this.safeId = id && this._toSafeId(id);
         this.baseUrl = baseUrl;
+        this.publicBaseUrl = publicBaseUrl;
         this.resourcePath = resourcePath;
         this.url = id ? `${baseUrl}/${resourcePath}/${this.safeId}` : `${baseUrl}/${resourcePath}`;
         this.apifyClient = apifyClient;
@@ -51,6 +55,7 @@ export abstract class ApiClient {
     protected _subResourceOptions<T>(moreOptions?: T): BaseOptions & T {
         const baseOptions: BaseOptions = {
             baseUrl: this._url(),
+            publicBaseUrl: this.publicBaseUrl,
             apifyClient: this.apifyClient,
             httpClient: this.httpClient,
             params: this._params(),
@@ -60,6 +65,13 @@ export abstract class ApiClient {
 
     protected _url(path?: string): string {
         return path ? `${this.url}/${path}` : this.url;
+    }
+
+    protected _publicUrl(path?: string): string {
+        const url = this.id
+            ? `${this.publicBaseUrl}/${this.resourcePath}/${this.safeId}`
+            : `${this.publicBaseUrl}/${this.resourcePath}`;
+        return path ? `${url}/${path}` : url;
     }
 
     protected _params<T>(endpointParams?: T): Record<string, unknown> {
@@ -74,6 +86,7 @@ export abstract class ApiClient {
 
 export interface BaseOptions {
     baseUrl: string;
+    publicBaseUrl: string;
     apifyClient: ApifyClient;
     httpClient: HttpClient;
     params: Record<string, unknown>;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -180,6 +180,7 @@ export class ActorClient extends ResourceClient {
 
         return new BuildClient({
             baseUrl: this.apifyClient.baseUrl,
+            publicBaseUrl: this.apifyClient.publicBaseUrl,
             httpClient: this.httpClient,
             apifyClient: this.apifyClient,
             id,

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -199,7 +199,7 @@ export class DatasetClient<
 
         const { expiresInSecs, ...queryOptions } = options;
 
-        let createdItemsPublicUrl = new URL(this._url('items'));
+        let createdItemsPublicUrl = new URL(this._publicUrl('items'));
 
         if (dataset?.urlSigningSecretKey) {
             const signature = createStorageContentSignature({

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -96,7 +96,7 @@ export class KeyValueStoreClient extends ResourceClient {
 
         const store = await this.get();
 
-        const recordPublicUrl = new URL(this._url(`records/${key}`));
+        const recordPublicUrl = new URL(this._publicUrl(`records/${key}`));
 
         if (store?.urlSigningSecretKey) {
             const signature = createHmacSignature(store.urlSigningSecretKey, key);
@@ -134,7 +134,7 @@ export class KeyValueStoreClient extends ResourceClient {
 
         const { expiresInSecs, ...queryOptions } = options;
 
-        let createdPublicKeysUrl = new URL(this._url('keys'));
+        let createdPublicKeysUrl = new URL(this._publicUrl('keys'));
 
         if (store?.urlSigningSecretKey) {
             const signature = createStorageContentSignature({

--- a/test/datasets.test.js
+++ b/test/datasets.test.js
@@ -329,6 +329,24 @@ describe('Dataset methods', () => {
         });
 
         describe('createItemsPublicUrl()', () => {
+            it.each([
+                ['https://custom.public.url/', 'custom.public.url'],
+                [undefined, 'api.apify.com'],
+            ])('respects publicBaseUrl client option (%s)', async (publicBaseUrl, expectedHostname) => {
+                const datasetId = 'dataset-id';
+                client = new ApifyClient({
+                    baseUrl,
+                    publicBaseUrl,
+                    ...DEFAULT_OPTIONS,
+                });
+
+                const res = await client.dataset(datasetId).createItemsPublicUrl();
+
+                const url = new URL(res);
+                expect(url.hostname).toBe(expectedHostname);
+                expect(url.pathname).toBe(`/v2/datasets/${datasetId}/items`);
+            });
+
             it('should include a signature in the URL when the caller has permission to access the signing secret key', async () => {
                 const datasetId = 'id-with-secret-key';
                 const res = await client.dataset(datasetId).createItemsPublicUrl();

--- a/test/key_value_stores.test.js
+++ b/test/key_value_stores.test.js
@@ -555,6 +555,26 @@ describe('Key-Value Store methods', () => {
         });
 
         describe('getRecordPublicUrl()', () => {
+            it.each([
+                ['https://custom.public.url/', 'custom.public.url'],
+                [undefined, 'api.apify.com'],
+            ])('respects publicBaseUrl client option (%s)', async (publicBaseUrl, expectedHostname) => {
+                const storeId = 'some-id';
+                const key = 'some-key';
+
+                client = new ApifyClient({
+                    baseUrl,
+                    publicBaseUrl,
+                    ...DEFAULT_OPTIONS,
+                });
+
+                const res = await client.keyValueStore(storeId).getRecordPublicUrl(key);
+
+                const url = new URL(res);
+                expect(url.hostname).toBe(expectedHostname);
+                expect(url.pathname).toBe(`/v2/key-value-stores/${storeId}/records/${key}`);
+            });
+
             it('should include a signature in the URL when the caller has permission to access the signing secret key', async () => {
                 const storeId = 'id-with-secret-key';
                 const key = 'some-key';
@@ -577,6 +597,25 @@ describe('Key-Value Store methods', () => {
         });
 
         describe('createKeysPublicUrl()', () => {
+            it.each([
+                ['https://custom.public.url/', 'custom.public.url'],
+                [undefined, 'api.apify.com'],
+            ])('respects publicBaseUrl client option (%s)', async (publicBaseUrl, expectedHostname) => {
+                const storeId = 'some-id';
+
+                client = new ApifyClient({
+                    baseUrl,
+                    publicBaseUrl,
+                    ...DEFAULT_OPTIONS,
+                });
+
+                const res = await client.keyValueStore(storeId).createKeysPublicUrl();
+
+                const url = new URL(res);
+                expect(url.hostname).toBe(expectedHostname);
+                expect(url.pathname).toBe(`/v2/key-value-stores/${storeId}/keys`);
+            });
+
             it('should include a signature in the URL when the caller has permission to access the signing secret key', async () => {
                 const storeId = 'id-with-secret-key';
                 const res = await client.keyValueStore(storeId).createKeysPublicUrl();


### PR DESCRIPTION
Closes #744 