### PR TITLE
feat: expose `actorPermissionLevel` in Actor client

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -489,6 +489,8 @@ export interface Actor {
     actorStandby?: ActorStandby & {
         isEnabled: boolean;
     };
+    /** Permission level of the Actor on Apify platform */
+    actorPermissionLevel: ACTOR_PERMISSION_LEVEL;
 }
 
 /**
@@ -563,6 +565,7 @@ export type ActorUpdateOptions = Partial<
         | 'categories'
         | 'defaultRunOptions'
         | 'actorStandby'
+        | 'actorPermissionLevel'
     >
 >;
 


### PR DESCRIPTION
Exposes the `actorPermissionLevel` in Actor client to be align it with the API since the feature is publicly released already.