### PR TITLE
perf: dynamic imports for certain `node:` packages

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
         externals: {
             'node:util': 'node:util',
             'node:zlib': 'node:zlib',
-        }
+        },
     },
     tools: {
         htmlPlugin: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,10 +120,10 @@ export async function maybeGzipValue(value: unknown): Promise<Buffer | undefined
         if (!gzipPromisified) {
             const { promisify } = await import('node:util');
             const { gzip } = await import('node:zlib');
-            (gzipPromisified as any) = promisify(gzip);
+            gzipPromisified = promisify(gzip);
         }
 
-        return gzipPromisified!(value);
+        return gzipPromisified(value);
     }
 
     return undefined;


### PR DESCRIPTION
Changes some `node:`-scoped imports into dynamic imports to remove the need for polyfilling / bundling those packages (which are unused in the browser environment anyway).

Related to #753 

Note that the issue is not fully solved because of the dependencies from https://github.com/apify/apify-shared-js and the calls to `node:os` in `HttpClient` (see below), which would require bigger refactors (ESM imports are asynchronous, so cannot be done in a constructor).

https://github.com/apify/apify-client-js/blob/a9c65ec2ed75e1141c33d5d7ad0b1dec7fc0654c/src/http_client.ts#L109