### PR TITLE
ci: pin `@puppeteer/browsers` to v3 to fix Chrome install

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -41,16 +41,6 @@ jobs:
 
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.1.2
-              env:
-                  # Puppeteer's postinstall kicks off the Chrome download in a
-                  # fire-and-forget Promise (downloadBrowsers() is not awaited
-                  # in puppeteer's install.mjs). When pnpm install returns
-                  # before the download finishes, ~/.cache/puppeteer is left
-                  # half-populated, and the subsequent `browsers install`
-                  # silently no-ops because the directory already exists.
-                  # Skip the postinstall download entirely and let the explicit
-                  # step below do it synchronously.
-                  PUPPETEER_SKIP_DOWNLOAD: 1
 
             - name: Install Chrome for puppeteer
               run: pnpm exec puppeteer browsers install chrome

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@puppeteer/browsers': ^3.0.4
+
 importers:
 
   .:
@@ -53,7 +56,7 @@ importers:
         version: 0.1.2
       '@crawlee/puppeteer':
         specifier: ^3.2.2
-        version: 3.16.0(puppeteer@24.40.0(typescript@6.0.3))
+        version: 3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))
       '@rsbuild/core':
         specifier: ^2.0.0
         version: 2.0.7(core-js@3.49.0)
@@ -110,7 +113,7 @@ importers:
         version: 0.23.0
       puppeteer:
         specifier: ^24.0.0
-        version: 24.40.0(typescript@6.0.3)
+        version: 24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)
       rimraf:
         specifier: ^6.0.0
         version: 6.1.3
@@ -134,22 +137,22 @@ importers:
     dependencies:
       '@apify/docs-theme':
         specifier: ^1.0.251
-        version: 1.0.251(f6dcd3fd0836f8c999ede86f00396755)
+        version: 1.0.251(c32501c1fe5a743af7156a98c200b804)
       '@apify/docusaurus-plugin-typedoc-api':
         specifier: ^5.1.6
-        version: 5.1.6(1c82802afa52346b937ae8ba2627bd17)
+        version: 5.1.6(c7d37cf19f1a2afffdf39d2b6229ef98)
       '@docusaurus/core':
         specifier: ^3.8.1
-        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/faster':
         specifier: ^3.8.1
-        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2)
+        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/preset-classic':
         specifier: ^3.8.1
-        version: 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2)
+        version: 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@signalwire/docusaurus-plugin-llms-txt':
         specifier: ^1.2.2
