### PR TITLE
ci: rebase before pushing version-docs commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "latest" }'
 
     version-docs:
-        needs: publish_to_npm
+        needs: [release_metadata, publish_to_npm]
         runs-on: ubuntu-latest
 
         steps:
@@ -154,4 +154,5 @@ jobs:
               with:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
-                  message: 'docs: update docs for ${{ inputs.version }} version'
+                  message: 'docs: update docs for ${{ needs.release_metadata.outputs.version_number }} version'
+                  pull: '--rebase --autostash'


### PR DESCRIPTION
## Summary
- Add `pull: '--rebase --autostash'` to the `version-docs` job's commit step so it doesn't race with concurrent merges to `master` (same fix already applied to `update_changelog` in #887).
- Replace `${{ inputs.version }}` in the commit message — that input doesn't exist on this workflow, so the message was rendering as `docs: update docs for  version` (e.g. commit 4920ab6). Use `needs.release_metadata.outputs.version_number` instead, and add `release_metadata` to the job's `needs`.

## Context
The release run [25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121) failed in `version-docs` with:

```
remote rejected (cannot lock ref 'refs/heads/master': is at 0ccde32 but expected e08f977)
```

This is a fast-forward race, not a permission issue — the remote logged `Bypassed rule violations for refs/heads/master`, so the service account bypass succeeded. PR #877 landed on master between this job's checkout and push, advancing the ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)