### PR TITLE
fix: remove preinstall script that breaks npm/yarn consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
         "format": "oxfmt",
         "format:check": "oxfmt --check",
         "build:node": "tsc",
-        "build:browser": "rsbuild build",
-        "preinstall": "npx only-allow pnpm"
+        "build:browser": "rsbuild build"
     },
     "dependencies": {
         "@apify/consts": "^2.50.0",


### PR DESCRIPTION
Removes the `preinstall: "npx only-allow pnpm"` script from package.json.

This script ships in the published tarball and runs when apify-client is installed as a dependency — it breaks `npm install -g apify-cli` and anything else that pulls in apify-client via npm or yarn:

```
npm error path .../node_modules/apify-client
npm error command failed
npm error command sh -c npx only-allow pnpm
```

The `packageManager` field already handles pnpm enforcement for local dev via Corepack without affecting downstream consumers. `only-allow` is also [archived](https://github.com/pnpm/only-allow) and has a [known issue](https://github.com/pnpm/only-allow/issues/2) with firing during dependency installs.

Only affects v2.23.2.