### PR TITLE
ci: skip puppeteer postinstall download to avoid Chrome race on Node 24

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -43,7 +43,11 @@ jobs:
               uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Chrome for puppeteer
-              run: pnpm exec puppeteer browsers install chrome
+              # Clear the cache first so puppeteer's "already installed" check
+              # can't short-circuit on stale state restored from the pnpm store.
+              run: |
+                  rm -rf ~/.cache/puppeteer
+                  pnpm exec puppeteer browsers install chrome
 
             - name: Run Tests
               run: pnpm test

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -41,13 +41,19 @@ jobs:
 
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.1.2
+              env:
+                  # Puppeteer's postinstall kicks off the Chrome download in a
+                  # fire-and-forget Promise (downloadBrowsers() is not awaited
+                  # in puppeteer's install.mjs). When pnpm install returns
+                  # before the download finishes, ~/.cache/puppeteer is left
+                  # half-populated, and the subsequent `browsers install`
+                  # silently no-ops because the directory already exists.
+                  # Skip the postinstall download entirely and let the explicit
+                  # step below do it synchronously.
+                  PUPPETEER_SKIP_DOWNLOAD: 1
 
             - name: Install Chrome for puppeteer
-              # Clear the cache first so puppeteer's "already installed" check
-              # can't short-circuit on stale state restored from the pnpm store.
-              run: |
-                  rm -rf ~/.cache/puppeteer
-                  pnpm exec puppeteer browsers install chrome
+              run: pnpm exec puppeteer browsers install chrome
 
             - name: Run Tests
               run: pnpm test


### PR DESCRIPTION
## What

Set `PUPPETEER_SKIP_DOWNLOAD=1` on the `pnpm install` step in the `Build & Test` matrix, so puppeteer's postinstall doesn't try to download Chrome. The dedicated `Install Chrome for puppeteer` step (already in the workflow) keeps doing the download synchronously and reliably.

## Why

Node 24 jobs have been failing intermittently with:

```
BrowserLaunchError: Failed to launch browser
Caused by: Could not find Chrome (ver. 146.0.7680.153).
```

Step timing shows the `Install Chrome for puppeteer` step has been silently no-opping on Node 24 — exiting in ~1 s with no output, vs ~4 s with a `chrome@146.0.7680.153 …` line on a healthy run.

### Root cause

Puppeteer's postinstall hook ([`install.mjs`](https://github.com/puppeteer/puppeteer/blob/puppeteer-v24.40.0/packages/puppeteer/install.mjs)) is **fire-and-forget**:

```js
const {downloadBrowsers} = await importInstaller();
downloadBrowsers();   // ← not awaited
```

Inside, `downloadBrowsers()` kicks off downloads for chrome, chrome-headless-shell, and firefox in parallel. When `pnpm install` returns before they finish, the process is reaped mid-download and `~/.cache/puppeteer/chrome/linux-146.0.7680.153/` is left half-populated.

The next step then runs `pnpm exec puppeteer browsers install chrome`, which hands off to `@puppeteer/browsers`. That library's "already installed" check is purely "does this directory exist with the right buildId?" — so it sees the half-written directory, assumes Chrome is installed, and exits silently. Tests then explode at runtime because the binary isn't actually there.

That explains everything we observed:
- **Only Node 24** — probably just timing; Node 24's faster startup loses the race more often.
- **Intermittent** — it's a literal race between `pnpm install` returning and the download completing.
- **Retries sometimes work** — when the download happens to finish in time, no orphaned directory, all green.
- **Has been a slow-burn issue** — but the Renovate/TS-v6 lockfile bumps that invalidate the pnpm-store cache made the race lose more often.

### Fix

`PUPPETEER_SKIP_DOWNLOAD=1` on the install step makes puppeteer's postinstall log "Skipping downloading browsers as instructed" and return immediately — no racy background download, no orphaned cache directory. The explicit step that follows then performs the download synchronously and reliably.

Credit to @barjin for [suggesting this approach](https://github.com/apify/apify-client-js/pull/912#discussion_r3317592049) — it's much cleaner than the `rm -rf ~/.cache/puppeteer` workaround in the first commit, which only mopped up after the race instead of preventing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)