### PR TITLE
chore: run lychee link checker on PRs only

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -105,6 +105,7 @@ jobs:
 
             - name: Run Lychee Link Checker
               id: lychee
+              if: github.event_name == 'pull_request'
               uses: lycheeverse/lychee-action@v2.8.0
               with:
                   fail: false


### PR DESCRIPTION
The Lychee link checking action seems to be failing on `master` (perhaps due to insufficient permissions)? 
We need to run the checks on PRs only anyway. 
