### PR TITLE
fix: Use long commit SHA in release workflow [internal]

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -44,7 +44,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
`actions/checkout` requires the long commit SHA if we want to check out a specific commit, not the short SHA. This fixes the release workflow to use the long sha.