### PR TITLE
fix: pin axios to 1.14.0 — supply chain attack mitigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@crawlee/types": "^3.3.0",
                 "ansi-colors": "^4.1.1",
                 "async-retry": "^1.3.3",
-                "axios": "^1.6.7",
+                "axios": "1.14.0",
                 "content-type": "^1.0.5",
                 "ow": "^0.28.2",
                 "proxy-agent": "^6.5.0",
@@ -4212,14 +4212,23 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+            "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/b4a": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "@crawlee/types": "^3.3.0",
         "ansi-colors": "^4.1.1",
         "async-retry": "^1.3.3",
-        "axios": "^1.6.7",
+        "axios": "1.14.0",
         "content-type": "^1.0.5",
         "ow": "^0.28.2",
         "proxy-agent": "^6.5.0",


### PR DESCRIPTION
## Summary

- Pins `axios` direct dependency from `^1.6.7` to exact `1.14.0`

## Context

`axios@1.14.1` and `axios@0.30.4` were compromised with a malicious dependency (`plain-crypto-js@4.2.1`) that deploys a Remote Access Trojan (RAT) via a postinstall hook. The RAT targets macOS, Linux, and Windows and phones home to a C2 server.

Anyone running `npm install` with `apify-client` currently resolves `axios@^1.6.7` to the compromised `1.14.1`.

**Advisory:** https://www.aikido.dev/blog/axios-npm-compromised-maintainer-hijacked-rat

## Changes

- `package.json`: pin axios to exact `1.14.0`