### PR TITLE
feat: Add output schema to ActorDefinition and includeUnrunnableActors to store API

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -833,7 +833,7 @@ export interface ActorLastRunOptions {
  * Actor definition from the `.actor/actor.json` file.
  *
  * Contains the Actor's configuration, input schema, and other metadata.
- * @see https://docs.apify.com/platform/actors/development/actor-definition
+ * @see https://docs.apify.com/platform/actors/development/actor-definition/actor-json
  */
 export interface ActorDefinition {
     actorSpecification: number;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -843,7 +843,18 @@ export interface ActorDefinition {
     dockerfile?: string;
     dockerContextDir?: string;
     readme?: string | null;
+    /**
+     * @deprecated Use `inputSchema` instead.
+     */
     input?: object | null;
+    /**
+     * The input schema for the Actor, defining expected input parameters.
+     */
+    inputSchema?: object | null;
+    /**
+     * The output schema for the Actor, defining the structure of the output data.
+     */
+    outputSchema?: object | null;
     changelog?: string | null;
     storages?: {
         dataset?: object;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -833,6 +833,7 @@ export interface ActorLastRunOptions {
  * Actor definition from the `.actor/actor.json` file.
  *
  * Contains the Actor's configuration, input schema, and other metadata.
+ * @see https://docs.apify.com/platform/actors/development/actor-definition
  */
 export interface ActorDefinition {
     actorSpecification: number;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -843,18 +843,8 @@ export interface ActorDefinition {
     dockerfile?: string;
     dockerContextDir?: string;
     readme?: string | null;
-    /**
-     * @deprecated Use `inputSchema` instead.
-     */
     input?: object | null;
-    /**
-     * The input schema for the Actor, defining expected input parameters.
-     */
-    inputSchema?: object | null;
-    /**
-     * The output schema for the Actor, defining the structure of the output data.
-     */
-    outputSchema?: object | null;
+    output?: object | null;
     changelog?: string | null;
     storages?: {
         dataset?: object;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -843,7 +843,15 @@ export interface ActorDefinition {
     dockerfile?: string;
     dockerContextDir?: string;
     readme?: string | null;
+    /**
+     * Input schema for the Actor.
+     * @see https://docs.apify.com/platform/actors/development/actor-definition/input-schema
+     */
     input?: object | null;
+    /**
+     * Output schema for the Actor.
+     * @see https://docs.apify.com/platform/actors/development/actor-definition/output-schema
+     */
     output?: object | null;
     changelog?: string | null;
     storages?: {

--- a/src/resource_clients/store_collection.ts
+++ b/src/resource_clients/store_collection.ts
@@ -67,6 +67,7 @@ export class StoreCollectionClient extends ResourceCollectionClient {
                 category: ow.optional.string,
                 username: ow.optional.string,
                 pricingModel: ow.optional.string,
+                includeUnrunnableActors: ow.optional.boolean,
             }),
         );
 
@@ -99,4 +100,9 @@ export interface StoreCollectionListOptions extends PaginationOptions {
     category?: string;
     username?: string;
     pricingModel?: string;
+    /**
+     * If true, the response will include Actors that cannot be run (e.g., Actors
+     * that require a linked integration account that the current user does not have).
+     */
+    includeUnrunnableActors?: boolean;
 }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -45,6 +45,7 @@ describe('Store', () => {
             category: 'my category',
             username: 'my username',
             pricingModel: 'my pricing model',
+            includeUnrunnableActors: true,
         };
 
         const res: any = client && (await client.store().list(opts));


### PR DESCRIPTION
## Summary
- Add `output` field to `ActorDefinition` interface for defining Actor output schema
- Add `includeUnrunnableActors` option to store API for filtering

## Changes

### ActorDefinition
- Added `output?: object | null` field for output schema
- Added JSDoc comments with documentation links to `input` and `output` fields
- Added `@see` link to the `ActorDefinition` interface pointing to the actor.json docs

### Store API
- Added `includeUnrunnableActors?: boolean` to `StoreCollectionListOptions`
- Allows fetching Actors that cannot be run (e.g., Actors requiring linked integration accounts the user doesn't have)

## Documentation links
- [actor.json](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)
- [Input Schema](https://docs.apify.com/platform/actors/development/actor-definition/input-schema)
- [Output Schema](https://docs.apify.com/platform/actors/development/actor-definition/output-schema)

## Related
Slack thread: https://apify.slack.com/archives/CD0SF6KD4/p1775828663590919?thread_ts=1775828039.990079&cid=CD0SF6KD4

https://claude.ai/code/session_01AFuG3Z7LFPC6DWmT7oGgFB