### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,22 +39,11 @@ jobs:
               run: pnpm --filter apify-client-website update @apify/docs-theme
 
             # We do this as early as possible to prevent conflicts if someone else would push something in the meantime
-            - name: Stage the updated package.json and lockfile
-              id: stage
-              run: |
-                  git add website/package.json
-                  git add pnpm-lock.yaml
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit the updated package.json and lockfile
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore: Automatic theme updating workflow [skip ci]'
+                  message: 'chore: Automatic theme updating workflow [skip ci]'
+                  add: 'website/package.json pnpm-lock.yaml'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Build Docusaurus docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,14 +39,23 @@ jobs:
               run: pnpm --filter apify-client-website update @apify/docs-theme
 
             # We do this as early as possible to prevent conflicts if someone else would push something in the meantime
-            - name: Commit the updated package.json and lockfile
+            - name: Stage the updated package.json and lockfile
+              id: stage
               run: |
-                  git config user.name 'GitHub Actions'
-                  git config user.email 'github-actions[bot]@users.noreply.github.com'
                   git add website/package.json
                   git add pnpm-lock.yaml
-                  git diff-index --quiet HEAD || git commit -m 'chore: Automatic theme updating workflow [skip ci]' || true
-                  git push
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Commit the updated package.json and lockfile
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
+              with:
+                  commit-message: 'chore: Automatic theme updating workflow [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Build Docusaurus docs
               run: pnpm build

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -44,7 +44,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -70,14 +70,24 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'chore(release): Update changelog and package version [skip ci]'
-                  pull: '--rebase --autostash'
+                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     publish_to_npm:
         name: Publish to NPM

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -44,7 +44,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -70,23 +70,12 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  message: 'chore(release): Update changelog and package version [skip ci]'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     publish_to_npm:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -44,7 +44,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -77,23 +77,12 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  message: 'chore(release): Update changelog and package version [skip ci]'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     create_github_release:
@@ -158,13 +147,9 @@ jobs:
                   cd ..
                   pnpm format
 
-            - name: Stage the version snapshot
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-
             - name: Commit and push the version snapshot
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'docs: update docs for ${{ needs.release_metadata.outputs.version_number }} version'
+                  message: 'docs: update docs for ${{ needs.release_metadata.outputs.version_number }} version'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
 
         steps:
             - name: Checkout repository
@@ -77,14 +77,24 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'chore(release): Update changelog and package version [skip ci]'
-                  pull: '--rebase --autostash'
+                  commit-message: 'chore(release): Update changelog and package version [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     create_github_release:
         name: Create github release
@@ -148,10 +158,13 @@ jobs:
                   cd ..
                   pnpm format
 
+            - name: Stage the version snapshot
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+
             - name: Commit and push the version snapshot
-              uses: EndBug/add-and-commit@v10
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'docs: update docs for ${{ needs.release_metadata.outputs.version_number }} version'
-                  pull: '--rebase --autostash'
+                  commit-message: 'docs: update docs for ${{ needs.release_metadata.outputs.version_number }} version'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.