### PR TITLE
fix: drop only-allow preinstall, enforce pnpm via devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
         "format": "oxfmt",
         "format:check": "oxfmt --check",
         "build:node": "tsc",
-        "build:browser": "rsbuild build",
-        "preinstall": "npx only-allow pnpm"
+        "build:browser": "rsbuild build"
     },
     "dependencies": {
         "@apify/consts": "^2.50.0",
@@ -108,5 +107,12 @@
         "webpack": "^5.105.2",
         "webpack-cli": "^7.0.0"
     },
-    "packageManager": "pnpm@10.24.0"
+    "packageManager": "pnpm@10.24.0",
+    "devEngines": {
+        "packageManager": {
+            "name": "pnpm",
+            "version": "10.24.0",
+            "onFail": "error"
+        }
+    }
 }


### PR DESCRIPTION
Fixes #893.

## What's wrong

`"preinstall": "npx only-allow pnpm"` ships in the published npm tarball and fires when downstream consumers install `apify-client` via npm/yarn. In the `npm install -g apify-cli` flow the npx bootstrap of `only-allow` fails to put the binary on PATH in time:
- Linux: `sh: 1: only-allow: not found` (exit 127)
- Windows: `'only-allow' is not recognized as an internal or external command` (exit 1)

`only-allow` itself has a `node_modules` guard since v1.x and would exit silently if it ever managed to run, but the `npx` bootstrap fails first in global-install context. The script breaks downstream users for no benefit — local enforcement is already covered by `packageManager` + Corepack + docs.

## What changes

- Drop `preinstall: npx only-allow pnpm`.
- Add `devEngines.packageManager: { name: pnpm, version: 10.24.0, onFail: error }` for hard local-repo enforcement (Node 22+/npm 10+ honors it; older runtimes ignore it harmlessly).
- `devEngines` only fires at the package's own repo root, never on transitive installs, so downstream consumers are unaffected.

Patch release (2.23.3) needed after merge.

## Verified locally

- `npm install apify-client@2.23.2` reproduces the failure in `npm install -g apify-cli` context.
- With this change applied, `pnpm install --frozen-lockfile` still works (no warning, since `packageManager` and `devEngines.packageManager` versions match exactly at `10.24.0`).
- `npm install` in this repo now errors with `EBADDEVENGINES` instead of pretending to work — same outcome as before, cleaner signal.