### PR TITLE
feat: Add CONNECT tunneling support for HTTP proxy in sandboxed environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,8 @@
                 "async-retry": "^1.3.3",
                 "axios": "^1.6.7",
                 "content-type": "^1.0.5",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
                 "ow": "^0.28.2",
+                "proxy-agent": "^6.5.0",
                 "tslib": "^2.5.0",
                 "type-fest": "^4.0.0"
             },
@@ -3638,7 +3637,6 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@tsconfig/node10": {
@@ -4641,7 +4639,6 @@
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.1"
@@ -5041,7 +5038,6 @@
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
             "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -6131,7 +6127,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -6296,7 +6291,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ast-types": "^0.13.4",
@@ -6828,7 +6822,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "esprima": "^4.0.1",
@@ -7183,7 +7176,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -7223,7 +7215,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -7233,7 +7224,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -8156,7 +8146,6 @@
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
             "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "basic-ftp": "^5.0.2",
@@ -8915,7 +8904,6 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
             "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -10818,7 +10806,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
@@ -11196,7 +11183,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
             "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -11216,7 +11202,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "degenerator": "^5.0.0",
@@ -11723,7 +11708,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
             "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -11743,7 +11727,6 @@
             "version": "7.18.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -12845,7 +12828,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -12856,7 +12838,6 @@
             "version": "2.8.7",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ip-address": "^10.0.1",
@@ -12871,7 +12852,6 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -12886,7 +12866,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -70,9 +70,8 @@
         "async-retry": "^1.3.3",
         "axios": "^1.6.7",
         "content-type": "^1.0.5",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "ow": "^0.28.2",
+        "proxy-agent": "^6.5.0",
         "tslib": "^2.5.0",
         "type-fest": "^4.0.0"
     },


### PR DESCRIPTION
This PR is a follow-up of PR #788, which unfortunately didn't fully fix the use of **apify-cli** in Claude Code sandbox (in the browser, not the local one).

Currently, this is what's happening :

1. Proxy receives the request
2. Proxy returns: HTTP/1.1 301 Moved Permanently
3. Location: https://api.apify.com:443/v2/users/me (adds explicit :443 port)
4. axios follows redirect to https://api.apify.com:443/v2/users/me
5. Proxy strips the :443 and redirects back to https://api.apify.com/v2/users/me
6. **Infinite loop!**

This is a known `axios` problem, referenced in several **unsolved** issues :
- https://github.com/axios/axios/issues/6725
- https://github.com/axios/axios/issues/2072
- https://github.com/axios/axios/issues/925
- https://github.com/axios/axios/issues/4531

To fix this issue, this PR adds support for CONNECT tunneling through HTTP/HTTPS proxies, using [proxy-agents](https://github.com/TooTallNate/proxy-agents) modules.

What this does :
1. HttpsProxyAgent sends CONNECT api.apify.com:443
2. Proxy establishes tunnel (returns 200 OK)
3. Client does TLS handshake through tunnel
4. Encrypted traffic flows through tunnel
5. Proxy cannot see/modify the HTTPS traffic (acts like classic proxy)
6. **No redirects, no loops!**

~By precaution, we keep here the current http[s] agent implementation when the `HTTP[S]_PROXY` env vars are not defined.~ (Changed since commit 89571f926747e0e23cdb1bf1a63ba1a4bb480f3f)