### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install Chrome for puppeteer
               run: pnpm exec puppeteer browsers install chrome
@@ -61,7 +61,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Run Tests
               run: pnpm test:bundling
@@ -77,7 +77,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
             - run: pnpm lint
             - name: Format check
               run: pnpm format:check
@@ -95,7 +95,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Build docs
               run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install Chrome for puppeteer
               run: pnpm exec puppeteer browsers install chrome
@@ -61,7 +61,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Run Tests
               run: pnpm test:bundling
@@ -77,7 +77,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
             - run: pnpm lint
             - name: Format check
               run: pnpm format:check
@@ -95,7 +95,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Build docs
               run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Chrome for puppeteer
               run: pnpm exec puppeteer browsers install chrome
@@ -61,7 +61,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Run Tests
               run: pnpm test:bundling
@@ -77,7 +77,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
             - run: pnpm lint
             - name: Format check
               run: pnpm format:check
@@ -95,7 +95,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Build docs
               run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Update docs theme
               run: pnpm --filter apify-client-website update @apify/docs-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Update docs theme
               run: pnpm --filter apify-client-website update @apify/docs-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update docs theme
               run: pnpm --filter apify-client-website update @apify/docs-theme

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.0.0
+            - uses: apify/actions/git-cliff-release@v1.1.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -58,7 +58,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -84,7 +84,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "beta" }'

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.1
+            - uses: apify/actions/git-cliff-release@v1.1.2
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -58,7 +58,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -84,7 +84,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.1.1
+              uses: apify/actions/execute-workflow@v1.1.2
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "beta" }'

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.0
+            - uses: apify/actions/git-cliff-release@v1.1.1
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -58,7 +58,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -84,7 +84,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.1.0
+              uses: apify/actions/execute-workflow@v1.1.1
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "beta" }'

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -34,7 +34,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}
               run: node ./.github/scripts/before-beta-release.js

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -34,7 +34,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}
               run: node ./.github/scripts/before-beta-release.js

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -34,7 +34,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}
               run: node ./.github/scripts/before-beta-release.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.0
+            - uses: apify/actions/git-cliff-release@v1.1.1
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -65,7 +65,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -106,7 +106,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.1.0
+              uses: apify/actions/execute-workflow@v1.1.1
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "latest" }'
@@ -132,7 +132,7 @@ jobs:
               run: sudo apt-get install jq
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Snapshot the current version
               run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.1
+            - uses: apify/actions/git-cliff-release@v1.1.2
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -65,7 +65,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -106,7 +106,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.1.1
+              uses: apify/actions/execute-workflow@v1.1.2
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "latest" }'
@@ -132,7 +132,7 @@ jobs:
               run: sudo apt-get install jq
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Snapshot the current version
               run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.0.0
+            - uses: apify/actions/git-cliff-release@v1.1.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -65,7 +65,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -106,7 +106,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "latest" }'
@@ -132,7 +132,7 @@ jobs:
               run: sudo apt-get install jq
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Snapshot the current version
               run: |


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.