-        version: 1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))
+        version: 1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -2659,10 +2662,15 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@puppeteer/browsers@2.13.0':
-    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
-    engines: {node: '>=18'}
+  '@puppeteer/browsers@3.0.4':
+    resolution: {integrity: sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -3627,9 +3635,6 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -3902,14 +3907,6 @@ packages:
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
-  b4a@1.8.0:
-    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   babel-loader@10.1.1:
     resolution: {integrity: sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==}
     engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
@@ -3971,47 +3968,6 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  bare-events@2.8.2:
-    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
-    peerDependencies:
-      bare-abort-controller: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-
-  bare-fs@4.7.0:
-    resolution: {integrity: sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
-  bare-os@3.8.7:
-    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
-    engines: {bare: '>=1.14.0'}
-
-  bare-path@3.0.0:
-    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
-
-  bare-stream@2.13.0:
-    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
-    peerDependencies:
-      bare-abort-controller: '*'
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.4.0:
-    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4107,9 +4063,6 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4851,9 +4804,6 @@ packages:
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -5014,9 +4964,6 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
-  events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
-
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -5051,20 +4998,12 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-average-color@9.5.2:
     resolution: {integrity: sha512-FbaU8iPTPljP7tmnVhXbCyASNw/zxnmaNDf88gn5pTXlNvejl9w4FapeWMh6UNDwIjhJJU28EPfQWwW032YgPA==}
     engines: {node: '>= 12'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5089,9 +5028,6 @@ packages:
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5270,10 +5206,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -6464,6 +6396,10 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  modern-tar@0.7.6:
+    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+    engines: {node: '>=18.0.0'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -6799,9 +6735,6 @@ packages:
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
     engines: {node: '>= 0.10'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -7373,10 +7306,6 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -7414,9 +7343,6 @@ packages:
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -8080,9 +8006,6 @@ packages:
   stream-json@1.9.1:
     resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
-  streamx@2.25.0:
-    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8196,15 +8119,6 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tar-fs@3.1.2:
-    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
-
-  tar-stream@3.1.8:
-    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
-
-  teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
-
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
     engines: {node: '>= 10.13.0'}
@@ -8225,9 +8139,6 @@ packages:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
     hasBin: true
-
-  text-decoder@1.2.7:
-    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thingies@2.6.0:
     resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
@@ -8831,9 +8742,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -9128,16 +9036,16 @@ snapshots:
       - search-insights
       - supports-color
 
-  '@apify/docs-theme@1.0.251(f6dcd3fd0836f8c999ede86f00396755)':
+  '@apify/docs-theme@1.0.251(c32501c1fe5a743af7156a98c200b804)':
     dependencies:
       '@apify/docs-search-modal': 1.3.6(@algolia/client-search@5.50.1)(@babel/core@7.29.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(search-insights@2.17.3)
       '@apify/ui-icons': 1.34.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@apify/ui-library': 1.132.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5))
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@stackql/docusaurus-plugin-hubspot': 1.1.0
       algoliasearch: 5.50.1
       algoliasearch-helper: 3.28.1(algoliasearch@5.50.1)
-      babel-loader: 10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      babel-loader: 10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       clsx: 2.1.1
       docusaurus-gtm-plugin: 0.0.2
       postcss-preset-env: 11.2.1(postcss@8.5.15)
@@ -9167,15 +9075,15 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.6(1c82802afa52346b937ae8ba2627bd17)':
+  '@apify/docusaurus-plugin-typedoc-api@5.1.6(c7d37cf19f1a2afffdf39d2b6229ef98)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/preset-classic': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/preset-classic': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@types/react': 19.2.14
       '@vscode/codicons': 0.0.35
       cheerio: 1.2.0
@@ -10027,14 +9935,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser-pool@3.16.0(puppeteer@24.40.0(typescript@6.0.3))':
+  '@crawlee/browser-pool@3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))':
     dependencies:
       '@apify/log': 2.5.34
       '@apify/timeout': 0.3.2
       '@crawlee/core': 3.16.0
       '@crawlee/types': 3.16.0
       fingerprint-generator: 2.1.82
-      fingerprint-injector: 2.1.82(puppeteer@24.40.0(typescript@6.0.3))
+      fingerprint-injector: 2.1.82(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))
       lodash.merge: 4.6.2
       nanoid: 3.3.12
       ow: 0.28.2
@@ -10044,22 +9952,22 @@ snapshots:
       tiny-typed-emitter: 2.1.0
       tslib: 2.8.1
     optionalDependencies:
-      puppeteer: 24.40.0(typescript@6.0.3)
+      puppeteer: 24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser@3.16.0(puppeteer@24.40.0(typescript@6.0.3))':
+  '@crawlee/browser@3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))':
     dependencies:
       '@apify/timeout': 0.3.2
       '@crawlee/basic': 3.16.0
-      '@crawlee/browser-pool': 3.16.0(puppeteer@24.40.0(typescript@6.0.3))
+      '@crawlee/browser-pool': 3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))
       '@crawlee/types': 3.16.0
       '@crawlee/utils': 3.16.0
       ow: 0.28.2
       tslib: 2.8.1
       type-fest: 4.41.0
     optionalDependencies:
-      puppeteer: 24.40.0(typescript@6.0.3)
+      puppeteer: 24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10103,12 +10011,12 @@ snapshots:
       proper-lockfile: 4.1.2
       tslib: 2.8.1
 
-  '@crawlee/puppeteer@3.16.0(puppeteer@24.40.0(typescript@6.0.3))':
+  '@crawlee/puppeteer@3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))':
     dependencies:
       '@apify/datastructures': 2.0.3
       '@apify/log': 2.5.34
-      '@crawlee/browser': 3.16.0(puppeteer@24.40.0(typescript@6.0.3))
-      '@crawlee/browser-pool': 3.16.0(puppeteer@24.40.0(typescript@6.0.3))
+      '@crawlee/browser': 3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))
+      '@crawlee/browser-pool': 3.16.0(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3))
       '@crawlee/types': 3.16.0
       '@crawlee/utils': 3.16.0
       cheerio: 1.0.0-rc.12
@@ -10117,7 +10025,7 @@ snapshots:
       ow: 0.28.2
       tslib: 2.8.1
     optionalDependencies:
-      puppeteer: 24.40.0(typescript@6.0.3)
+      puppeteer: 24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - playwright
       - supports-color
