### PR TITLE
fix: add support for new list request-queue requests parameters

### DIFF
--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -683,12 +683,14 @@ export class RequestQueueClient extends ResourceClient {
     ): Promise<RequestQueueClientListRequestsResult> & AsyncIterable<RequestQueueClientRequestSchema> {
         ow(
             options,
-            ow.object.exactShape({
-                limit: ow.optional.number.not.negative,
-                exclusiveStartId: ow.optional.string,
-                cursor: ow.optional.string,
-                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
-            }).validate(mutuallyExclusive('exclusiveStartId', 'cursor'))
+            ow.object
+                .exactShape({
+                    limit: ow.optional.number.not.negative,
+                    exclusiveStartId: ow.optional.string,
+                    cursor: ow.optional.string,
+                    filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
+                })
+                .validate(mutuallyExclusive('exclusiveStartId', 'cursor')),
         );
 
         const getPaginatedList = async (
@@ -786,13 +788,15 @@ export class RequestQueueClient extends ResourceClient {
     ): RequestQueueRequestsAsyncIterable<RequestQueueClientListRequestsResult> {
         ow(
             options,
-            ow.object.exactShape({
-                limit: ow.optional.number.not.negative,
-                maxPageLimit: ow.optional.number,
-                exclusiveStartId: ow.optional.string,
-                cursor: ow.optional.string,
-                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
-            }).validate(mutuallyExclusive('exclusiveStartId', 'cursor')),
+            ow.object
+                .exactShape({
+                    limit: ow.optional.number.not.negative,
+                    maxPageLimit: ow.optional.number,
+                    exclusiveStartId: ow.optional.string,
+                    cursor: ow.optional.string,
+                    filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
+                })
+                .validate(mutuallyExclusive('exclusiveStartId', 'cursor')),
         );
 
         const {

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -12,6 +12,7 @@ import type { ApifyRequestConfig } from '../http_client';
 import {
     cast,
     catchNotFoundOrThrow,
+    mutuallyExclusive,
     parseDateFields,
     pluckData,
     RequestQueuePaginationIterator,
@@ -686,12 +687,9 @@ export class RequestQueueClient extends ResourceClient {
                 limit: ow.optional.number.not.negative,
                 exclusiveStartId: ow.optional.string,
                 cursor: ow.optional.string,
-                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
-            }),
+                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
+            }).validate(mutuallyExclusive('exclusiveStartId', 'cursor'))
         );
-        if (options.exclusiveStartId && options.cursor) {
-            throw new Error('Cannot specify both exclusiveStartId and cursor for pagination');
-        }
 
         const getPaginatedList = async (
             rqListOptions: RequestQueueClientListRequestsOptions = {},
@@ -793,9 +791,10 @@ export class RequestQueueClient extends ResourceClient {
                 maxPageLimit: ow.optional.number,
                 exclusiveStartId: ow.optional.string,
                 cursor: ow.optional.string,
-                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
-            }),
+                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])).minLength(1),
+            }).validate(mutuallyExclusive('exclusiveStartId', 'cursor')),
         );
