### PR TITLE
perf: omit `proxy-agent` from the browser bundle

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
             'node:http': 'node:http',
             'node:https': 'node:https',
             crypto: 'node:crypto',
+            'proxy-agent': 'proxy-agent',
         },
     },
     tools: {


### PR DESCRIPTION
Sets `proxy-agent` as an `external` in the `rsbuild` config file.

Removes ~2.4 MB from the browser bundle (~5 MB from the package size because of the map file).

Closes #812
