### PR TITLE
fix: align `LimitsUpdateOptions` type with backend validation logic

### DIFF
--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -285,7 +285,7 @@ export interface Limits {
     dataRetentionDays: number;
 }
 
-export type LimitsUpdateOptions = Pick<Limits, 'maxMonthlyUsageUsd' | 'dataRetentionDays'>;
+export type LimitsUpdateOptions = { maxMonthlyUsageUsd: number } | { dataRetentionDays: number };
 
 export interface Current {
     monthlyUsageUsd: number;


### PR DESCRIPTION
The backend expects _at least one_ of the fields to be present.

Closes #813 