+
         const {
             limit,
             exclusiveStartId,

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -685,6 +685,8 @@ export class RequestQueueClient extends ResourceClient {
             ow.object.exactShape({
                 limit: ow.optional.number.not.negative,
                 exclusiveStartId: ow.optional.string,
+                cursor: ow.optional.string,
+                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
             }),
         );
 
@@ -712,10 +714,15 @@ export class RequestQueueClient extends ResourceClient {
             // of exhausting all requests we get response with empty items which ends the loop.
             while (
                 currentPage.items.length > 0 && // Continue only if at least some items were returned in the last page.
+                currentPage.nextCursor && // Continue only if the API returned a cursor for the next page.
                 (remainingItems === undefined || remainingItems > 0) // Continue only if the limit was not exceeded.
             ) {
-                const exclusiveStartId = currentPage.items[currentPage.items.length - 1].id;
-                const newOptions = { ...options, limit: remainingItems, exclusiveStartId };
+                const newOptions = { ...options,
+                    limit: remainingItems,
+                    // remove original exclusiveStartId, if there was any, and use cursor-based pagination
+                    exclusiveStartId: undefined,
+                    cursor: currentPage.nextCursor
+                };
                 currentPage = await getPaginatedList(newOptions);
                 yield* currentPage.items;
                 if (remainingItems) {
@@ -777,13 +784,16 @@ export class RequestQueueClient extends ResourceClient {
                 limit: ow.optional.number.not.negative,
                 maxPageLimit: ow.optional.number,
                 exclusiveStartId: ow.optional.string,
+                cursor: ow.optional.string,
+                filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
             }),
         );
-        const { limit, exclusiveStartId, maxPageLimit = DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT } = options;
+        const { limit, exclusiveStartId, cursor, filter, maxPageLimit = DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT } = options;
         return new PaginationIterator({
-            getPage: this.listRequests.bind(this),
+            getPage: async (pageOptions) => this.listRequests({ ...pageOptions, filter }),
             limit,
             exclusiveStartId,
+            cursor,
             maxPageLimit,
         });
     }
@@ -860,13 +870,20 @@ export interface RequestQueueClientListHeadResult {
     items: RequestQueueClientListItem[];
 }
 
+export type RequestQueueListRequestsFilter = 'locked' | 'pending';
+
 /**
  * Options for listing all requests in the queue.
  */
 export interface RequestQueueClientListRequestsOptions {
     limit?: number;
-    /* Using id of request that does not exist in request queue leads to unpredictable results. */
+    /**
+     * Using id of request that does not exist in request queue leads to unpredictable results.
+     * @deprecated Use `cursor` for pagination instead.
+     */
     exclusiveStartId?: string;
+    cursor?: string;
+    filter?: RequestQueueListRequestsFilter[];
 }
 
 /**
@@ -875,7 +892,10 @@ export interface RequestQueueClientListRequestsOptions {
 export interface RequestQueueClientPaginateRequestsOptions {
     limit?: number;
     maxPageLimit?: number;
+    /** @deprecated Use `cursor` for pagination instead. */
     exclusiveStartId?: string;
+    cursor?: string;
+    filter?: RequestQueueListRequestsFilter[];
 }
 
 /**
@@ -883,7 +903,10 @@ export interface RequestQueueClientPaginateRequestsOptions {
  */
 export interface RequestQueueClientListRequestsResult {
     limit: number;
+    /** @deprecated Use `cursor` for pagination instead. */
     exclusiveStartId?: string;
+    cursor?: string;
+    nextCursor?: string;
     items: RequestQueueClientRequestSchema[];
 }
 

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -697,7 +697,7 @@ export class RequestQueueClient extends ResourceClient {
                 url: this._url('requests'),
                 method: 'GET',
                 timeout: Math.min(MEDIUM_TIMEOUT_MILLIS, this.timeoutMillis ?? Infinity),
-                params: this._params({ ...rqListOptions, clientKey: this.clientKey }),
+                params: this._params({ ...rqListOptions, filter: rqListOptions.filter ? rqListOptions.filter.join(",") : undefined, clientKey: this.clientKey }),
             });
 
             return cast(parseDateFields(pluckData(response.data)));
@@ -883,7 +883,7 @@ export interface RequestQueueClientListRequestsOptions {
      */
     exclusiveStartId?: string;
     cursor?: string;
-    filter?: RequestQueueListRequestsFilter[];
+    filter?: readonly RequestQueueListRequestsFilter[];
 }
 
 /**
@@ -895,7 +895,7 @@ export interface RequestQueueClientPaginateRequestsOptions {
     /** @deprecated Use `cursor` for pagination instead. */
     exclusiveStartId?: string;
     cursor?: string;
