### PR TITLE
chore(deps): bump axios to ^1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "@crawlee/types": "^3.3.0",
         "ansi-colors": "^4.1.1",
         "async-retry": "^1.3.3",
-        "axios": "^1.6.7",
+        "axios": "^1.16.0",
         "content-type": "^1.0.5",
         "ow": "^0.28.2",
         "proxy-agent": "^6.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       axios:
-        specifier: ^1.6.7
-        version: 1.15.0
+        specifier: ^1.16.0
+        version: 1.16.0
       content-type:
         specifier: ^1.0.5
         version: 1.0.5
@@ -134,22 +134,22 @@ importers:
     dependencies:
       '@apify/docs-theme':
         specifier: ^1.0.245
-        version: 1.0.245(81edeb9d2a40f9daad897fc78a4f0aab)
+        version: 1.0.245(01e77081c65a9eeb98ba577cfaff75e5)
       '@apify/docusaurus-plugin-typedoc-api':
         specifier: ^5.1.3
-        version: 5.1.4(304d710916aebb3c4aea3c6f76fcf56f)
+        version: 5.1.4(fdd8aa7a3949e9d7460f8df6243e2d57)
       '@docusaurus/core':
         specifier: ^3.8.1
-        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/faster':
         specifier: ^3.8.1
-        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2)
+        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/preset-classic':
         specifier: ^3.8.1
-        version: 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2)
+        version: 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@signalwire/docusaurus-plugin-llms-txt':
         specifier: ^1.2.2
-        version: 1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))
+        version: 1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -3809,8 +3809,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -7253,8 +7253,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss@8.5.13:
-    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.9:
@@ -9046,20 +9046,20 @@ snapshots:
       - search-insights
       - supports-color
 
-  '@apify/docs-theme@1.0.245(81edeb9d2a40f9daad897fc78a4f0aab)':
+  '@apify/docs-theme@1.0.245(01e77081c65a9eeb98ba577cfaff75e5)':
     dependencies:
       '@apify/docs-search-modal': 1.3.6(@algolia/client-search@5.50.1)(@babel/core@7.29.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(search-insights@2.17.3)
       '@apify/ui-icons': 1.34.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@apify/ui-library': 1.132.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5))
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@stackql/docusaurus-plugin-hubspot': 1.1.0
       algoliasearch: 5.50.1
       algoliasearch-helper: 3.28.1(algoliasearch@5.50.1)
-      axios: 1.15.0
-      babel-loader: 10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      axios: 1.16.0
+      babel-loader: 10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       clsx: 2.1.1
       docusaurus-gtm-plugin: 0.0.2
-      postcss-preset-env: 11.2.1(postcss@8.5.13)
+      postcss-preset-env: 11.2.1(postcss@8.5.14)
       prism-react-renderer: 2.4.1(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -9087,15 +9087,15 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.4(304d710916aebb3c4aea3c6f76fcf56f)':
+  '@apify/docusaurus-plugin-typedoc-api@5.1.4(fdd8aa7a3949e9d7460f8df6243e2d57)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/preset-classic': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/preset-classic': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@types/react': 19.2.14
       '@vscode/codicons': 0.0.35
       cheerio: 1.2.0
@@ -10130,14 +10130,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-alpha-function@2.0.4(postcss@8.5.13)':
+  '@csstools/postcss-alpha-function@2.0.4(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.9)':
     dependencies:
@@ -10145,10 +10145,10 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  '@csstools/postcss-cascade-layers@6.0.0(postcss@8.5.13)':
+  '@csstools/postcss-cascade-layers@6.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   '@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.9)':
@@ -10160,14 +10160,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-color-function-display-p3-linear@2.0.3(postcss@8.5.13)':
+  '@csstools/postcss-color-function-display-p3-linear@2.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-color-function@4.0.12(postcss@8.5.9)':
     dependencies:
@@ -10178,14 +10178,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-color-function@5.0.3(postcss@8.5.13)':
+  '@csstools/postcss-color-function@5.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.9)':
     dependencies:
@@ -10196,14 +10196,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-color-mix-function@4.0.3(postcss@8.5.13)':
+  '@csstools/postcss-color-mix-function@4.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.9)':
     dependencies:
@@ -10214,14 +10214,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-color-mix-variadic-function-arguments@2.0.3(postcss@8.5.13)':
+  '@csstools/postcss-color-mix-variadic-function-arguments@2.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.9)':
     dependencies:
@@ -10231,13 +10231,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-content-alt-text@3.0.0(postcss@8.5.13)':
+  '@csstools/postcss-content-alt-text@3.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.9)':
     dependencies:
@@ -10248,14 +10248,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-contrast-color-function@3.0.3(postcss@8.5.13)':
+  '@csstools/postcss-contrast-color-function@3.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.9)':
     dependencies:
@@ -10264,12 +10264,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-exponential-functions@3.0.2(postcss@8.5.13)':
+  '@csstools/postcss-exponential-functions@3.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.9)':
     dependencies:
@@ -10277,16 +10277,16 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-font-format-keywords@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-font-format-keywords@5.0.0(postcss@8.5.14)':
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-font-width-property@1.0.0(postcss@8.5.13)':
+  '@csstools/postcss-font-width-property@1.0.0(postcss@8.5.14)':
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.9)':
     dependencies:
