### PR TITLE
refactor: Use canonical /v2/actors/ path instead of legacy /v2/acts/ alias

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -45,7 +45,7 @@ export class ActorClient extends ResourceClient {
      */
     constructor(options: ApiClientSubResourceOptions) {
         super({
-            resourcePath: 'acts',
+            resourcePath: 'actors',
             ...options,
         });
     }

--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -35,7 +35,7 @@ export class ActorCollectionClient extends ResourceCollectionClient {
      */
     constructor(options: ApiClientSubResourceOptions) {
         super({
-            resourcePath: 'acts',
+            resourcePath: 'actors',
             ...options,
         });
     }

--- a/test/mock_server/server.ts
+++ b/test/mock_server/server.ts
@@ -96,10 +96,10 @@ export function createDefaultApp(v2Router = express.Router()) {
     app.use('/external', external);
 
     // Attaching V2 routers
-    v2Router.use('/acts/redirect-actor-id', async (_, res) => {
+    v2Router.use('/actors/redirect-actor-id', async (_, res) => {
         res.json({ data: { name: 'redirect-actor-name', id: 'redirect-run-id' } });
     });
-    v2Router.use('/acts', actors);
+    v2Router.use('/actors', actors);
     v2Router.use('/actor-builds', builds);
     v2Router.use('/actor-runs/redirect-run-id/log', streamLogChunks);
     v2Router.use('/actor-runs/redirect-run-id', async (_, res) => {


### PR DESCRIPTION
Switches the actor resource client URLs from the legacy `/v2/acts/...` alias to the canonical `/v2/actors/...` family.

Follow-up to [apify/apify-docs#2522](https://github.com/apify/apify-docs/pull/2522) (and [apify/apify-core#27780](https://github.com/apify/apify-core/pull/27780)), which made `/v2/actors/...` the documented canonical path while keeping `/v2/acts/...` as an undocumented alias. Non-breaking — the server still accepts the legacy alias, but the client should hit the canonical path.