-    filter?: RequestQueueListRequestsFilter[];
+    filter?: readonly RequestQueueListRequestsFilter[];
 }
 
 /**

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -12,9 +12,9 @@ import type { ApifyRequestConfig } from '../http_client';
 import {
     cast,
     catchNotFoundOrThrow,
-    PaginationIterator,
     parseDateFields,
     pluckData,
+    RequestQueuePaginationIterator,
     sliceArrayByByteLength,
 } from '../utils';
 
@@ -689,6 +689,9 @@ export class RequestQueueClient extends ResourceClient {
                 filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
             }),
         );
+        if (options.exclusiveStartId && options.cursor) {
+            throw new Error('Cannot specify both exclusiveStartId and cursor for pagination');
+        }
 
         const getPaginatedList = async (
             rqListOptions: RequestQueueClientListRequestsOptions = {},
@@ -800,7 +803,7 @@ export class RequestQueueClient extends ResourceClient {
             filter,
             maxPageLimit = DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT,
         } = options;
-        return new PaginationIterator({
+        return new RequestQueuePaginationIterator({
             getPage: async (pageOptions) => this.listRequests({ ...pageOptions, filter }),
             limit,
             exclusiveStartId,

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -697,7 +697,11 @@ export class RequestQueueClient extends ResourceClient {
                 url: this._url('requests'),
                 method: 'GET',
                 timeout: Math.min(MEDIUM_TIMEOUT_MILLIS, this.timeoutMillis ?? Infinity),
-                params: this._params({ ...rqListOptions, filter: rqListOptions.filter ? rqListOptions.filter.join(",") : undefined, clientKey: this.clientKey }),
+                params: this._params({
+                    ...rqListOptions,
+                    filter: rqListOptions.filter ? rqListOptions.filter.join(',') : undefined,
+                    clientKey: this.clientKey,
+                }),
             });
 
             return cast(parseDateFields(pluckData(response.data)));
@@ -717,11 +721,12 @@ export class RequestQueueClient extends ResourceClient {
                 currentPage.nextCursor && // Continue only if the API returned a cursor for the next page.
                 (remainingItems === undefined || remainingItems > 0) // Continue only if the limit was not exceeded.
             ) {
-                const newOptions = { ...options,
+                const newOptions = {
+                    ...options,
                     limit: remainingItems,
                     // remove original exclusiveStartId, if there was any, and use cursor-based pagination
                     exclusiveStartId: undefined,
-                    cursor: currentPage.nextCursor
+                    cursor: currentPage.nextCursor,
                 };
                 currentPage = await getPaginatedList(newOptions);
                 yield* currentPage.items;
@@ -788,7 +793,13 @@ export class RequestQueueClient extends ResourceClient {
                 filter: ow.optional.array.ofType(ow.string.oneOf(['locked', 'pending'])),
             }),
         );
-        const { limit, exclusiveStartId, cursor, filter, maxPageLimit = DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT } = options;
+        const {
+            limit,
+            exclusiveStartId,
+            cursor,
+            filter,
+            maxPageLimit = DEFAULT_REQUEST_QUEUE_REQUEST_PAGE_LIMIT,
+        } = options;
         return new PaginationIterator({
             getPage: async (pageOptions) => this.listRequests({ ...pageOptions, filter }),
             limit,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,7 +195,7 @@ export function getVersionData(): { version: string } {
 /**
  * Helper class to create async iterators from paginated list endpoints with exclusive start key.
  */
