### PR TITLE
refactor: switch devEngines onFail from error to warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "packageManager": {
             "name": "pnpm",
             "version": "10.24.0",
-            "onFail": "error"
+            "onFail": "warn"
         }
     }
 }


### PR DESCRIPTION
Follow-up to #895.

The pre-release run for the merge of #895 (run 25664746379) failed at the version-bump step:

\`\`\`
> pnpm version --no-git-tag-version --allow-same-version 2.23.3
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
\`\`\`

Root cause: pnpm v10 still shells out to system \`npm\` for several subcommands — \`pnpm version\`, \`pnpm config\` (default scope), \`pnpm pkg\`. With \`onFail: error\`, those shellouts trip devEngines. pnpm v11 has its own native implementations and isn't affected, but we're staying on pnpm v10 here because Node 18/20 support matters for this package.

\`onFail: warn\` keeps the developer-visible signal (npm prints a warning when invoked in this repo) without breaking the release pipeline. The actual bug fix from #895 — dropping \`preinstall: npx only-allow pnpm\` so downstream npm consumers (\`npm install -g apify-cli\`) don't break — stays in place. Original issue #893 remains resolved.

Bundled \`@npmcli/*\` libraries used by \`pnpm publish\` import as Node modules rather than spawning the npm binary, so publish itself was already safe — failure was strictly at the version-bump step before publish ran.