@@ -10798,7 +10706,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/babel@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10810,7 +10718,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -10823,34 +10731,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
-      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
+      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       cssnano: 6.1.2(postcss@8.5.15)
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
-      null-loader: 4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
+      null-loader: 4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       postcss: 8.5.15
-      postcss-loader: 7.3.4(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      postcss-loader: 7.3.4(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       postcss-preset-env: 10.6.1(postcss@8.5.15)
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
-      webpackbar: 6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      webpackbar: 6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10866,15 +10774,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10890,7 +10798,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.4
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -10900,7 +10808,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       react-router: 5.3.4(react@19.2.5)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5)
       react-router-dom: 5.3.4(react@19.2.5)
@@ -10909,12 +10817,12 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10938,18 +10846,18 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.15)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2)':
+  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/html': 1.15.24
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      swc-loader: 0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/helpers'
       - esbuild
@@ -10961,16 +10869,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       fs-extra: 11.3.4
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10986,9 +10894,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       vfile: 6.0.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10996,9 +10904,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -11014,17 +10922,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-blog@3.10.0(d70c2d5a7136e879aabd00d1a6f55928)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -11037,7 +10945,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11056,17 +10964,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.4
@@ -11077,7 +10985,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11096,18 +11004,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11126,12 +11034,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -11153,11 +11061,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11181,11 +11089,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11207,11 +11115,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11234,11 +11142,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11260,14 +11168,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11291,18 +11199,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11321,23 +11229,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-blog': 3.10.0(d70c2d5a7136e879aabd00d1a6f55928)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -11366,21 +11274,21 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-blog': 3.10.0(d70c2d5a7136e879aabd00d1a6f55928)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -11414,13 +11322,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -11438,17 +11346,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.50.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.50.1)(algoliasearch@5.50.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.2(@algolia/client-search@5.50.1)(@types/react@19.2.14)(algoliasearch@5.50.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       algoliasearch: 5.50.1
       algoliasearch-helper: 3.28.1(algoliasearch@5.50.1)
       clsx: 2.1.1
@@ -11485,7 +11393,7 @@ snapshots:
       fs-extra: 11.3.4
       tslib: 2.8.1
 
-  '@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -11497,7 +11405,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -11506,9 +11414,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils-common@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -11519,11 +11427,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils-validation@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -11538,14 +11446,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)':
+  '@docusaurus/utils@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2)
+      '@docusaurus/types': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11558,9 +11466,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -12280,20 +12188,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@puppeteer/browsers@2.13.0':
+  '@puppeteer/browsers@3.0.4(proxy-agent@6.5.0)':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.5.0
-      semver: 7.7.4
-      tar-fs: 3.1.2
+      modern-tar: 0.7.6
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
+    optionalDependencies:
+      proxy-agent: 6.5.0
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -12715,9 +12615,9 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2))':
+  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@swc/helpers@0.5.21)(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       fs-extra: 11.3.4
       hast-util-select: 6.0.4
       hast-util-to-html: 9.0.5
@@ -13213,11 +13113,6 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.12.2
-    optional: true
-
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/expect@4.1.4':
@@ -13550,22 +13445,20 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  b4a@1.8.0: {}
-
-  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -13626,38 +13519,6 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
-
-  bare-events@2.8.2: {}
-
-  bare-fs@4.7.0:
-    dependencies:
-      bare-events: 2.8.2
-      bare-path: 3.0.0
-      bare-stream: 2.13.0(bare-events@2.8.2)
-      bare-url: 2.4.0
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  bare-os@3.8.7: {}
-
-  bare-path@3.0.0:
-    dependencies:
-      bare-os: 3.8.7
-
-  bare-stream@2.13.0(bare-events@2.8.2):
-    dependencies:
-      streamx: 2.25.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - react-native-b4a
-
-  bare-url@2.4.0:
-    dependencies:
-      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -13807,8 +13668,6 @@ snapshots:
       electron-to-chromium: 1.5.335
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -14106,7 +13965,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -14114,7 +13973,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   core-js-compat@3.49.0:
     dependencies:
@@ -14227,7 +14086,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -14239,9 +14098,9 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.15)
@@ -14249,7 +14108,7 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     optionalDependencies:
       clean-css: 5.3.3
       esbuild: 0.28.0
@@ -14583,10 +14442,6 @@ snapshots:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
 
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -14765,12 +14620,6 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
-  events-universal@1.0.1:
-    dependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-
   events@3.3.0: {}
 
   evp_bytestokey@1.0.3:
@@ -14869,21 +14718,9 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-average-color@9.5.2: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -14911,10 +14748,6 @@ snapshots:
     dependencies:
       websocket-driver: 0.7.4
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -14929,11 +14762,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   file-type@20.5.0:
     dependencies:
@@ -15001,12 +14834,12 @@ snapshots:
       header-generator: 2.1.82
       tslib: 2.8.1
 
