### PR TITLE
fix: actorPermissionLevel was missing in ActorCollectionCreateOptions

### DIFF
--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -5,6 +5,7 @@ import { ResourceCollectionClient } from '../base/resource_collection_client';
 import type { PaginatedIterator, PaginatedList, PaginationOptions } from '../utils';
 import type { Actor, ActorDefaultRunOptions, ActorExampleRunInput, ActorStandby } from './actor';
 import type { ActorVersion } from './actor_version';
+import { ACTOR_PERMISSION_LEVEL } from '@apify/consts';
 
 /**
  * Client for managing the collection of Actors in your account.
@@ -127,4 +128,5 @@ export interface ActorCollectionCreateOptions {
     actorStandby?: ActorStandby & {
         isEnabled: boolean;
     };
+    actorPermissionLevel?: ACTOR_PERMISSION_LEVEL;
 }

--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -1,11 +1,12 @@
 import ow from 'ow';
 
+import type { ACTOR_PERMISSION_LEVEL } from '@apify/consts';
+
 import type { ApiClientSubResourceOptions } from '../base/api_client';
 import { ResourceCollectionClient } from '../base/resource_collection_client';
 import type { PaginatedIterator, PaginatedList, PaginationOptions } from '../utils';
 import type { Actor, ActorDefaultRunOptions, ActorExampleRunInput, ActorStandby } from './actor';
 import type { ActorVersion } from './actor_version';
-import { ACTOR_PERMISSION_LEVEL } from '@apify/consts';
 
 /**
  * Client for managing the collection of Actors in your account.


### PR DESCRIPTION
The field is missing in type, but is supported in the API.