@@ -10295,12 +10295,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-gamut-mapping@3.0.3(postcss@8.5.13)':
+  '@csstools/postcss-gamut-mapping@3.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.9)':
     dependencies:
@@ -10311,14 +10311,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-gradients-interpolation-method@6.0.3(postcss@8.5.13)':
+  '@csstools/postcss-gradients-interpolation-method@6.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-hwb-function@4.0.12(postcss@8.5.9)':
     dependencies:
@@ -10329,14 +10329,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-hwb-function@5.0.3(postcss@8.5.13)':
+  '@csstools/postcss-hwb-function@5.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-ic-unit@4.0.4(postcss@8.5.9)':
     dependencies:
@@ -10345,20 +10345,20 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-ic-unit@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-ic-unit@5.0.0(postcss@8.5.14)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-initial@2.0.1(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-initial@3.0.0(postcss@8.5.13)':
+  '@csstools/postcss-initial@3.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.9)':
     dependencies:
@@ -10366,10 +10366,10 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  '@csstools/postcss-is-pseudo-class@6.0.0(postcss@8.5.13)':
+  '@csstools/postcss-is-pseudo-class@6.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   '@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.9)':
@@ -10380,46 +10380,46 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-light-dark-function@3.0.0(postcss@8.5.13)':
+  '@csstools/postcss-light-dark-function@3.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-logical-float-and-clear@4.0.0(postcss@8.5.13)':
+  '@csstools/postcss-logical-float-and-clear@4.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-logical-overflow@3.0.0(postcss@8.5.13)':
+  '@csstools/postcss-logical-overflow@3.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-logical-overscroll-behavior@3.0.0(postcss@8.5.13)':
+  '@csstools/postcss-logical-overscroll-behavior@3.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-resize@4.0.0(postcss@8.5.13)':
+  '@csstools/postcss-logical-resize@4.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.9)':
@@ -10428,11 +10428,11 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-logical-viewport-units@4.0.0(postcss@8.5.13)':
+  '@csstools/postcss-logical-viewport-units@4.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-media-minmax@2.0.9(postcss@8.5.9)':
     dependencies:
@@ -10442,13 +10442,13 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.5.9
 
-  '@csstools/postcss-media-minmax@3.0.2(postcss@8.5.13)':
+  '@csstools/postcss-media-minmax@3.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.9)':
     dependencies:
@@ -10457,18 +10457,18 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.5.9
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@4.0.0(postcss@8.5.13)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@4.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      postcss: 8.5.13
+      postcss: 8.5.14
 
-  '@csstools/postcss-mixins@1.0.0(postcss@8.5.13)':
+  '@csstools/postcss-mixins@1.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.9)':
     dependencies:
@@ -10476,10 +10476,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-nested-calc@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-nested-calc@5.0.0(postcss@8.5.14)':
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.9)':
@@ -10487,9 +10487,9 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@5.0.1(postcss@8.5.13)':
+  '@csstools/postcss-normalize-display-values@5.0.1(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-oklab-function@4.0.12(postcss@8.5.9)':
@@ -10501,31 +10501,31 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-oklab-function@5.0.3(postcss@8.5.13)':
+  '@csstools/postcss-oklab-function@5.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-position-area-property@1.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-position-area-property@2.0.0(postcss@8.5.13)':
+  '@csstools/postcss-position-area-property@2.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-progressive-custom-properties@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-progressive-custom-properties@5.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.9)':
@@ -10534,11 +10534,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-property-rule-prelude-list@2.0.0(postcss@8.5.13)':
+  '@csstools/postcss-property-rule-prelude-list@2.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-random-function@2.0.1(postcss@8.5.9)':
     dependencies:
