### PR TITLE
fix: align User-Agent OS token with other Apify clients

### DIFF
--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -159,7 +159,7 @@ export class HttpClient {
 
         // Works only in Node. Cannot be set in browser
         const isAtHome = !!process.env[APIFY_ENV_VARS.IS_AT_HOME];
-        let userAgent = `ApifyClient/${version} (${os.type()}; Node/${process.version}); isAtHome/${isAtHome}`;
+        let userAgent = `ApifyClient/${version} (${os.platform()}; Node/${process.version}); isAtHome/${isAtHome}`;
 
         if (this.userAgentSuffix) {
             userAgent += `; ${asArray(this.userAgentSuffix).join('; ')}`;

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -1,4 +1,5 @@
 import type { AddressInfo } from 'node:net';
+import os from 'node:os';
 
 import { ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
@@ -43,6 +44,9 @@ describe('HttpClient', () => {
         await expect(client.actor(resourceId).get()).rejects.toThrow('timeout of 1000ms exceeded');
         const ua = mockServer.getLastRequest()?.headers['user-agent'];
         expect(ua).toMatch(/ApifyClient\/\d+\.\d+\.\d+/);
+        // The OS token uses os.platform() (e.g. `linux`, `darwin`, `win32`) so it stays aligned
+        // with the Python client's `sys.platform` value.
+        expect(ua).toMatch(`(${os.platform()}; Node/${process.version})`);
         expect(ua).toMatch('isAtHome/false; SDK/3.1.1; Crawlee/3.11.5');
 
         await expect(page.evaluate((rId) => client.task(rId).get(), resourceId)).rejects.toThrow();

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -44,8 +44,6 @@ describe('HttpClient', () => {
         await expect(client.actor(resourceId).get()).rejects.toThrow('timeout of 1000ms exceeded');
         const ua = mockServer.getLastRequest()?.headers['user-agent'];
         expect(ua).toMatch(/ApifyClient\/\d+\.\d+\.\d+/);
-        // The OS token uses os.platform() (e.g. `linux`, `darwin`, `win32`) so it stays aligned
-        // with the Python client's `sys.platform` value.
         expect(ua).toMatch(`(${os.platform()}; Node/${process.version})`);
         expect(ua).toMatch('isAtHome/false; SDK/3.1.1; Crawlee/3.11.5');
 


### PR DESCRIPTION
## What & why

The JS client builds its `User-Agent` OS token from `os.type()`, which returns `uname`-style names (`Linux`, `Darwin`, `Windows_NT`). The Python client uses `sys.platform`, which returns short lowercase identifiers (`linux`, `darwin`, `win32`). This makes the same platform look different across clients — most starkly on Windows (`Windows_NT` vs `win32`).

This PR switches JS from `os.type()` to `os.platform()`. Node's `os.platform()` returns exactly the same lowercase identifiers as Python's `sys.platform`, so the OS token lines up across clients on every OS with no per-OS special-casing.

## OS token before/after

| OS | `os.type()` (before) | `os.platform()` (after) | Python `sys.platform` |
|----|----------------------|-------------------------|-----------------------|
| Linux | `Linux` | `linux` | `linux` |
| Android | `Linux` | `android` | `android` |
| macOS | `Darwin` | `darwin` | `darwin` |
| Windows | `Windows_NT` | `win32` | `win32` |

## Changes

- `src/http_client.ts`: `os.type()` → `os.platform()` in the User-Agent string.
- `test/http_client.test.ts`: assert the OS token matches `os.platform()`.

## Notes

Example of current data that is inconsistent

<img width="365" height="373" alt="image" src="https://github.com/user-attachments/assets/80f59a51-4c70-43f2-aab2-5ec12c6d369e" />

