### PR TITLE
fix: accept readonly arrays for webhook `eventTypes` input

### DIFF
--- a/src/resource_clients/webhook.ts
+++ b/src/resource_clients/webhook.ts
@@ -156,7 +156,6 @@ export type WebhookUpdateData = Partial<
     Pick<
         Webhook,
         | 'isAdHoc'
-        | 'eventTypes'
         | 'condition'
         | 'ignoreSslErrors'
         | 'doNotRetry'
@@ -166,7 +165,11 @@ export type WebhookUpdateData = Partial<
         | 'isApifyIntegration'
         | 'headersTemplate'
         | 'description'
-    >
+    > & {
+        // Input only: the client doesn't mutate the array, so accept a `readonly`
+        // one too (the `Webhook` response keeps `eventTypes` mutable).
+        eventTypes: readonly WebhookEventType[];
+    }
 > &
     WebhookIdempotencyKey;
 


### PR DESCRIPTION
`WebhookUpdateData.eventTypes` — the input to `create()` / `update()` — now accepts a `readonly WebhookEventType[]`. The `Webhook` **response** type keeps `eventTypes` mutable, so this is **input-only** and not a breaking change for code that reads webhooks.

The client never mutates the array (it only appears in type declarations), and a `readonly T[]` still accepts a plain mutable `T[]`, so:

- **Existing callers are unaffected** — passing `['ACTOR.RUN.SUCCEEDED']` to `create()` / `update()` keeps working.
- **Callers holding a `readonly` array can now pass it directly.** The Apify SDK types `WebhookOptions.eventTypes` as `readonly WebhookEventType[]`, so it currently copies the array (`eventTypes: [...options.eventTypes]`) just to satisfy this client's mutable input type. With this change the copy goes away.

Emitted types after the change:

```ts
interface Webhook            { eventTypes: WebhookEventType[]; ... }          // response — mutable
type WebhookUpdateData = ... { eventTypes: readonly WebhookEventType[]; ... } // input — readonly
```

Type-only change; no runtime behavior changes. `tsc` build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)