### PR TITLE
fix: Fix incomplete type hint of last run/task

### DIFF
--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -845,7 +845,7 @@ export interface ActorBuildOptions {
  */
 export interface ActorLastRunOptions {
     status?: ValueOf<typeof ACTOR_JOB_STATUSES>;
-    origin?: ValueOf<typeof ACTOR_JOB_STATUSES>;
+    origin?: ValueOf<typeof META_ORIGINS>;
 }
 
 /**

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -2,7 +2,7 @@ import type { AxiosRequestConfig } from 'axios';
 import ow from 'ow';
 
 import type { RUN_GENERAL_ACCESS } from '@apify/consts';
-import { ACT_JOB_STATUSES, ACTOR_PERMISSION_LEVEL, META_ORIGINS } from '@apify/consts';
+import { ACTOR_JOB_STATUSES, ACTOR_PERMISSION_LEVEL, META_ORIGINS } from '@apify/consts';
 import { Log } from '@apify/log';
 
 import type { ApiClientSubResourceOptions } from '../base/api_client';
@@ -18,6 +18,7 @@ import { RunClient } from './run';
 import { RunCollectionClient } from './run_collection';
 import type { WebhookUpdateData } from './webhook';
 import { WebhookCollectionClient } from './webhook_collection';
+import { ValueOf } from 'type-fest';
 
 /**
  * Client for managing a specific Actor.
@@ -371,7 +372,7 @@ export class ActorClient extends ResourceClient {
         ow(
             options,
             ow.object.exactShape({
-                status: ow.optional.string.oneOf(Object.values(ACT_JOB_STATUSES)),
+                status: ow.optional.string.oneOf(Object.values(ACTOR_JOB_STATUSES)),
                 origin: ow.optional.string.oneOf(Object.values(META_ORIGINS)),
             }),
         );
@@ -708,7 +709,7 @@ export interface ActorRunListItem {
     actorTaskId?: string;
     startedAt: Date;
     finishedAt: Date;
-    status: (typeof ACT_JOB_STATUSES)[keyof typeof ACT_JOB_STATUSES];
+    status: (typeof ACTOR_JOB_STATUSES)[keyof typeof ACTOR_JOB_STATUSES];
     meta: ActorRunMeta;
     buildId: string;
     buildNumber: string;
@@ -843,8 +844,8 @@ export interface ActorBuildOptions {
  * Options for filtering the last run of an Actor.
  */
 export interface ActorLastRunOptions {
-    status?: keyof typeof ACT_JOB_STATUSES;
-    origin?: keyof typeof META_ORIGINS;
+    status?: ValueOf<typeof ACTOR_JOB_STATUSES>;
+    origin?: ValueOf<typeof ACTOR_JOB_STATUSES>;
 }
 
 /**

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -844,6 +844,7 @@ export interface ActorBuildOptions {
  */
 export interface ActorLastRunOptions {
     status?: keyof typeof ACT_JOB_STATUSES;
+    origin?: keyof typeof META_ORIGINS;
 }
 
 /**

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -18,7 +18,7 @@ import { RunClient } from './run';
 import { RunCollectionClient } from './run_collection';
 import type { WebhookUpdateData } from './webhook';
 import { WebhookCollectionClient } from './webhook_collection';
-import { ValueOf } from 'type-fest';
+import type { ValueOf } from 'type-fest';
 
 /**
  * Client for managing a specific Actor.

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -8,7 +8,7 @@ import { ResourceClient } from '../base/resource_client';
 import type { ApifyRequestConfig } from '../http_client';
 import type { Dictionary } from '../utils';
 import { cast, catchNotFoundOrThrow, parseDateFields, pluckData, stringifyWebhooksToBase64 } from '../utils';
-import type { ActorRun, ActorStandby, ActorStartOptions } from './actor';
+import type { ActorLastRunOptions, ActorRun, ActorStandby, ActorStartOptions } from './actor';
 import { RunClient } from './run';
 import { RunCollectionClient } from './run_collection';
 import { WebhookCollectionClient } from './webhook_collection';
@@ -322,9 +322,7 @@ export type TaskUpdateData = Partial<
 /**
  * Options for filtering the last run of a Task.
  */
-export interface TaskLastRunOptions {
-    status?: keyof typeof ACT_JOB_STATUSES;
-}
+export interface TaskLastRunOptions extends ActorLastRunOptions {}
 
 /**
  * Options for starting a Task.

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -400,7 +400,7 @@ describe('Actor methods', () => {
                         log: 'last-run-log',
                     } as const;
                     validateRequest({
-                        query: { status: requestedStatus , origin: META_ORIGINS.API },
+                        query: { status: requestedStatus, origin: META_ORIGINS.API },
                         params: { actorId },
                         endpointId: endpointIdMap[method],
                     });

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -9,7 +9,7 @@ import express from 'express';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { WEBHOOK_EVENT_TYPES } from '@apify/consts';
+import { META_ORIGINS, WEBHOOK_EVENT_TYPES } from '@apify/consts';
 import { LEVELS, Log } from '@apify/log';
 
 import { stringifyWebhooksToBase64 } from '../src/utils';
@@ -387,7 +387,9 @@ describe('Actor methods', () => {
                     const actorId = 'some-actor-id';
                     const requestedStatus = 'SUCCEEDED';
 
-                    const lastRunClient = client.actor(actorId).lastRun({ status: requestedStatus });
+                    const lastRunClient = client
+                        .actor(actorId)
+                        .lastRun({ status: requestedStatus, origin: META_ORIGINS.API });
                     const res = method === 'get' ? await lastRunClient.get() : await lastRunClient[method]().get();
 
                     const endpointIdMap = {
@@ -398,7 +400,7 @@ describe('Actor methods', () => {
                         log: 'last-run-log',
                     } as const;
                     validateRequest({
-                        query: { status: requestedStatus },
+                        query: { status: requestedStatus , origin: META_ORIGINS.API },
                         params: { actorId },
                         endpointId: endpointIdMap[method],
                     });

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -385,7 +385,7 @@ describe('Actor methods', () => {
                 '%s() works',
                 async (method) => {
                     const actorId = 'some-actor-id';
-                    const requestedStatus = 'SUCCEEDED';
+                    const requestedStatus = 'TIMING-OUT';
 
                     const lastRunClient = client
                         .actor(actorId)


### PR DESCRIPTION
The API accepts the `origin` argument as well. Type is not complete.
- Fix type by adding `origin`
- Reuse duplicate type
- Add the argument to one integration test to make it covered.

API source:
Task:
https://github.com/apify/apify-core/blob/v0.1508.0/src/api/src/routes/actor_tasks/last_run.ts#L21
Run:
https://github.com/apify/apify-core/blob/v0.1508.0/src/api/src/routes/actors/last_run.ts#L21