### PR TITLE
chore!: require Node.js 22 or newer

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [22, 24]
+                node-version: [22, 24, 26]
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -79,6 +79,8 @@ jobs:
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.4.0
             - run: pnpm lint
+            - name: Type-check tests
+              run: pnpm tsc-check-tests
             - name: Format check
               run: pnpm format:check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to the official JavaScript/TypeScrip
 
 ### Prerequisites
 
-- Node.js 18+ (LTS recommended)
+- Node.js 22+ (LTS recommended)
 - npm 10+
 
 ### Installation

--- a/docs/01_introduction/index.md
+++ b/docs/01_introduction/index.md
@@ -17,13 +17,13 @@ The client simplifies interaction with the Apify platform by providing:
 - Intelligent parsing of API responses and rich error messages for debugging
 - Built-in [exponential backoff](../02_concepts/02_error-handling.md#retries-with-exponential-backoff) for failed requests
 - Full TypeScript support with comprehensive type definitions
-- Cross-platform compatibility in [Node.js](https://nodejs.org/) v16+ and modern browsers
+- Cross-platform compatibility in [Node.js](https://nodejs.org/) v22+ and modern browsers
 
 All requests and responses (including errors) are encoded in JSON format with UTF-8 encoding.
 
 ## Pre-requisites
 
-`apify-client` requires Node.js version 16 or higher. Node.js is available for download on the [official website](https://nodejs.org/). Check for your current Node.js version by running:
+`apify-client` requires Node.js version 22 or higher. Node.js is available for download on the [official website](https://nodejs.org/). Check for your current Node.js version by running:
 
 ```bash
 node -v

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "apify-client",
     "version": "2.24.0",
     "description": "Apify API client for JavaScript",
+    "engines": {
+        "node": ">=22.0.0"
+    },
     "main": "dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,8 +119,8 @@ async function brotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buf
         const { promisify } = await import('node:util');
         const { brotliCompress, constants } = await import('node:zlib');
         const compress = promisify(brotliCompress);
-        brotliCompressPromisified = async (value) =>
-            compress(value, { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } });
+        const options = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
+        brotliCompressPromisified = async (input) => compress(input, options);
     }
 
     return brotliCompressPromisified(value);
@@ -144,7 +144,14 @@ export async function maybeCompressValue(value: unknown): Promise<CompressedValu
     const areDataLargeEnough = Buffer.byteLength(value) >= MIN_COMPRESS_BYTES;
     if (!areDataLargeEnough) return undefined;
 
-    return { data: await brotliValue(value), encoding: 'br' };
+    try {
+        return { data: await brotliValue(value), encoding: 'br' };
+    } catch {
+        // Same reasoning as above: compression is a best-effort optimization, so skip it instead
+        // of failing the request. Runtimes that only provide a partial `node:zlib` (bundler
+        // polyfills, edge runtimes with Node compatibility shims) may not implement brotli.
+        return undefined;
+    }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,13 +126,29 @@ async function brotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buf
     return brotliCompressPromisified(value);
 }
 
+let gzipPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
+
+/**
+ * Gzip-compress the provided value.
+ */
+async function gzipValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
+    if (!gzipPromisified) {
+        const { promisify } = await import('node:util');
+        const { gzip } = await import('node:zlib');
+        gzipPromisified = promisify(gzip);
+    }
+
+    return gzipPromisified(value);
+}
+
 export interface CompressedValue {
     data: Buffer;
-    encoding: 'br';
+    encoding: 'br' | 'gzip';
 }
 
 /**
- * Compress the passed value using brotli. Returns undefined if the data is too small / wrong type.
+ * Compress the passed value using brotli, falling back to gzip. Returns undefined if the data is
+ * too small / wrong type, or if neither algorithm is available.
  */
 export async function maybeCompressValue(value: unknown): Promise<CompressedValue | undefined> {
     if (!isNode()) return undefined;
@@ -147,9 +163,15 @@ export async function maybeCompressValue(value: unknown): Promise<CompressedValu
     try {
         return { data: await brotliValue(value), encoding: 'br' };
     } catch {
+        // Runtimes that only provide a partial `node:zlib` (bundler polyfills, edge runtimes with
+        // Node compatibility shims) may not implement brotli, but usually do implement gzip.
+    }
+
+    try {
+        return { data: await gzipValue(value), encoding: 'gzip' };
+    } catch {
         // Same reasoning as above: compression is a best-effort optimization, so skip it instead
-        // of failing the request. Runtimes that only provide a partial `node:zlib` (bundler
-        // polyfills, edge runtimes with Node compatibility shims) may not implement brotli.
+        // of failing the request.
         return undefined;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,23 +109,6 @@ export function stringifyWebhooksToBase64(webhooks: WebhookUpdateData[]): string
     return btoa(String.fromCharCode(...uint8Array));
 }
 
-let brotliCompressPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
-
-/**
- * Brotli-compress the provided value.
- */
-async function brotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
-    if (!brotliCompressPromisified) {
-        const { promisify } = await import('node:util');
-        const { brotliCompress, constants } = await import('node:zlib');
-        const compress = promisify(brotliCompress);
-        const options = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
-        brotliCompressPromisified = async (input) => compress(input, options);
-    }
-
-    return brotliCompressPromisified(value);
-}
-
 let gzipPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
 
 /**
@@ -141,14 +124,41 @@ async function gzipValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffe
     return gzipPromisified(value);
 }
 
+// null = confirmed unavailable; undefined = not yet checked
+let brotliCompressPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | null | undefined;
+
+/**
+ * Brotli-compress the provided value, or return undefined if brotli is unavailable
+ * (Node.js < v10.16.0), this is a strict defensive guard.
+ */
+async function maybeBrotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer | undefined> {
+    if (brotliCompressPromisified === undefined) {
+        const { promisify } = await import('node:util');
+        const { brotliCompress, constants } = await import('node:zlib');
+        if (typeof brotliCompress === 'function') {
+            const compress = promisify(brotliCompress);
+            brotliCompressPromisified = async (value) =>
+                compress(value, { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } });
+        } else {
+            brotliCompressPromisified = null;
+        }
+    }
+
+    if (brotliCompressPromisified !== null) {
+        return brotliCompressPromisified(value);
+    }
+
+    return undefined;
+}
+
 export interface CompressedValue {
     data: Buffer;
     encoding: 'br' | 'gzip';
 }
 
 /**
- * Compress the passed value using brotli, falling back to gzip. Returns undefined if the data is
- * too small / wrong type, or if neither algorithm is available.
+ * Compress the passed value using brotli if available or using gzip as a fallback. Returns undefined
+ * if the data is too small / wrong type.
  */
 export async function maybeCompressValue(value: unknown): Promise<CompressedValue | undefined> {
     if (!isNode()) return undefined;
@@ -160,20 +170,11 @@ export async function maybeCompressValue(value: unknown): Promise<CompressedValu
     const areDataLargeEnough = Buffer.byteLength(value) >= MIN_COMPRESS_BYTES;
     if (!areDataLargeEnough) return undefined;
 
-    try {
-        return { data: await brotliValue(value), encoding: 'br' };
-    } catch {
-        // Runtimes that only provide a partial `node:zlib` (bundler polyfills, edge runtimes with
-        // Node compatibility shims) may not implement brotli, but usually do implement gzip.
-    }
+    const brotli = await maybeBrotliValue(value);
+    if (brotli) return { data: brotli, encoding: 'br' };
 
-    try {
-        return { data: await gzipValue(value), encoding: 'gzip' };
-    } catch {
-        // Same reasoning as above: compression is a best-effort optimization, so skip it instead
-        // of failing the request.
-        return undefined;
-    }
+    const gzipped = await gzipValue(value);
+    return { data: gzipped, encoding: 'gzip' };
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,56 +109,30 @@ export function stringifyWebhooksToBase64(webhooks: WebhookUpdateData[]): string
     return btoa(String.fromCharCode(...uint8Array));
 }
 
-let gzipPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
+let brotliCompressPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
 
 /**
- * Gzip-compress the provided value.
+ * Brotli-compress the provided value.
  */
-async function gzipValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
-    if (!gzipPromisified) {
-        const { promisify } = await import('node:util');
-        const { gzip } = await import('node:zlib');
-        gzipPromisified = promisify(gzip);
-    }
-
-    return gzipPromisified(value);
-}
-
-// null = confirmed unavailable; undefined = not yet checked
-let brotliCompressPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | null | undefined;
-
-/**
- * Brotli-compress the provided value, or return undefined if brotli is unavailable
- * (Node.js < v10.16.0), this is a strict defensive guard.
- */
-async function maybeBrotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer | undefined> {
-    if (brotliCompressPromisified === undefined) {
+async function brotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
+    if (!brotliCompressPromisified) {
         const { promisify } = await import('node:util');
         const { brotliCompress, constants } = await import('node:zlib');
-        if (typeof brotliCompress === 'function') {
-            const compress = promisify(brotliCompress);
-            brotliCompressPromisified = async (value) =>
-                compress(value, { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } });
-        } else {
-            brotliCompressPromisified = null;
-        }
+        const compress = promisify(brotliCompress);
+        brotliCompressPromisified = async (value) =>
+            compress(value, { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } });
     }
 
-    if (brotliCompressPromisified !== null) {
-        return brotliCompressPromisified(value);
-    }
-
-    return undefined;
+    return brotliCompressPromisified(value);
 }
 
 export interface CompressedValue {
     data: Buffer;
-    encoding: 'br' | 'gzip';
+    encoding: 'br';
 }
 
 /**
- * Compress the passed value using brotli if available or using gzip as a fallback. Returns undefined
- * if the data is too small / wrong type.
+ * Compress the passed value using brotli. Returns undefined if the data is too small / wrong type.
  */
 export async function maybeCompressValue(value: unknown): Promise<CompressedValue | undefined> {
     if (!isNode()) return undefined;
@@ -170,11 +144,7 @@ export async function maybeCompressValue(value: unknown): Promise<CompressedValu
     const areDataLargeEnough = Buffer.byteLength(value) >= MIN_COMPRESS_BYTES;
     if (!areDataLargeEnough) return undefined;
 
-    const brotli = await maybeBrotliValue(value);
-    if (brotli) return { data: brotli, encoding: 'br' };
-
-    const gzipped = await gzipValue(value);
-    return { data: gzipped, encoding: 'gzip' };
+    return { data: await brotliValue(value), encoding: 'br' };
 }
 
 /**

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -456,7 +456,9 @@ describe('Redirect run logs', () => {
             await setTimeoutNode(500);
             await expect(streamedLog?.stop()).resolves.not.toThrow();
             expect(
-                warnSpy.mock.calls.some(([msg]: [string]) => msg?.includes('Log redirection stopped due to error')),
+                warnSpy.mock.calls.some(
+                    ([msg]) => typeof msg === 'string' && msg.includes('Log redirection stopped due to error'),
+                ),
             ).toBe(true);
             warnSpy.mockRestore();
         });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,12 +3,17 @@
     "compilerOptions": {
         "rootDir": "../",
         "noEmit": true,
-        // This project only type-checks, so declaration-emit portability errors are irrelevant noise.
+        // A type-check-only project must not write build state into the published `dist` directory.
+        "incremental": false,
+        // Nothing is emitted here, so declaration-emit portability errors are not actionable.
         "declaration": false,
         "allowJs": true,
         "paths": {
             "apify-client": ["../src"]
         }
     },
-    "include": [".", "../src/**/*"]
+    "include": [".", "../src/**/*"],
+    // `bundling` is a standalone bundler smoke test that imports the generated `dist/bundle.js`.
+    // Keep build output out of the type-check program so the check does not depend on `pnpm build`.
+    "exclude": ["bundling"]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,8 @@
     "compilerOptions": {
         "rootDir": "../",
         "noEmit": true,
+        // This project only type-checks, so declaration-emit portability errors are irrelevant noise.
+        "declaration": false,
         "allowJs": true,
         "paths": {
             "apify-client": ["../src"]

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import type { WebhookUpdateData } from 'apify-client';
 import { ApifyApiError } from 'apify-client';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import * as utils from '../src/utils';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "allowJs": true,
         "lib": ["ES2024", "DOM"],
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "module": "node20",
+        "moduleResolution": "nodenext",
         "target": "ES2024",
         "outDir": "dist",
         "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,6 @@
     "compilerOptions": {
         "allowJs": true,
         "lib": ["ES2024", "DOM"],
-        "module": "node20",
-        "moduleResolution": "nodenext",
         "target": "ES2024",
         "outDir": "dist",
         "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
     "extends": "@apify/tsconfig",
     "compilerOptions": {
         "allowJs": true,
-        "lib": ["ESNext", "DOM"],
-        "module": "Node16",
-        "moduleResolution": "Node16",
+        "lib": ["ES2024", "DOM"],
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2024",
         "outDir": "dist",
         "rootDir": "src",
         "skipLibCheck": true,


### PR DESCRIPTION
Raises the minimum supported Node.js version to 22, matching the Crawlee v4 floor. `apify-client` sits below `@crawlee/core`, so its minimum must not be higher than Crawlee's, and there is no reason for it to be lower.

- **`package.json`** — added `engines: { "node": ">=22.0.0" }`.
- **`check.yaml`** — `build_and_test` matrix `[20, 22, 24]` -> `[22, 24, 26]`, so the client is now also tested against Node.js 26. The remaining jobs stay on 24, as Node.js 26 does not become LTS until October 2026.
- **`tsconfig.json`** — dropped the `module: "Node16"` and `moduleResolution` overrides, so the `@apify/tsconfig` base values (`node20`/`nodenext`) apply; `lib` -> `["ES2024", "DOM"]`, `target: "ES2024"`. ES2024 rather than Crawlee's `ESNext`, because Node 22 does not implement ES2025 syntax such as `using`.
- **Docs** — updated `docs/01_introduction/index.md` and `CONTRIBUTING.md`. `website/versioned_docs/version-2/**` is untouched, as it is a frozen v2 snapshot.

Drive-by: `pnpm tsc-check-tests` was already failing on `v3`, mostly with `TS1541` from the old `module: Node16`. Nothing ran it in CI, so it went unnoticed; it is fixed and now part of the `lint` job.

BREAKING CHANGE: Node.js 18 and 20 are no longer supported. The minimum supported version is now Node.js 22.

*✍️ Drafted by Claude Code*
