### PR TITLE
chore: bump pnpm to 10.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,11 +107,11 @@
         "webpack": "^5.105.2",
         "webpack-cli": "^7.0.0"
     },
-    "packageManager": "pnpm@10.24.0",
+    "packageManager": "pnpm@10.33.4",
     "devEngines": {
         "packageManager": {
             "name": "pnpm",
-            "version": "10.24.0",
+            "version": "10.33.4",
             "onFail": "warn"
         }
     }


### PR DESCRIPTION
Brings `packageManager` and `devEngines.packageManager.version` up to the latest pnpm v10 patch (was 10.24.0). No behavior change — just keeps the version pin current.

Same bump going across the other recently-migrated public repos.