### PR TITLE
refactor: startedBefore and startedAfter types

### DIFF
--- a/src/resource_clients/run_collection.ts
+++ b/src/resource_clients/run_collection.ts
@@ -48,6 +48,6 @@ export interface RunCollectionListOptions {
     status?:
         | (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES]
         | (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES][];
-    startedBefore?: string;
-    startedAfter?: string;
+    startedBefore?: Date | string;
+    startedAfter?: Date | string;
 }


### PR DESCRIPTION
After testing the changes, I realized that TS yells when I pass the dates as Date object. This PR fixes types.

This PR updates types of `startedBefore` and `startedAfter`.