### PR TITLE
feat: support APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ Some actions can't be performed by the API itself, such as indefinite waiting fo
 Key-value store records can be retrieved as objects, buffers or streams via the respective options, dataset items
 can be fetched as individual objects or serialized data and we plan to add better stream support and async iterators.
 
+### Custom API URLs
+
+By default, the client talks to `https://api.apify.com`. You can point it elsewhere — e.g. a local or staging
+instance of the Apify platform — either via constructor options or environment variables:
+
+```js
+const apifyClient = new ApifyClient({
+    token: 'my-token',
+    baseUrl: 'http://localhost:8080',
+});
+```
+
+`baseUrl` also falls back to the `APIFY_API_BASE_URL` environment variable, and `publicBaseUrl` (the globally
+accessible URL, used when `baseUrl` is an internal address) falls back to `APIFY_API_PUBLIC_BASE_URL`. Precedence
+is `constructor option` > `environment variable` > `https://api.apify.com` default, and the two variables are
+independent of each other — setting one does not change the other's default.
+
 ## Usage concepts
 
 The `ApifyClient` interface follows a generic pattern that is applicable to all of its components.

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -35,6 +35,24 @@ import { Statistics } from './statistics';
 
 const DEFAULT_TIMEOUT_SECS = 360;
 
+/** Default base URL for the Apify API. Overridable via the `APIFY_API_BASE_URL` environment variable. */
+const DEFAULT_BASE_URL = 'https://api.apify.com';
+
+/** Default globally accessible base URL for the Apify API. Overridable via `APIFY_API_PUBLIC_BASE_URL`. */
+const DEFAULT_PUBLIC_BASE_URL = 'https://api.apify.com';
+
+/**
+ * Reads an environment variable in a browser-safe way.
+ *
+ * A bare `process.env.X` throws in browser bundles where `process` is not defined, so this guards
+ * both the existence of `process` and of `process.env` before reading. A blank-but-defined value
+ * (e.g. `X=''`, as can happen with CI/Docker `-e` flags) is treated as unset, so callers can safely
+ * fall back with `??`.
+ */
+function readEnvVar(name: string): string | undefined {
+    return (typeof process !== 'undefined' ? process.env?.[name] : undefined) || undefined;
+}
+
 /**
  * The official JavaScript client for the Apify API.
  *
@@ -85,8 +103,8 @@ export class ApifyClient {
         );
 
         const {
-            baseUrl = 'https://api.apify.com',
-            publicBaseUrl = 'https://api.apify.com',
+            baseUrl = readEnvVar('APIFY_API_BASE_URL') ?? DEFAULT_BASE_URL,
+            publicBaseUrl = readEnvVar('APIFY_API_PUBLIC_BASE_URL') ?? DEFAULT_PUBLIC_BASE_URL,
             maxRetries = 8,
             minDelayBetweenRetriesMillis = 500,
             requestInterceptors = [],
@@ -566,9 +584,18 @@ export class ApifyClient {
  * Configuration options for ApifyClient.
  */
 export interface ApifyClientOptions {
-    /** @default https://api.apify.com */
+    /**
+     * The URL of the Apify API server to connect to.
+     *
+     * @default process.env.APIFY_API_BASE_URL ?? 'https://api.apify.com'
+     */
     baseUrl?: string;
-    /** @default https://api.apify.com */
+    /**
+     * The globally accessible URL of the Apify API server. Should be set only if `baseUrl` is an
+     * internal URL that is not globally accessible.
+     *
+     * @default process.env.APIFY_API_PUBLIC_BASE_URL ?? 'https://api.apify.com'
+     */
     publicBaseUrl?: string;
     /** @default 8 */
     maxRetries?: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -24,66 +24,51 @@ describe('ApifyClient', () => {
             vi.unstubAllEnvs();
         });
 
-        test('with no env vars and no options, baseUrl and publicBaseUrl resolve to the production default', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', undefined as unknown as string);
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', undefined as unknown as string);
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('https://api.apify.com/v2');
-            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
+        // Stubs an env var, or clears it when the value is undefined.
+        const stubEnv = (name: string, value: string | undefined) => {
+            vi.stubEnv(name, value as unknown as string);
+        };
+
+        describe('baseUrl (APIFY_API_BASE_URL)', () => {
+            test.each([
+                { case: 'defaults to production when unset', env: undefined, option: undefined, expected: 'https://api.apify.com/v2' },
+                { case: 'uses the env var when no option is given', env: 'http://localhost:8080', option: undefined, expected: 'http://localhost:8080/v2' },
+                { case: 'explicit option wins over the env var', env: 'http://localhost:8080', option: 'http://example.test', expected: 'http://example.test/v2' },
+                { case: 'honors a custom port with no special handling', env: 'http://localhost:9999', option: undefined, expected: 'http://localhost:9999/v2' },
+                { case: 'treats a blank-but-defined value as unset', env: '', option: undefined, expected: 'https://api.apify.com/v2' },
+            ])('$case', ({ env, option, expected }) => {
+                stubEnv('APIFY_API_BASE_URL', env);
+                const client = new ApifyClient(option ? { baseUrl: option } : {});
+                expect(client.baseUrl).toBe(expected);
+            });
         });
 
-        test('APIFY_API_BASE_URL is used when no baseUrl option is given', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('http://localhost:8080/v2');
+        describe('publicBaseUrl (APIFY_API_PUBLIC_BASE_URL)', () => {
+            test.each([
+                { case: 'defaults to production when unset', env: undefined, option: undefined, expected: 'https://api.apify.com/v2' },
+                { case: 'uses the env var when no option is given', env: 'http://localhost:8080', option: undefined, expected: 'http://localhost:8080/v2' },
+                { case: 'explicit option wins over the env var', env: 'http://localhost:8080', option: 'http://example.test', expected: 'http://example.test/v2' },
+                { case: 'treats a blank-but-defined value as unset', env: '', option: undefined, expected: 'https://api.apify.com/v2' },
+            ])('$case', ({ env, option, expected }) => {
+                stubEnv('APIFY_API_PUBLIC_BASE_URL', env);
+                const client = new ApifyClient(option ? { publicBaseUrl: option } : {});
+                expect(client.publicBaseUrl).toBe(expected);
+            });
         });
 
-        test('APIFY_API_PUBLIC_BASE_URL is used when no publicBaseUrl option is given', () => {
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient();
-            expect(client.publicBaseUrl).toBe('http://localhost:8080/v2');
-        });
-
-        test('explicit baseUrl option wins over APIFY_API_BASE_URL', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient({ baseUrl: 'http://example.test' });
-            expect(client.baseUrl).toBe('http://example.test/v2');
-        });
-
-        test('explicit publicBaseUrl option wins over APIFY_API_PUBLIC_BASE_URL', () => {
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient({ publicBaseUrl: 'http://example.test' });
-            expect(client.publicBaseUrl).toBe('http://example.test/v2');
-        });
-
-        test('a custom port in APIFY_API_BASE_URL is honored with no special handling', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:9999');
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('http://localhost:9999/v2');
-        });
-
-        test('APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL are independent (only base set)', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', undefined as unknown as string);
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('http://localhost:8080/v2');
-            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
-        });
-
-        test('APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL are independent (only public set)', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', undefined as unknown as string);
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('https://api.apify.com/v2');
-            expect(client.publicBaseUrl).toBe('http://localhost:8080/v2');
-        });
-
-        test('the /v2 suffix is appended to env-supplied URLs', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
-            const client = new ApifyClient();
-            expect(client.baseUrl.endsWith('/v2')).toBe(true);
-            expect(client.publicBaseUrl.endsWith('/v2')).toBe(true);
+        describe('the two env vars are independent and each keeps the /v2 suffix', () => {
+            test.each([
+                { case: 'both unset resolve to their defaults', baseEnv: undefined, publicEnv: undefined, expectedBase: 'https://api.apify.com/v2', expectedPublic: 'https://api.apify.com/v2' },
+                { case: 'only base set leaves public at its default', baseEnv: 'http://localhost:8080', publicEnv: undefined, expectedBase: 'http://localhost:8080/v2', expectedPublic: 'https://api.apify.com/v2' },
+                { case: 'only public set leaves base at its default', baseEnv: undefined, publicEnv: 'http://localhost:8080', expectedBase: 'https://api.apify.com/v2', expectedPublic: 'http://localhost:8080/v2' },
+                { case: 'both set get the /v2 suffix appended independently', baseEnv: 'http://localhost:8080', publicEnv: 'http://localhost:9090', expectedBase: 'http://localhost:8080/v2', expectedPublic: 'http://localhost:9090/v2' },
+            ])('$case', ({ baseEnv, publicEnv, expectedBase, expectedPublic }) => {
+                stubEnv('APIFY_API_BASE_URL', baseEnv);
+                stubEnv('APIFY_API_PUBLIC_BASE_URL', publicEnv);
+                const client = new ApifyClient();
+                expect(client.baseUrl).toBe(expectedBase);
+                expect(client.publicBaseUrl).toBe(expectedPublic);
+            });
         });
 
         test('sub-clients inherit the resolved base URL and public base URL', () => {
@@ -93,18 +78,6 @@ describe('ApifyClient', () => {
             const dataset = client.dataset('some-id');
             expect((dataset as unknown as { baseUrl: string }).baseUrl).toBe('http://localhost:8080/v2');
             expect((dataset as unknown as { publicBaseUrl: string }).publicBaseUrl).toBe('http://localhost:9090/v2');
-        });
-
-        test('a blank-but-defined APIFY_API_BASE_URL is treated as unset, not as an empty host', () => {
-            vi.stubEnv('APIFY_API_BASE_URL', '');
-            const client = new ApifyClient();
-            expect(client.baseUrl).toBe('https://api.apify.com/v2');
-        });
-
-        test('a blank-but-defined APIFY_API_PUBLIC_BASE_URL is treated as unset, not as an empty host', () => {
-            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', '');
-            const client = new ApifyClient();
-            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
         });
     });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { ApifyClient } from 'apify-client';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 describe('ApifyClient', () => {
     test('default baseUrl is correctly set', () => {
@@ -17,5 +17,94 @@ describe('ApifyClient', () => {
         const token = 'myToken';
         const client = new ApifyClient({ token });
         expect(client.token).toBe(token);
+    });
+
+    describe('base URL environment variable resolution', () => {
+        afterEach(() => {
+            vi.unstubAllEnvs();
+        });
+
+        test('with no env vars and no options, baseUrl and publicBaseUrl resolve to the production default', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', undefined as unknown as string);
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', undefined as unknown as string);
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('https://api.apify.com/v2');
+            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
+        });
+
+        test('APIFY_API_BASE_URL is used when no baseUrl option is given', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('http://localhost:8080/v2');
+        });
+
+        test('APIFY_API_PUBLIC_BASE_URL is used when no publicBaseUrl option is given', () => {
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient();
+            expect(client.publicBaseUrl).toBe('http://localhost:8080/v2');
+        });
+
+        test('explicit baseUrl option wins over APIFY_API_BASE_URL', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient({ baseUrl: 'http://example.test' });
+            expect(client.baseUrl).toBe('http://example.test/v2');
+        });
+
+        test('explicit publicBaseUrl option wins over APIFY_API_PUBLIC_BASE_URL', () => {
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient({ publicBaseUrl: 'http://example.test' });
+            expect(client.publicBaseUrl).toBe('http://example.test/v2');
+        });
+
+        test('a custom port in APIFY_API_BASE_URL is honored with no special handling', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:9999');
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('http://localhost:9999/v2');
+        });
+
+        test('APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL are independent (only base set)', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', undefined as unknown as string);
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('http://localhost:8080/v2');
+            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
+        });
+
+        test('APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL are independent (only public set)', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', undefined as unknown as string);
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('https://api.apify.com/v2');
+            expect(client.publicBaseUrl).toBe('http://localhost:8080/v2');
+        });
+
+        test('the /v2 suffix is appended to env-supplied URLs', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080');
+            const client = new ApifyClient();
+            expect(client.baseUrl.endsWith('/v2')).toBe(true);
+            expect(client.publicBaseUrl.endsWith('/v2')).toBe(true);
+        });
+
+        test('sub-clients inherit the resolved base URL and public base URL', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', 'http://localhost:8080');
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:9090');
+            const client = new ApifyClient();
+            const dataset = client.dataset('some-id');
+            expect((dataset as unknown as { baseUrl: string }).baseUrl).toBe('http://localhost:8080/v2');
+            expect((dataset as unknown as { publicBaseUrl: string }).publicBaseUrl).toBe('http://localhost:9090/v2');
+        });
+
+        test('a blank-but-defined APIFY_API_BASE_URL is treated as unset, not as an empty host', () => {
+            vi.stubEnv('APIFY_API_BASE_URL', '');
+            const client = new ApifyClient();
+            expect(client.baseUrl).toBe('https://api.apify.com/v2');
+        });
+
+        test('a blank-but-defined APIFY_API_PUBLIC_BASE_URL is treated as unset, not as an empty host', () => {
+            vi.stubEnv('APIFY_API_PUBLIC_BASE_URL', '');
+            const client = new ApifyClient();
+            expect(client.publicBaseUrl).toBe('https://api.apify.com/v2');
+        });
     });
 });


### PR DESCRIPTION
## Description

The API base URL and public API base URL were hardcoded as inline literals in the `ApifyClient` constructor. Anyone pointing the client at a local platform, a staging deployment, or a custom host/port had to edit or wrap the library.

Both URLs now resolve as **explicit constructor option > environment variable > built-in default constant**:

- `APIFY_API_BASE_URL` → `baseUrl`
- `APIFY_API_PUBLIC_BASE_URL` → `publicBaseUrl`

The two variables are independent (each keeps its own default). Empty-string env values are treated as unset (fall through to the default). The production defaults are now top-level constants, env reads are browser-safe (guarded so they don't throw when `process` is undefined), and the automatic `/v2` suffixing is unchanged. **Setting nothing reproduces today's behavior exactly.**

### Context 

This is one of three sibling PRs applying the same env-var contract across the Apify clients and CLI (the CLI also adds `APIFY_CONSOLE_BASE_URL`). Separate repos, no overlapping files:

- apify-client-js (this PR): apify/apify-client-js#967
- apify-client-python: apify/apify-client-python#948
- apify-cli: apify/apify-cli#1275