@@ -10547,12 +10547,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-random-function@3.0.2(postcss@8.5.13)':
+  '@csstools/postcss-random-function@3.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.9)':
     dependencies:
@@ -10563,23 +10563,23 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  '@csstools/postcss-relative-color-syntax@4.0.3(postcss@8.5.13)':
+  '@csstools/postcss-relative-color-syntax@4.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  '@csstools/postcss-scope-pseudo-class@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-scope-pseudo-class@5.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   '@csstools/postcss-sign-functions@1.1.4(postcss@8.5.9)':
@@ -10589,12 +10589,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-sign-functions@2.0.2(postcss@8.5.13)':
+  '@csstools/postcss-sign-functions@2.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.9)':
     dependencies:
@@ -10603,22 +10603,22 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-stepped-value-functions@5.0.2(postcss@8.5.13)':
+  '@csstools/postcss-stepped-value-functions@5.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.9)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-syntax-descriptor-syntax-production@2.0.0(postcss@8.5.13)':
+  '@csstools/postcss-syntax-descriptor-syntax-production@2.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.9)':
     dependencies:
@@ -10626,11 +10626,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-system-ui-font-family@2.0.0(postcss@8.5.13)':
+  '@csstools/postcss-system-ui-font-family@2.0.0(postcss@8.5.14)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.9)':
     dependencies:
@@ -10638,10 +10638,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-text-decoration-shorthand@5.0.3(postcss@8.5.13)':
+  '@csstools/postcss-text-decoration-shorthand@5.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.9)':
@@ -10651,20 +10651,20 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.9
 
-  '@csstools/postcss-trigonometric-functions@5.0.2(postcss@8.5.13)':
+  '@csstools/postcss-trigonometric-functions@5.0.2(postcss@8.5.14)':
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/postcss-unset-value@4.0.0(postcss@8.5.9)':
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/postcss-unset-value@5.0.0(postcss@8.5.13)':
+  '@csstools/postcss-unset-value@5.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.1)':
     dependencies:
@@ -10686,9 +10686,9 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  '@csstools/utilities@3.0.0(postcss@8.5.13)':
+  '@csstools/utilities@3.0.0(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -10716,7 +10716,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/babel@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10728,7 +10728,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -10741,34 +10741,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
-      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
+      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       cssnano: 6.1.2(postcss@8.5.9)
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
-      null-loader: 4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
+      null-loader: 4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       postcss: 8.5.9
-      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@5.9.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      postcss-loader: 7.3.4(postcss@8.5.9)(typescript@5.9.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       postcss-preset-env: 10.6.1(postcss@8.5.9)
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
-      webpackbar: 6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      webpackbar: 6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10784,15 +10784,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10808,7 +10808,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.4
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -10818,7 +10818,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       react-router: 5.3.4(react@19.2.5)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5)
       react-router-dom: 5.3.4(react@19.2.5)
@@ -10827,12 +10827,12 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10856,18 +10856,18 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.9)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2)':
+  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/html': 1.15.24
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/helpers'
       - esbuild