-  fingerprint-injector@2.1.82(puppeteer@24.40.0(typescript@6.0.3)):
+  fingerprint-injector@2.1.82(puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)):
     dependencies:
       fingerprint-generator: 2.1.82
       tslib: 2.8.1
     optionalDependencies:
-      puppeteer: 24.40.0(typescript@6.0.3)
+      puppeteer: 24.40.0(proxy-agent@6.5.0)(typescript@6.0.3)
 
   flat@5.0.2: {}
 
@@ -15087,10 +14920,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -15469,7 +15298,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -15522,7 +15351,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  html-webpack-plugin@5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15531,7 +15360,7 @@ snapshots:
       tapable: 2.3.2
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   htmlparser2@10.1.0:
     dependencies:
@@ -16697,11 +16526,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  mini-css-extract-plugin@2.10.2(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.2
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   minimalistic-assert@1.0.1: {}
 
@@ -16724,6 +16553,8 @@ snapshots:
   minipass@7.1.3: {}
 
   mitt@3.0.1: {}
+
+  modern-tar@0.7.6: {}
 
   mrmime@2.0.1: {}
 
@@ -16778,11 +16609,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  null-loader@4.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   object-assign@4.1.1: {}
 
@@ -17099,8 +16930,6 @@ snapshots:
       sha.js: 2.4.12
       to-buffer: 1.2.2
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -17360,13 +17189,13 @@ snapshots:
       '@csstools/utilities': 3.0.0(postcss@8.5.15)
       postcss: 8.5.15
 
-  postcss-loader@7.3.4(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  postcss-loader@7.3.4(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.15
       semver: 7.7.4
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - typescript
 
@@ -17789,8 +17618,6 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress@2.0.3: {}
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -17851,11 +17678,6 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode.js@2.3.1: {}
 
   punycode@1.4.1: {}
@@ -17866,9 +17688,9 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  puppeteer-core@24.40.0:
+  puppeteer-core@24.40.0(proxy-agent@6.5.0):
     dependencies:
-      '@puppeteer/browsers': 2.13.0
+      '@puppeteer/browsers': 3.0.4(proxy-agent@6.5.0)
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
       debug: 4.4.3(supports-color@5.5.0)
       devtools-protocol: 0.0.1581282
@@ -17876,26 +17698,22 @@ snapshots:
       webdriver-bidi-protocol: 0.4.1
       ws: 8.20.0
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
-      - react-native-b4a
+      - proxy-agent
       - supports-color
       - utf-8-validate
 
-  puppeteer@24.40.0(typescript@6.0.3):
+  puppeteer@24.40.0(proxy-agent@6.5.0)(typescript@6.0.3):
     dependencies:
-      '@puppeteer/browsers': 2.13.0
+      '@puppeteer/browsers': 3.0.4(proxy-agent@6.5.0)
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
       cosmiconfig: 9.0.1(typescript@6.0.3)
       devtools-protocol: 0.0.1581282
-      puppeteer-core: 24.40.0
+      puppeteer-core: 24.40.0(proxy-agent@6.5.0)
       typed-query-selector: 2.12.1
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
-      - react-native-b4a
+      - proxy-agent
       - supports-color
       - typescript
       - utf-8-validate
@@ -17985,11 +17803,11 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -18041,7 +17859,7 @@ snapshots:
 
   react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@floating-ui/dom': 1.7.6
@@ -18743,15 +18561,6 @@ snapshots:
     dependencies:
       stream-chain: 2.2.5
 
-  streamx@2.25.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.7
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -18868,53 +18677,23 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  swc-loader@0.2.7(@swc/core@1.15.24(@swc/helpers@0.5.21))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       '@swc/counter': 0.1.3
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
 
   tabbable@6.4.0: {}
 
   tapable@2.3.2: {}
 
-  tar-fs@3.1.2:
-    dependencies:
-      pump: 3.0.4
-      tar-stream: 3.1.8
-    optionalDependencies:
-      bare-fs: 4.7.0
-      bare-path: 3.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
-  tar-stream@3.1.8:
-    dependencies:
-      b4a: 1.8.0
-      bare-fs: 4.7.0
-      fast-fifo: 1.3.2
-      streamx: 2.25.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
-  teex@1.0.1:
-    dependencies:
-      streamx: 2.25.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     optionalDependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
       esbuild: 0.28.0
@@ -18935,12 +18714,6 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
-
-  text-decoder@1.2.7:
-    dependencies:
-      b4a: 1.8.0
-    transitivePeerDependencies:
-      - react-native-b4a
 
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
@@ -19165,14 +18938,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
 
   url@0.11.4:
     dependencies:
@@ -19319,7 +19092,7 @@ snapshots:
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1)
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -19328,7 +19101,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
     transitivePeerDependencies:
       - tslib
 
@@ -19385,7 +19158,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19413,10 +19186,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       webpack-cli: 7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)
     transitivePeerDependencies:
       - bufferutil
@@ -19480,7 +19253,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2):
+  webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19504,7 +19277,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -19548,7 +19321,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)):
+  webpackbar@6.0.1(webpack@5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -19557,7 +19330,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.1))
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
@@ -19655,11 +19428,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,18 @@ onlyBuiltDependencies:
   - esbuild
   - puppeteer
 
