### PR TITLE
ci: bump apify/actions/pnpm-install to v1.3.1

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Install Chrome for puppeteer
               run: pnpm exec puppeteer browsers install chrome
@@ -61,7 +61,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Run Tests
               run: pnpm test:bundling
@@ -77,7 +77,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
             - run: pnpm lint
             - name: Format check
               run: pnpm format:check
@@ -95,7 +95,7 @@ jobs:
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Build docs
               run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Update docs theme
               run: pnpm --filter apify-client-website update @apify/docs-theme

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -58,7 +58,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -34,7 +34,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}
               run: node ./.github/scripts/before-beta-release.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -132,7 +132,7 @@ jobs:
               run: sudo apt-get install jq
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.3.0
+              uses: apify/actions/pnpm-install@v1.3.1
 
             - name: Snapshot the current version
               run: |


### PR DESCRIPTION
Bumps the pinned `apify/actions/pnpm-install` composite action to `v1.3.1`.

That release updates `actions/cache` to `v6.1.0`, so the action runs on the Node.js 24 runtime. It clears the "Node.js 20 is deprecated" warning that shows up on every CI run. For details, see apify/actions#29.
