### PR TITLE
ci: [diagnostic] add logging to find Node 24 puppeteer install no-op

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,7 +53,30 @@ jobs:
                   PUPPETEER_SKIP_DOWNLOAD: 1
 
             - name: Install Chrome for puppeteer
-              run: pnpm exec puppeteer browsers install chrome
+              # TEMPORARY DIAGNOSTIC: figure out why this step silently no-ops
+              # on Node 24 sometimes (finishes in ~1s with no output, leaving
+              # Chrome uninstalled). Revert to a single-line `run:` once we
+              # know the cause.
+              run: |
+                  echo "=== Node + pnpm versions ==="
+                  node --version
+                  pnpm --version
+                  echo "=== Puppeteer-related env ==="
+                  env | grep -i puppeteer || echo "(no PUPPETEER_* env vars)"
+                  echo "=== Puppeteer cache state before ==="
+                  ls -la ~/.cache/puppeteer 2>&1 || echo "(no cache dir)"
+                  echo "=== Cosmiconfig search paths (.puppeteerrc.*, puppeteer.config.*) ==="
+                  for dir in . .. ../.. ~ /home /; do
+                      ls -la "$dir"/.puppeteerrc* "$dir"/puppeteer.config* 2>/dev/null || true
+                  done
+                  echo "=== puppeteer.configuration as the CLI sees it ==="
+                  node -e "console.log(JSON.stringify(require('puppeteer/internal/getConfiguration.js').getConfiguration(), null, 2))" || true
+                  echo "=== Running the actual install (DEBUG=puppeteer:*) ==="
+                  set -x
+                  DEBUG='puppeteer:*,@puppeteer/browsers:*' pnpm exec puppeteer browsers install chrome
+                  echo "=== Puppeteer cache state after ==="
+                  ls -la ~/.cache/puppeteer 2>&1 || echo "(no cache dir)"
+                  find ~/.cache/puppeteer -maxdepth 4 -type f 2>/dev/null | head -20 || true
 
             - name: Run Tests
               run: pnpm test


### PR DESCRIPTION
## What

Temporary diagnostic instrumentation on the `Install Chrome for puppeteer` step. **Not for merge** — once we capture a failing Node 24 run that surfaces the root cause, this will be replaced with the real fix.

## Why

[#912](https://github.com/apify/apify-client-js/pull/912) tried to fix Node-24-only failures by skipping the puppeteer postinstall download with `PUPPETEER_SKIP_DOWNLOAD=1`, on the theory that puppeteer's fire-and-forget postinstall was leaving `~/.cache/puppeteer` half-populated and causing the subsequent `puppeteer browsers install chrome` to short-circuit. That theory turned out to be wrong — the first post-merge master run still failed on Node 24 ([job 78289031217](https://github.com/apify/apify-client-js/actions/runs/26574220020/job/78289031217)). Same code, same cache, same env: Node 22 downloads Chrome in 4s, Node 24 silently no-ops in 2s.

So the bug is genuinely inside that step on Node 24 — not in any cross-step state. This PR adds enough logging to figure out *why* the puppeteer CLI is exiting silently:

- Node + pnpm versions actually in use
- All `PUPPETEER_*` env vars in scope
- Cache directory state before + after
- Cosmiconfig search hits (a stray `.puppeteerrc.cjs` anywhere up the tree would silently flip `skipDownload` via [getConfiguration.js:102-106](https://github.com/puppeteer/puppeteer/blob/puppeteer-v24.40.0/packages/puppeteer/src/getConfiguration.ts#L102-L106))
- The resolved `puppeteer.configuration` object the CLI sees
- The install command itself run with `DEBUG='puppeteer:*,@puppeteer/browsers:*'`

## Plan

1. Merge nothing — let CI run on this branch.
2. If Node 24 happens to pass: rerun until it fails (the bug is intermittent), then read the diagnostic output to identify the root cause.
3. Open a follow-up PR with the surgical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)