### PR TITLE
ci: rebase before pushing release commit to avoid non-fast-forward

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -74,6 +74,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: 'chore(release): Update changelog and package version [skip ci]'
+                  pull: '--rebase --autostash'
 
     publish_to_npm:
         name: Publish to NPM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,6 +81,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: 'chore(release): Update changelog and package version [skip ci]'
+                  pull: '--rebase --autostash'
 
     create_github_release:
         name: Create github release


### PR DESCRIPTION
## Summary
- The release and pre-release workflows wait for code checks to pass before committing the changelog/version bump. If another commit lands on master during that wait, the bot's push is rejected as non-fast-forward (seen in [run 24656479517](https://github.com/apify/apify-client-js/actions/runs/24656479517/job/72091410020)).
- Enables `pull: '--rebase --autostash'` on the `EndBug/add-and-commit@v10` step in both `pre_release.yaml` and `release.yaml` so the release bot reconciles with the latest master before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)