### PR TITLE
chore: stop publishing broken declaration and source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
         "moduleResolution": "Node16",
         "outDir": "dist",
         "rootDir": "src",
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "declarationMap": false,
+        "sourceMap": false
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
The published tarball excludes `src` but ships `.d.ts.map`/`.js.map` that reference `../src/*.ts`, so the maps never resolve — editors fall back to the compiled `.d.ts`/`.js` instead of the original source. Disabling `declarationMap`/`sourceMap` stops emitting these dead maps and shrinks the tarball. The rsbuild browser bundle sourcemap (which embeds its own sources) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)