+# Pin @puppeteer/browsers to v3 even though our direct puppeteer dep
+# is still on v24 (which would otherwise pull in @puppeteer/browsers v2).
+# v2.x uses extract-zip@2.0.1, which silently aborts mid-stream on newer
+# Node releases, leaving ~/.cache/puppeteer/chrome/.../ with only the
+# first archive entry and no `chrome` binary. Test runs then fail with
+# "Could not find Chrome (ver. X)". Fixed in @puppeteer/browsers v3,
+# which shells out to system `unzip`/`tar.exe` instead.
+# Upstream: https://github.com/puppeteer/puppeteer/issues/14957
+# Fix:      https://github.com/puppeteer/puppeteer/pull/14960
+overrides:
+  "@puppeteer/browsers": "^3.0.4"
+
 nodeLinker: hoisted
 linkWorkspacePackages: true
 preferWorkspacePackages: true


### PR DESCRIPTION
## What

Add a pnpm `overrides` entry to pin `@puppeteer/browsers` to v3 even though our direct `puppeteer` devDep stays on v24. Also reverts the misdiagnosed `PUPPETEER_SKIP_DOWNLOAD=1` workaround from #912.

## Why

Reported Node-24-only test failures are caused by a known upstream bug:

- `puppeteer@24` → `@puppeteer/browsers@2.x` → `extract-zip@2.0.1` (unmaintained since 2020).
- On newer Node releases, `extract-zip` silently aborts mid-stream without rejecting, exits with code 0, and leaves the Chrome cache directory existing-but-empty (only the first archive entry, `ABOUT`, ends up on disk). Subsequent test runs fail with `Could not find Chrome (ver. 146.0.7680.153)`.

Confirmed empirically — diagnostic instrumentation in [#916](https://github.com/apify/apify-client-js/pull/916) captured a clean repro:

```
puppeteer:browsers:install Downloading binary from https://storage.googleapis.com/...
puppeteer:browsers:install Duration for download: 1321ms
puppeteer:browsers:install Installing .../146.0.7680.153-chrome-linux64.zip to .../linux-146.0.7680.153
+ find /home/runner/.cache/puppeteer -maxdepth 4 -type f
/home/runner/.cache/puppeteer/chrome/linux-146.0.7680.153/chrome-linux64/ABOUT     ← only ABOUT
/home/runner/.cache/puppeteer/chrome/146.0.7680.153-chrome-linux64.zip
```

No `Duration for extract` debug line — `unpackArchive()` never resolved.

### Upstream

- Tracking issue: [puppeteer/puppeteer#14957](https://github.com/puppeteer/puppeteer/issues/14957)
- Fix: [puppeteer/puppeteer#14960](https://github.com/puppeteer/puppeteer/pull/14960) (merged 2026-05-11) — replaces `extract-zip` with native `unzip`/`tar.exe`. Released as `@puppeteer/browsers@3.0.0` (and bundled into `puppeteer@25.0.0`).

### Why override instead of bumping puppeteer to v25

`puppeteer@25` is ESM-only and requires Node ≥22.12. Both are surmountable for us, but pinning just the buggy transitive package is a smaller change with less risk surface:

- This client only uses puppeteer as a Chrome installer for browser-bundle tests. `test/_helper.ts` calls into `@crawlee/puppeteer` (CJS, bundles its own `puppeteer-core`); the rest of the test code is type-only imports. No direct runtime use of puppeteer's main module.
- puppeteer@24's CLI binary is CJS that does `require('@puppeteer/browsers')`. v3 is ESM-only, but `require()`-of-ESM is stable on Node ≥20.20 / ≥22.12 / ≥24 — empirically verified on all three locally with full extraction.
- Lockfile diff: 270 insertions / 490 deletions vs. ~600 insertions / ~1100 deletions for the puppeteer v25 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)