### PR TITLE
chore: bump docusaurus-plugin-typedoc-api

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^1.0.246
         version: 1.0.246(8a033ace605630a33139ee57ab3263ab)
       '@apify/docusaurus-plugin-typedoc-api':
-        specifier: ^5.1.3
-        version: 5.1.4(304d710916aebb3c4aea3c6f76fcf56f)
+        specifier: ^5.1.6
+        version: 5.1.6(304d710916aebb3c4aea3c6f76fcf56f)
       '@docusaurus/core':
         specifier: ^3.8.1
         version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
@@ -356,8 +356,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.4':
-    resolution: {integrity: sha512-/h960ua/DQnE8i7k2pXws+8gZojv7PCL4vPgAYjSqwiC3zB+Mqz/csHB3BK6rFRW+Exizo2TCtFoH8Syq0jQiQ==}
+  '@apify/docusaurus-plugin-typedoc-api@5.1.6':
+    resolution: {integrity: sha512-qBjozPWltxMNyrH8GSM6V7KNTNc17KGcAOn8Z9RZftRH5SRhn/PKn/ENRAwjW8kpxT+0vEQAf+n32W/G7diZ8A==}
     engines: {node: '>=16.12.0'}
     peerDependencies:
       '@docusaurus/core': ^3.8.1
@@ -9088,7 +9088,7 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.4(304d710916aebb3c4aea3c6f76fcf56f)':
+  '@apify/docusaurus-plugin-typedoc-api@5.1.6(304d710916aebb3c4aea3c6f76fcf56f)':
     dependencies:
       '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.27.4)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(webpack-cli@7.0.2)
       '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.246",
-        "@apify/docusaurus-plugin-typedoc-api": "^5.1.3",
+        "@apify/docusaurus-plugin-typedoc-api": "^5.1.6",
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",


### PR DESCRIPTION
Bumps the API reference rendering plugin version.