@@ -10879,16 +10879,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       fs-extra: 11.3.4
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10904,9 +10904,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       vfile: 6.0.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10914,9 +10914,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -10932,17 +10932,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-blog@3.10.0(24e5c6abfc450637c59135b4220ea340)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -10955,7 +10955,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10974,17 +10974,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.4
@@ -10995,7 +10995,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11014,18 +11014,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11044,12 +11044,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -11071,11 +11071,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11099,11 +11099,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11125,11 +11125,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11152,11 +11152,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11178,14 +11178,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11209,18 +11209,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11239,23 +11239,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-blog': 3.10.0(24e5c6abfc450637c59135b4220ea340)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -11284,21 +11284,21 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-blog': 3.10.0(24e5c6abfc450637c59135b4220ea340)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -11332,13 +11332,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -11356,17 +11356,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.50.1)(algoliasearch@5.50.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.2(@algolia/client-search@5.50.1)(@types/react@19.2.14)(algoliasearch@5.50.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       algoliasearch: 5.50.1
       algoliasearch-helper: 3.28.1(algoliasearch@5.50.1)
       clsx: 2.1.1
@@ -11403,7 +11403,7 @@ snapshots:
       fs-extra: 11.3.4
       tslib: 2.8.1
 
-  '@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -11415,7 +11415,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -11424,9 +11424,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils-common@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -11437,11 +11437,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils-validation@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -11456,14 +11456,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11476,9 +11476,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -12561,9 +12561,9 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2))':
+  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       fs-extra: 11.3.4
       hast-util-select: 6.0.4
       hast-util-to-html: 9.0.5
@@ -13375,13 +13375,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.13):
+  autoprefixer@10.4.27(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001787
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.27(postcss@8.5.9):
@@ -13397,7 +13397,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -13407,20 +13407,20 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -13961,7 +13961,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -13969,7 +13969,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   core-js-compat@3.49.0:
     dependencies:
@@ -14059,9 +14059,9 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  css-blank-pseudo@8.0.1(postcss@8.5.13):
+  css-blank-pseudo@8.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   css-color-keywords@1.0.0: {}
@@ -14077,14 +14077,14 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-has-pseudo@8.0.0(postcss@8.5.13):
+  css-has-pseudo@8.0.0(postcss@8.5.14):
     dependencies:
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.9)
       postcss: 8.5.9
@@ -14096,9 +14096,9 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.9)
@@ -14106,7 +14106,7 @@ snapshots:
       postcss: 8.5.9
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     optionalDependencies:
       clean-css: 5.3.3
       esbuild: 0.27.4
@@ -14115,9 +14115,9 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  css-prefers-color-scheme@11.0.0(postcss@8.5.13):
+  css-prefers-color-scheme@11.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   css-select@4.3.0:
     dependencies:
@@ -14786,11 +14786,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   file-type@20.5.0:
     dependencies:
@@ -15379,7 +15379,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  html-webpack-plugin@5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15388,7 +15388,7 @@ snapshots:
       tapable: 2.3.2
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   htmlparser2@10.1.0:
     dependencies:
@@ -16553,11 +16553,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  mini-css-extract-plugin@2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   minimalistic-assert@1.0.1: {}
 
@@ -16636,11 +16636,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  null-loader@4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   object-assign@4.1.1: {}
 
@@ -16989,9 +16989,9 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-attribute-case-insensitive@8.0.0(postcss@8.5.13):
+  postcss-attribute-case-insensitive@8.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-calc@9.0.1(postcss@8.5.9):
@@ -17000,9 +17000,9 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.13):
+  postcss-clamp@4.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-clamp@4.1.0(postcss@8.5.9):
@@ -17019,14 +17019,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  postcss-color-functional-notation@8.0.3(postcss@8.5.13):
+  postcss-color-functional-notation@8.0.3(postcss@8.5.14):
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
   postcss-color-hex-alpha@10.0.0(postcss@8.5.9):
     dependencies:
@@ -17034,10 +17034,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-color-hex-alpha@11.0.0(postcss@8.5.13):
+  postcss-color-hex-alpha@11.0.0(postcss@8.5.14):
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-color-rebeccapurple@10.0.0(postcss@8.5.9):
@@ -17046,10 +17046,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@11.0.0(postcss@8.5.13):
+  postcss-color-rebeccapurple@11.0.0(postcss@8.5.14):
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.5.9):
@@ -17074,13 +17074,13 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.5.9
 
-  postcss-custom-media@12.0.1(postcss@8.5.13):
+  postcss-custom-media@12.0.1(postcss@8.5.14):
     dependencies:
       '@csstools/cascade-layer-name-parser': 3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-custom-properties@14.0.6(postcss@8.5.9):
     dependencies:
@@ -17091,13 +17091,13 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-custom-properties@15.0.1(postcss@8.5.13):
+  postcss-custom-properties@15.0.1(postcss@8.5.14):
     dependencies:
       '@csstools/cascade-layer-name-parser': 3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-custom-selectors@8.0.5(postcss@8.5.9):
@@ -17108,17 +17108,17 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-custom-selectors@9.0.1(postcss@8.5.13):
+  postcss-custom-selectors@9.0.1(postcss@8.5.14):
     dependencies:
       '@csstools/cascade-layer-name-parser': 3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-dir-pseudo-class@10.0.0(postcss@8.5.13):
