### PR TITLE
feat(actor): Add 'taggedBuilds' to ActorUpdateOptions

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -566,6 +566,7 @@ export type ActorUpdateOptions = Partial<
         | 'defaultRunOptions'
         | 'actorStandby'
         | 'actorPermissionLevel'
+        | 'taggedBuilds'
     >
 >;
 


### PR DESCRIPTION
Title:** Add 'taggedBuilds' to ActorUpdateOptions

### Change

A single-line addition to `src/resource_clients/actor.ts:569`:

```diff
export type ActorUpdateOptions = Partial<
    Pick<
        Actor,
        | 'name'
        | 'description'
        | 'isPublic'
        | 'isDeprecated'
        | 'seoTitle'
        | 'seoDescription'
        | 'title'
        | 'restartOnError'
        | 'versions'
        | 'categories'
        | 'defaultRunOptions'
        | 'actorStandby'
        | 'actorPermissionLevel'
+       | 'taggedBuilds'
    >
>;
```

### Purpose

Allows users to update build tags via the `actor.update()` method:

```typescript
await client.actor('my-actor').update({
    taggedBuilds: {
        'latest': { buildId: 'abc123' },
        'beta': { buildId: 'def456' },
    }
});
```

### Why It Matters

Previously, the only way to tag a build was during build creation (`actor.build(version, { tag: 'latest' })`). This change enables reassigning tags to existing builds without triggering a new build, which is useful for:

closes #829 