-export class PaginationIterator {
+export class RequestQueuePaginationIterator {
     private readonly maxPageLimit: number;
 
     private readonly getPage: (
@@ -207,7 +207,7 @@ export class PaginationIterator {
     private readonly exclusiveStartId?: string;
     private readonly cursor?: string;
 
-    constructor(options: PaginationIteratorOptions) {
+    constructor(options: RequestQueuePaginationIteratorOptions) {
         this.maxPageLimit = options.maxPageLimit;
         this.limit = options.limit;
         this.exclusiveStartId = options.exclusiveStartId;
@@ -236,7 +236,7 @@ export class PaginationIterator {
             yield page;
             iterateItemCount += page.items.length;
             // Limit reached stopping to iterate
-            if (this.limit && iterateItemCount >= this.limit) return;
+            if ((this.limit && iterateItemCount >= this.limit) || !page.nextCursor) return;
 
             nextCursor = page.nextCursor;
             nextExclusiveStartId = undefined; // see comment above - delete it for any page after the first one, and paginate with cursor
@@ -252,7 +252,7 @@ declare global {
 /**
  * Options for creating a pagination iterator.
  */
-export interface PaginationIteratorOptions {
+export interface RequestQueuePaginationIteratorOptions {
     maxPageLimit: number;
     getPage: (opts: RequestQueueClientListRequestsOptions) => Promise<RequestQueueClientListRequestsResult>;
     limit?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -363,3 +363,13 @@ export function applyQueryParamsToUrl(
     }
     return url;
 }
+
+export const mutuallyExclusive =
+    <T, K extends keyof T>(...keys: K[]) =>
+    (value: T) => {
+        const presentKeys = keys.filter((key) => typeof value[key] !== 'undefined');
+        return {
+            validator: presentKeys.length <= 1,
+            message: `At most one of the following fields is allowed: ${keys.join(', ')}`,
+        };
+    };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,25 +205,31 @@ export class PaginationIterator {
     private readonly limit?: number;
 
     private readonly exclusiveStartId?: string;
+    private readonly cursor?: string;
 
     constructor(options: PaginationIteratorOptions) {
         this.maxPageLimit = options.maxPageLimit;
         this.limit = options.limit;
         this.exclusiveStartId = options.exclusiveStartId;
+        this.cursor = options.cursor;
         this.getPage = options.getPage;
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<RequestQueueClientListRequestsResult> {
-        let nextPageExclusiveStartId;
+        let nextCursor = this.cursor;
+        // allow using exclusiveStartId for the first page, but then we'll delete it to avoid using it for any later page
+        let nextExclusiveStartId = this.exclusiveStartId;
+
         let iterateItemCount = 0;
         while (true) {
             const pageLimit = this.limit
                 ? Math.min(this.maxPageLimit, this.limit - iterateItemCount)
                 : this.maxPageLimit;
-            const pageExclusiveStartId = nextPageExclusiveStartId || this.exclusiveStartId;
+
             const page: RequestQueueClientListRequestsResult = await this.getPage({
                 limit: pageLimit,
-                exclusiveStartId: pageExclusiveStartId,
+                cursor: nextCursor,
+                exclusiveStartId: nextExclusiveStartId,
             });
             // There are no more pages to iterate
             if (page.items.length === 0) return;
@@ -231,7 +237,9 @@ export class PaginationIterator {
             iterateItemCount += page.items.length;
             // Limit reached stopping to iterate
             if (this.limit && iterateItemCount >= this.limit) return;
-            nextPageExclusiveStartId = page.items[page.items.length - 1].id;
+
+            nextCursor = page.nextCursor;
+            nextExclusiveStartId = undefined; // see comment above - delete it for any page after the first one, and paginate with cursor
         }
     }
 }
@@ -249,6 +257,7 @@ export interface PaginationIteratorOptions {
     getPage: (opts: RequestQueueClientListRequestsOptions) => Promise<RequestQueueClientListRequestsResult>;
     limit?: number;
     exclusiveStartId?: string;
+    cursor?: string;
 }
 
 /**

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -363,7 +363,7 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
             testName: 'cursor',
             userDefinedOptions: { cursor: 'cursor:1000' },
             expectedItems: range(1000, 2500),
-        }
+        },
     ];
 
     const testCases = generateTestCases(

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -376,17 +376,23 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
             // There are 2500 items in the collection.
             // Items are simple objects with incrementing attributes for easy verification.
 
-            const exclusiveStartId = request.params.exclusiveStartId ? request.params.exclusiveStartId : null;
             const limit = request.params.limit ? request.params.limit : 0;
 
             if (limit < 0) {
                 throw new Error('Limit must be non-negative');
             }
 
-            const lowerIndex = Math.min(
-                request.params.exclusiveStartId ? Number(request.params.exclusiveStartId) + 1 : 0,
-                totalItems,
-            );
+            if (request.params.exclusiveStartId && request.params.cursor) {
+                throw new Error('exclusiveStartId and cursor cannot be used together');
+            }
+            let effectiveStartIndex = 0;
+            if (request.params.exclusiveStartId) {
+                effectiveStartIndex = Number(request.params.exclusiveStartId) + 1;
+            } else if (request.params.cursor) {
+                effectiveStartIndex = Number(request.params.cursor.split(':')[1]);
+            }
+
+            const lowerIndex = Math.min(effectiveStartIndex, totalItems);
             const upperIndex = Math.min(lowerIndex + (limit || totalItems), totalItems, lowerIndex + maxItemsPerPage);
             const items = range(lowerIndex, upperIndex);
 
@@ -396,7 +402,9 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
                         items,
                         count: items.length,
                         limit: limit || maxItemsPerPage,
-                        exclusiveStartId,
+                        exclusiveStartId: request.params.exclusiveStartId,
+                        cursor: request.params.cursor,
+                        nextCursor: upperIndex < totalItems ? `cursor:${upperIndex}` : null,
                     },
                 },
             };

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -404,7 +404,7 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
                         limit: limit || maxItemsPerPage,
                         exclusiveStartId: request.params.exclusiveStartId,
                         cursor: request.params.cursor,
-                        nextCursor: upperIndex < totalItems ? `cursor:${upperIndex}` : null,
+                        nextCursor: `cursor:${upperIndex}`,
                     },
                 },
             };

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -359,6 +359,11 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
             userDefinedOptions: { exclusiveStartId: '1000' },
             expectedItems: range(1001, 2500),
         },
+        {
+            testName: 'cursor',
+            userDefinedOptions: { cursor: 'cursor:1000' },
+            expectedItems: range(1000, 2500),
+        }
     ];
 
     const testCases = generateTestCases(
@@ -404,7 +409,7 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
                         limit: limit || maxItemsPerPage,
                         exclusiveStartId: request.params.exclusiveStartId,
                         cursor: request.params.cursor,
-                        nextCursor: `cursor:${upperIndex}`,
+                        nextCursor: items.length < maxItemsPerPage ? undefined : `cursor:${upperIndex}`,
                     },
                 },
             };
@@ -418,11 +423,7 @@ describe('RequestQueueClient.listKeys as async iterable', () => {
                 items.push(page);
             }
 
-            let expectedAPIcalls = Math.max(Math.ceil(expectedItems.length / maxItemsPerPage), 1);
-            if (userDefinedOptions.limit === undefined || userDefinedOptions.limit > totalItems) {
-                // One extra call to confirm there are no more items due RQ API design.
-                expectedAPIcalls += 1;
-            }
+            const expectedAPIcalls = Math.max(Math.ceil(expectedItems.length / maxItemsPerPage), 1);
 
             expect(items).toEqual(expectedItems);
             expect(mockedClient).toHaveBeenCalledTimes(expectedAPIcalls);

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -525,26 +525,27 @@ describe('Request Queue methods', () => {
             validateRequest({ query: {}, params: { queueId, requestId } });
         });
 
-        test.each([[undefined, undefined], [['pending'], 'pending'], [['pending', 'locked'], 'pending,locked']] as const)(
-            'listRequests() works',
-            async (filter, filterInQuery) => {
-                const queueId = 'some-id';
-                const options = { limit: 5, exclusiveStartId: '123' } as RequestQueueClientListRequestsOptions;
-                if (filter) options.filter = filter;
-                const queryForValidation = { ...options, filter: filterInQuery };
+        test.each([
+            [undefined, undefined],
+            [['pending'], 'pending'],
+            [['pending', 'locked'], 'pending,locked'],
+        ] as const)('listRequests() works', async (filter, filterInQuery) => {
+            const queueId = 'some-id';
+            const options = { limit: 5, exclusiveStartId: '123' } as RequestQueueClientListRequestsOptions;
+            if (filter) options.filter = filter;
+            const queryForValidation = { ...options, filter: filterInQuery };
 
-                const res = await client.requestQueue(queueId).listRequests(options);
-                validateRequest({ query: queryForValidation, params: { queueId }, endpointId: 'list-requests' });
+            const res = await client.requestQueue(queueId).listRequests(options);
+            validateRequest({ query: queryForValidation, params: { queueId }, endpointId: 'list-requests' });
 
-                const browserRes = await page.evaluate(
-                    (id, opts) => client.requestQueue(id).listRequests(opts),
-                    queueId,
-                    options,
-                );
-                expect(browserRes).toEqual(res);
-                validateRequest({ query: queryForValidation, params: { queueId } });
-            },
-        );
+            const browserRes = await page.evaluate(
+                (id, opts) => client.requestQueue(id).listRequests(opts),
+                queueId,
+                options,
+            );
+            expect(browserRes).toEqual(res);
+            validateRequest({ query: queryForValidation, params: { queueId } });
+        });
 
         test('paginateRequests() works', async () => {
             const queueId = 'some-id';

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import type { Dictionary } from 'apify-client';
+import type { Dictionary, RequestQueueClientListRequestsOptions } from 'apify-client';
 import { ApifyClient } from 'apify-client';
 import type { Request } from 'express';
 import type { Page } from 'puppeteer';
@@ -527,7 +527,7 @@ describe('Request Queue methods', () => {
 
         test('listRequests() works', async () => {
             const queueId = 'some-id';
-            const options = { limit: 5, exclusiveStartId: '123' };
+            const options = { limit: 5, exclusiveStartId: '123', filter: ['pending', 'locked'] } satisfies RequestQueueClientListRequestsOptions;
 
             const res = await client.requestQueue(queueId).listRequests(options);
             validateRequest({ query: options, params: { queueId }, endpointId: 'list-requests' });

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -525,21 +525,26 @@ describe('Request Queue methods', () => {
             validateRequest({ query: {}, params: { queueId, requestId } });
         });
 
-        test('listRequests() works', async () => {
-            const queueId = 'some-id';
-            const options = { limit: 5, exclusiveStartId: '123', filter: ['pending', 'locked'] } satisfies RequestQueueClientListRequestsOptions;
+        test.each([[undefined, undefined], [['pending'], 'pending'], [['pending', 'locked'], 'pending,locked']] as const)(
+            'listRequests() works',
+            async (filter, filterInQuery) => {
+                const queueId = 'some-id';
+                const options = { limit: 5, exclusiveStartId: '123' } as RequestQueueClientListRequestsOptions;
+                if (filter) options.filter = filter;
+                const queryForValidation = { ...options, filter: filterInQuery };
 
-            const res = await client.requestQueue(queueId).listRequests(options);
-            validateRequest({ query: options, params: { queueId }, endpointId: 'list-requests' });
+                const res = await client.requestQueue(queueId).listRequests(options);
+                validateRequest({ query: queryForValidation, params: { queueId }, endpointId: 'list-requests' });
 
-            const browserRes = await page.evaluate(
-                (id, opts) => client.requestQueue(id).listRequests(opts),
-                queueId,
-                options,
-            );
-            expect(browserRes).toEqual(res);
-            validateRequest({ query: options, params: { queueId } });
-        });
+                const browserRes = await page.evaluate(
+                    (id, opts) => client.requestQueue(id).listRequests(opts),
+                    queueId,
+                    options,
+                );
+                expect(browserRes).toEqual(res);
+                validateRequest({ query: queryForValidation, params: { queueId } });
+            },
+        );
 
         test('paginateRequests() works', async () => {
             const queueId = 'some-id';
@@ -551,7 +556,8 @@ describe('Request Queue methods', () => {
                     body: {
                         data: {
                             items,
-                            nextCursor: items.length > 0 ? `the-request-after-${items[items.length - 1].id}` : undefined
+                            nextCursor:
+                                items.length > 0 ? `the-request-after-${items[items.length - 1].id}` : undefined,
                         },
                     },
                 });

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -551,6 +551,7 @@ describe('Request Queue methods', () => {
                     body: {
                         data: {
                             items,
+                            nextCursor: items.length > 0 ? `the-request-after-${items[items.length - 1].id}` : undefined
                         },
                     },
                 });
@@ -559,17 +560,17 @@ describe('Request Queue methods', () => {
             const pagination = client.requestQueue(queueId).paginateRequests({ maxPageLimit });
             // Mock API call for the first page
             let expectedItemsInPage = requests.splice(0, maxPageLimit);
-            let expectedExclusiveStartId;
+            let expectedCursor;
             mockResponse(expectedItemsInPage);
             for await (const { items } of pagination) {
                 expect(items).toEqual(expectedItemsInPage);
                 // Validate the request for the current iteration page
                 validateRequest({
-                    query: { exclusiveStartId: expectedExclusiveStartId, limit: maxPageLimit },
+                    query: { cursor: expectedCursor, limit: maxPageLimit },
                     params: { queueId },
                 });
                 // Prepare expectations and mock request for the next iteration page
-                expectedExclusiveStartId = items[items.length - 1].id;
+                expectedCursor = `the-request-after-${items[items.length - 1].id}`;
                 expectedItemsInPage = requests.splice(0, maxPageLimit);
                 mockResponse(expectedItemsInPage);
             }

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -532,8 +532,11 @@ describe('Request Queue methods', () => {
         ] as const)('listRequests() works', async (filter, filterInQuery) => {
             const queueId = 'some-id';
             const options = { limit: 5, exclusiveStartId: '123' } as RequestQueueClientListRequestsOptions;
-            if (filter) options.filter = filter;
-            const queryForValidation = { ...options, filter: filterInQuery };
+            const queryForValidation = { limit: '5', exclusiveStartId: '123' } as Record<string, string>;
+            if (filter) {
+                options.filter = filter;
+                queryForValidation.filter = filterInQuery;
+            }
 
             const res = await client.requestQueue(queueId).listRequests(options);
             validateRequest({ query: queryForValidation, params: { queueId }, endpointId: 'list-requests' });


### PR DESCRIPTION
add support for endpoint parameters and new pagination method added in apify/apify-core#12115

There is a new parameter `filter` for the _request queue -> list requests_ endpoint. To properly support pagination, we also added proper cursor-based pagination, with opaque cursor provided by the server. So this PR switches the pagination internals to use this new way. All of this is done in backwards-compatible manner, the test updates are only necessary to update the server implementation mocks and cases where the existing tests were inspecting some internals.