+  postcss-dir-pseudo-class@10.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-dir-pseudo-class@9.0.1(postcss@8.5.9):
@@ -17154,11 +17154,11 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-double-position-gradients@7.0.0(postcss@8.5.13):
+  postcss-double-position-gradients@7.0.0(postcss@8.5.14):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-focus-visible@10.0.1(postcss@8.5.9):
@@ -17166,14 +17166,14 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-focus-visible@11.0.0(postcss@8.5.13):
+  postcss-focus-visible@11.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-focus-within@10.0.0(postcss@8.5.13):
+  postcss-focus-within@10.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-focus-within@9.0.1(postcss@8.5.9):
@@ -17181,9 +17181,9 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-font-variant@5.0.0(postcss@8.5.13):
+  postcss-font-variant@5.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-font-variant@5.0.0(postcss@8.5.9):
     dependencies:
@@ -17193,9 +17193,9 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  postcss-gap-properties@7.0.0(postcss@8.5.13):
+  postcss-gap-properties@7.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-image-set-function@7.0.0(postcss@8.5.9):
     dependencies:
@@ -17203,10 +17203,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-image-set-function@8.0.0(postcss@8.5.13):
+  postcss-image-set-function@8.0.0(postcss@8.5.14):
     dependencies:
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-lab-function@7.0.12(postcss@8.5.9):
@@ -17218,22 +17218,22 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.9)
       postcss: 8.5.9
 
-  postcss-lab-function@8.0.3(postcss@8.5.13):
+  postcss-lab-function@8.0.3(postcss@8.5.14):
     dependencies:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/utilities': 3.0.0(postcss@8.5.13)
-      postcss: 8.5.13
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/utilities': 3.0.0(postcss@8.5.14)
+      postcss: 8.5.14
 
-  postcss-loader@7.3.4(postcss@8.5.9)(typescript@5.9.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  postcss-loader@7.3.4(postcss@8.5.9)(typescript@5.9.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       jiti: 1.21.7
       postcss: 8.5.9
       semver: 7.7.4
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - typescript
 
@@ -17242,9 +17242,9 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-logical@9.0.0(postcss@8.5.13):
+  postcss-logical@9.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-merge-idents@6.0.3(postcss@8.5.9):
@@ -17319,11 +17319,11 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-nesting@14.0.0(postcss@8.5.13):
+  postcss-nesting@14.0.0(postcss@8.5.14):
     dependencies:
       '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-normalize-charset@6.0.2(postcss@8.5.9):
@@ -17371,9 +17371,9 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.5.13):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-opacity-percentage@3.0.0(postcss@8.5.9):
     dependencies:
@@ -17390,14 +17390,14 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@7.0.0(postcss@8.5.13):
+  postcss-overflow-shorthand@7.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.13):
+  postcss-page-break@3.0.4(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-page-break@3.0.4(postcss@8.5.9):
     dependencies:
@@ -17408,9 +17408,9 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-place@11.0.0(postcss@8.5.13):
+  postcss-place@11.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-preset-env@10.6.1(postcss@8.5.9):
@@ -17488,91 +17488,91 @@ snapshots:
       postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.9)
       postcss-selector-not: 8.0.1(postcss@8.5.9)
 
-  postcss-preset-env@11.2.1(postcss@8.5.13):
+  postcss-preset-env@11.2.1(postcss@8.5.14):
     dependencies:
-      '@csstools/postcss-alpha-function': 2.0.4(postcss@8.5.13)
-      '@csstools/postcss-cascade-layers': 6.0.0(postcss@8.5.13)
-      '@csstools/postcss-color-function': 5.0.3(postcss@8.5.13)
-      '@csstools/postcss-color-function-display-p3-linear': 2.0.3(postcss@8.5.13)
-      '@csstools/postcss-color-mix-function': 4.0.3(postcss@8.5.13)
-      '@csstools/postcss-color-mix-variadic-function-arguments': 2.0.3(postcss@8.5.13)
-      '@csstools/postcss-content-alt-text': 3.0.0(postcss@8.5.13)
-      '@csstools/postcss-contrast-color-function': 3.0.3(postcss@8.5.13)
-      '@csstools/postcss-exponential-functions': 3.0.2(postcss@8.5.13)
-      '@csstools/postcss-font-format-keywords': 5.0.0(postcss@8.5.13)
-      '@csstools/postcss-font-width-property': 1.0.0(postcss@8.5.13)
-      '@csstools/postcss-gamut-mapping': 3.0.3(postcss@8.5.13)
-      '@csstools/postcss-gradients-interpolation-method': 6.0.3(postcss@8.5.13)
-      '@csstools/postcss-hwb-function': 5.0.3(postcss@8.5.13)
-      '@csstools/postcss-ic-unit': 5.0.0(postcss@8.5.13)
-      '@csstools/postcss-initial': 3.0.0(postcss@8.5.13)
-      '@csstools/postcss-is-pseudo-class': 6.0.0(postcss@8.5.13)
-      '@csstools/postcss-light-dark-function': 3.0.0(postcss@8.5.13)
-      '@csstools/postcss-logical-float-and-clear': 4.0.0(postcss@8.5.13)
-      '@csstools/postcss-logical-overflow': 3.0.0(postcss@8.5.13)
-      '@csstools/postcss-logical-overscroll-behavior': 3.0.0(postcss@8.5.13)
-      '@csstools/postcss-logical-resize': 4.0.0(postcss@8.5.13)
-      '@csstools/postcss-logical-viewport-units': 4.0.0(postcss@8.5.13)
-      '@csstools/postcss-media-minmax': 3.0.2(postcss@8.5.13)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 4.0.0(postcss@8.5.13)
-      '@csstools/postcss-mixins': 1.0.0(postcss@8.5.13)
-      '@csstools/postcss-nested-calc': 5.0.0(postcss@8.5.13)
-      '@csstools/postcss-normalize-display-values': 5.0.1(postcss@8.5.13)
-      '@csstools/postcss-oklab-function': 5.0.3(postcss@8.5.13)
-      '@csstools/postcss-position-area-property': 2.0.0(postcss@8.5.13)
-      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.13)
-      '@csstools/postcss-property-rule-prelude-list': 2.0.0(postcss@8.5.13)
-      '@csstools/postcss-random-function': 3.0.2(postcss@8.5.13)
-      '@csstools/postcss-relative-color-syntax': 4.0.3(postcss@8.5.13)
-      '@csstools/postcss-scope-pseudo-class': 5.0.0(postcss@8.5.13)
-      '@csstools/postcss-sign-functions': 2.0.2(postcss@8.5.13)
-      '@csstools/postcss-stepped-value-functions': 5.0.2(postcss@8.5.13)
-      '@csstools/postcss-syntax-descriptor-syntax-production': 2.0.0(postcss@8.5.13)
-      '@csstools/postcss-system-ui-font-family': 2.0.0(postcss@8.5.13)
-      '@csstools/postcss-text-decoration-shorthand': 5.0.3(postcss@8.5.13)
-      '@csstools/postcss-trigonometric-functions': 5.0.2(postcss@8.5.13)
-      '@csstools/postcss-unset-value': 5.0.0(postcss@8.5.13)
-      autoprefixer: 10.4.27(postcss@8.5.13)
+      '@csstools/postcss-alpha-function': 2.0.4(postcss@8.5.14)
+      '@csstools/postcss-cascade-layers': 6.0.0(postcss@8.5.14)
+      '@csstools/postcss-color-function': 5.0.3(postcss@8.5.14)
+      '@csstools/postcss-color-function-display-p3-linear': 2.0.3(postcss@8.5.14)
+      '@csstools/postcss-color-mix-function': 4.0.3(postcss@8.5.14)
+      '@csstools/postcss-color-mix-variadic-function-arguments': 2.0.3(postcss@8.5.14)
+      '@csstools/postcss-content-alt-text': 3.0.0(postcss@8.5.14)
+      '@csstools/postcss-contrast-color-function': 3.0.3(postcss@8.5.14)
+      '@csstools/postcss-exponential-functions': 3.0.2(postcss@8.5.14)
+      '@csstools/postcss-font-format-keywords': 5.0.0(postcss@8.5.14)
+      '@csstools/postcss-font-width-property': 1.0.0(postcss@8.5.14)
+      '@csstools/postcss-gamut-mapping': 3.0.3(postcss@8.5.14)
+      '@csstools/postcss-gradients-interpolation-method': 6.0.3(postcss@8.5.14)
+      '@csstools/postcss-hwb-function': 5.0.3(postcss@8.5.14)
+      '@csstools/postcss-ic-unit': 5.0.0(postcss@8.5.14)
+      '@csstools/postcss-initial': 3.0.0(postcss@8.5.14)
+      '@csstools/postcss-is-pseudo-class': 6.0.0(postcss@8.5.14)
+      '@csstools/postcss-light-dark-function': 3.0.0(postcss@8.5.14)
+      '@csstools/postcss-logical-float-and-clear': 4.0.0(postcss@8.5.14)
+      '@csstools/postcss-logical-overflow': 3.0.0(postcss@8.5.14)
+      '@csstools/postcss-logical-overscroll-behavior': 3.0.0(postcss@8.5.14)
+      '@csstools/postcss-logical-resize': 4.0.0(postcss@8.5.14)
+      '@csstools/postcss-logical-viewport-units': 4.0.0(postcss@8.5.14)
+      '@csstools/postcss-media-minmax': 3.0.2(postcss@8.5.14)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 4.0.0(postcss@8.5.14)
+      '@csstools/postcss-mixins': 1.0.0(postcss@8.5.14)
+      '@csstools/postcss-nested-calc': 5.0.0(postcss@8.5.14)
+      '@csstools/postcss-normalize-display-values': 5.0.1(postcss@8.5.14)
+      '@csstools/postcss-oklab-function': 5.0.3(postcss@8.5.14)
+      '@csstools/postcss-position-area-property': 2.0.0(postcss@8.5.14)
+      '@csstools/postcss-progressive-custom-properties': 5.0.0(postcss@8.5.14)
+      '@csstools/postcss-property-rule-prelude-list': 2.0.0(postcss@8.5.14)
+      '@csstools/postcss-random-function': 3.0.2(postcss@8.5.14)
+      '@csstools/postcss-relative-color-syntax': 4.0.3(postcss@8.5.14)
+      '@csstools/postcss-scope-pseudo-class': 5.0.0(postcss@8.5.14)
+      '@csstools/postcss-sign-functions': 2.0.2(postcss@8.5.14)
+      '@csstools/postcss-stepped-value-functions': 5.0.2(postcss@8.5.14)
+      '@csstools/postcss-syntax-descriptor-syntax-production': 2.0.0(postcss@8.5.14)
+      '@csstools/postcss-system-ui-font-family': 2.0.0(postcss@8.5.14)
+      '@csstools/postcss-text-decoration-shorthand': 5.0.3(postcss@8.5.14)
+      '@csstools/postcss-trigonometric-functions': 5.0.2(postcss@8.5.14)
+      '@csstools/postcss-unset-value': 5.0.0(postcss@8.5.14)
+      autoprefixer: 10.4.27(postcss@8.5.14)
       browserslist: 4.28.2
