### PR TITLE
chore: Add pagination tests for `RunCollectionClient`

### DIFF
--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -79,6 +79,7 @@ describe('Collection clients list method as async iterable', () => {
         client.actor('some-id').versions(), // Does not support options
         client.store(), // Does not support desc
         client.actor('some-id').builds(),
+        client.actor('some-id').runs(),
         client.actors(),
         client.datasets(), // Supports unnamed
         client.keyValueStores(), // Supports unnamed


### PR DESCRIPTION
- Add pagination tests for `RunCollectionClient`. Implementation already done in https://github.com/apify/apify-client-js/pull/790
(Test was omitted by accident) 