### PR TITLE
fix: make Node-only imports bundler-discoverable

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,7 +1,23 @@
-import { defineConfig } from '@rsbuild/core';
+import { defineConfig, rspack } from '@rsbuild/core';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
 import { version } from './package.json';
+
+// Node-only modules that the client imports from behind `isNode()` guards.
+// They must stay statically discoverable in source (so Node-targeting bundlers
+// like esbuild, webpack or `bun build --compile` include them), but must be
+// stripped from the browser bundle since they never execute there.
+const nodeOnlyModules = /^proxy-agent$/;
+// Node built-ins (and their `node:`-prefixed variants) that are only used
+// in Node-only code paths. Aliasing them to `false` makes rspack resolve
+// them to an empty module instead of pulling in the respective polyfill.
+const unusedInBrowserBuiltins = ['os', 'zlib', 'util'];
+const builtinAliases = Object.fromEntries(
+    unusedInBrowserBuiltins.flatMap((m) => [
+        [m, false],
+        [`node:${m}`, false],
+    ]),
+);
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -39,6 +55,9 @@ export default defineConfig({
                     name: 'Apify',
                 },
                 globalObject: 'globalThis',
+                // Inline all dynamic imports into the main UMD bundle – the
+                // `node:*` / `proxy-agent` imports are stripped below.
+                asyncChunks: false,
             };
             config.optimization = {
                 ...config.optimization,
@@ -46,6 +65,17 @@ export default defineConfig({
                 usedExports: false,
                 splitChunks: false,
                 minimize: false,
+            };
+            config.plugins = [
+                ...(config.plugins ?? []),
+                new rspack.IgnorePlugin({ resourceRegExp: nodeOnlyModules }),
+            ];
+            config.resolve = {
+                ...config.resolve,
+                alias: {
+                    ...config.resolve?.alias,
+                    ...builtinAliases,
+                },
             };
             config.devtool = 'source-map';
         },

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -3,14 +3,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
 import { version } from './package.json';
 
-// Node-only modules that the client imports from behind `isNode()` guards.
-// They must stay statically discoverable in source (so Node-targeting bundlers
-// like esbuild, webpack or `bun build --compile` include them), but must be
-// stripped from the browser bundle since they never execute there.
 const nodeOnlyModules = /^proxy-agent$/;
-// Node built-ins (and their `node:`-prefixed variants) that are only used
-// in Node-only code paths. Aliasing them to `false` makes rspack resolve
-// them to an empty module instead of pulling in the respective polyfill.
 const unusedInBrowserBuiltins = ['os', 'zlib', 'util'];
 const builtinAliases = Object.fromEntries(
     unusedInBrowserBuiltins.flatMap((m) => [
@@ -55,8 +48,6 @@ export default defineConfig({
                     name: 'Apify',
                 },
                 globalObject: 'globalThis',
-                // Inline all dynamic imports into the main UMD bundle – the
-                // `node:*` / `proxy-agent` imports are stripped below.
                 asyncChunks: false,
             };
             config.optimization = {
@@ -66,10 +57,7 @@ export default defineConfig({
                 splitChunks: false,
                 minimize: false,
             };
-            config.plugins = [
-                ...(config.plugins ?? []),
-                new rspack.IgnorePlugin({ resourceRegExp: nodeOnlyModules }),
-            ];
+            config.plugins = [...(config.plugins ?? []), new rspack.IgnorePlugin({ resourceRegExp: nodeOnlyModules })];
             config.resolve = {
                 ...config.resolve,
                 alias: {

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -14,7 +14,7 @@ import { ApifyApiError } from './apify_api_error';
 import type { RequestInterceptorFunction } from './interceptors';
 import { InvalidResponseBodyError, requestInterceptors, responseInterceptors } from './interceptors';
 import type { Statistics } from './statistics';
-import { asArray, cast, dynamicNodeImport, getVersionData, isNode, isStream } from './utils';
+import { asArray, cast, getVersionData, isNode, isStream } from './utils';
 
 const { version } = getVersionData();
 
@@ -116,12 +116,7 @@ export class HttpClient {
     private async initNode(): Promise<void> {
         if (!isNode()) return;
 
-        const [{ ProxyAgent }, os] = await Promise.all([
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            dynamicNodeImport<typeof import('proxy-agent')>('proxy-agent'),
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            dynamicNodeImport<typeof import('node:os')>('node:os'),
-        ]);
+        const [{ ProxyAgent }, os] = await Promise.all([import('proxy-agent'), import('node:os')]);
 
         // We want to keep sockets alive for better performance.
         // Enhanced agent configuration based on agentkeepalive best practices:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,6 +162,7 @@ export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, sta
 }
 
 export function isNode(): boolean {
+    if (typeof BROWSER_BUILD !== 'undefined') return false;
     return !!(typeof process !== 'undefined' && process.versions && process.versions.node);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,10 +123,8 @@ export async function maybeGzipValue(value: unknown): Promise<Buffer | undefined
     const areDataLargeEnough = Buffer.byteLength(value as string) >= MIN_GZIP_BYTES;
     if (areDataLargeEnough) {
         if (!gzipPromisified) {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            const { promisify } = await dynamicNodeImport<typeof import('node:util')>('node:util');
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            const { gzip } = await dynamicNodeImport<typeof import('node:zlib')>('node:zlib');
+            const { promisify } = await import('node:util');
+            const { gzip } = await import('node:zlib');
             gzipPromisified = promisify(gzip);
         }
 
@@ -165,14 +163,6 @@ export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, sta
 
 export function isNode(): boolean {
     return !!(typeof process !== 'undefined' && process.versions && process.versions.node);
-}
-
-/**
- * Dynamic import wrapper that prevents bundlers from statically analyzing the import specifier.
- * Use this for Node.js-only modules that should not be included in browser bundles.
- */
-export async function dynamicNodeImport<T = any>(specifier: string): Promise<T> {
-    return await import(specifier);
 }
 
 export function isBuffer(value: unknown): value is Buffer | ArrayBuffer | TypedArray {


### PR DESCRIPTION
Closes #861, #852 

The `dynamicNodeImport(specifier)` helper hid `proxy-agent` from every bundler, so anything targeting Node (esbuild, Turbo, `bun build --compile`) crashed at runtime with `Cannot find module 'proxy-agent'`. Replacing it with plain `await import('proxy-agent')` / `await import('node:*')` makes those imports statically discoverable, so bundlers include them naturally.

The browser build strips the same imports back out via an `IgnorePlugin` for `proxy-agent` and `resolve.alias: false` entries for the `os` / `zlib` / `util` built-ins that are only used in `isNode()`-guarded code paths; `output.asyncChunks: false` keeps the UMD bundle a single file. The resulting `dist/bundle.js` stays at 907 KB with the same module list as before, and all four bundlers in `test/bundling` still build cleanly.

The `isNode()` now also checks the `BROWSER_BUILD` global variable - if it's set, we're running the browser bundle (so we do not even try loading the Node-specific parts, as they might be missing from the current environment).

https://claude.ai/code/session_01LnDB4Jd3qCoNoJBKgvWvFZ