-      css-blank-pseudo: 8.0.1(postcss@8.5.13)
-      css-has-pseudo: 8.0.0(postcss@8.5.13)
-      css-prefers-color-scheme: 11.0.0(postcss@8.5.13)
+      css-blank-pseudo: 8.0.1(postcss@8.5.14)
+      css-has-pseudo: 8.0.0(postcss@8.5.14)
+      css-prefers-color-scheme: 11.0.0(postcss@8.5.14)
       cssdb: 8.8.0
-      postcss: 8.5.13
-      postcss-attribute-case-insensitive: 8.0.0(postcss@8.5.13)
-      postcss-clamp: 4.1.0(postcss@8.5.13)
-      postcss-color-functional-notation: 8.0.3(postcss@8.5.13)
-      postcss-color-hex-alpha: 11.0.0(postcss@8.5.13)
-      postcss-color-rebeccapurple: 11.0.0(postcss@8.5.13)
-      postcss-custom-media: 12.0.1(postcss@8.5.13)
-      postcss-custom-properties: 15.0.1(postcss@8.5.13)
-      postcss-custom-selectors: 9.0.1(postcss@8.5.13)
-      postcss-dir-pseudo-class: 10.0.0(postcss@8.5.13)
-      postcss-double-position-gradients: 7.0.0(postcss@8.5.13)
-      postcss-focus-visible: 11.0.0(postcss@8.5.13)
-      postcss-focus-within: 10.0.0(postcss@8.5.13)
-      postcss-font-variant: 5.0.0(postcss@8.5.13)
-      postcss-gap-properties: 7.0.0(postcss@8.5.13)
-      postcss-image-set-function: 8.0.0(postcss@8.5.13)
-      postcss-lab-function: 8.0.3(postcss@8.5.13)
-      postcss-logical: 9.0.0(postcss@8.5.13)
-      postcss-nesting: 14.0.0(postcss@8.5.13)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.13)
-      postcss-overflow-shorthand: 7.0.0(postcss@8.5.13)
-      postcss-page-break: 3.0.4(postcss@8.5.13)
-      postcss-place: 11.0.0(postcss@8.5.13)
-      postcss-pseudo-class-any-link: 11.0.0(postcss@8.5.13)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.13)
-      postcss-selector-not: 9.0.0(postcss@8.5.13)
+      postcss: 8.5.14
+      postcss-attribute-case-insensitive: 8.0.0(postcss@8.5.14)
+      postcss-clamp: 4.1.0(postcss@8.5.14)
+      postcss-color-functional-notation: 8.0.3(postcss@8.5.14)
+      postcss-color-hex-alpha: 11.0.0(postcss@8.5.14)
+      postcss-color-rebeccapurple: 11.0.0(postcss@8.5.14)
+      postcss-custom-media: 12.0.1(postcss@8.5.14)
+      postcss-custom-properties: 15.0.1(postcss@8.5.14)
+      postcss-custom-selectors: 9.0.1(postcss@8.5.14)
+      postcss-dir-pseudo-class: 10.0.0(postcss@8.5.14)
+      postcss-double-position-gradients: 7.0.0(postcss@8.5.14)
+      postcss-focus-visible: 11.0.0(postcss@8.5.14)
+      postcss-focus-within: 10.0.0(postcss@8.5.14)
+      postcss-font-variant: 5.0.0(postcss@8.5.14)
+      postcss-gap-properties: 7.0.0(postcss@8.5.14)
+      postcss-image-set-function: 8.0.0(postcss@8.5.14)
+      postcss-lab-function: 8.0.3(postcss@8.5.14)
+      postcss-logical: 9.0.0(postcss@8.5.14)
+      postcss-nesting: 14.0.0(postcss@8.5.14)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.14)
+      postcss-overflow-shorthand: 7.0.0(postcss@8.5.14)
+      postcss-page-break: 3.0.4(postcss@8.5.14)
+      postcss-place: 11.0.0(postcss@8.5.14)
+      postcss-pseudo-class-any-link: 11.0.0(postcss@8.5.14)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.14)
+      postcss-selector-not: 9.0.0(postcss@8.5.14)
 
   postcss-pseudo-class-any-link@10.0.1(postcss@8.5.9):
     dependencies:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-pseudo-class-any-link@11.0.0(postcss@8.5.13):
+  postcss-pseudo-class-any-link@11.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-reduce-idents@6.0.3(postcss@8.5.9):
@@ -17591,9 +17591,9 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.13):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.5.9):
     dependencies:
@@ -17604,9 +17604,9 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 7.1.1
 
-  postcss-selector-not@9.0.0(postcss@8.5.13):
+  postcss-selector-not@9.0.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-selector-parser@6.1.2:
@@ -17641,7 +17641,7 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  postcss@8.5.13:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -17874,11 +17874,11 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -18757,11 +18757,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/counter': 0.1.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
 
   tabbable@6.4.0: {}
 
@@ -18797,13 +18797,13 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     optionalDependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       esbuild: 0.27.4
@@ -19054,14 +19054,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
 
   url@0.11.4:
     dependencies:
@@ -19121,7 +19121,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.13
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -19208,7 +19208,7 @@ snapshots:
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1)
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -19217,7 +19217,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
     transitivePeerDependencies:
       - tslib
 
@@ -19274,7 +19274,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19302,10 +19302,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       webpack-cli: 7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)
     transitivePeerDependencies:
       - bufferutil
@@ -19369,7 +19369,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2):
+  webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19393,7 +19393,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -19437,7 +19437,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)):
+  webpackbar@6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -19446,7 +19446,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.106.1))
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:


### PR DESCRIPTION
## Summary
Bumps the direct **axios** dep range from `^1.6.7` to `^1.16.0` and updates `pnpm-lock.yaml` accordingly. axios resolves to 1.16.0, closing all axios Dependabot alerts (#221-#232).

## Not addressed here — need more attention
- **postcss** — one transitive entry stuck at 8.5.9 (pulled by some `@csstools/postcss-*` plugin). Needs a `pnpm.overrides` entry to force ≥ 8.5.10.
- **basic-ftp** (alert #217, high) — transitive at 5.2.2; patched 5.3.0. Doesn't bump via `pnpm update`; needs an override.
- **serialize-javascript** — at 6.0.2; patched 7.x is a major bump. Needs an override.
- **elliptic** (alert #212, dev, low) — no patched version available upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)