### PR TITLE
feat: add Actor task publication endpoints

### DIFF
--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -68,49 +68,33 @@ export class TaskClient extends ResourceClient {
     }
 
     /**
-     * Publishes the task on its public landing page.
+     * Publishes the task on its public landing page, by setting `isPublic` through
+     * {@apilink TaskClient.update}.
      *
      * The task's Actor must be public and the task must have its public display configuration
-     * (`publicConfig`) set up via {@apilink TaskClient.update}. Requires write permission to
-     * both the task and its Actor.
-     *
-     * Publishing an already published task is a no-op that returns the current state, so this
-     * call is safe to retry (unlike {@apilink TaskClient.unpublish}).
+     * (`publicConfig`) set up first. Requires write permission to both the task and its Actor.
+     * Publishing an already published task does nothing.
      *
      * @returns The task object.
-     * @see https://docs.apify.com/api/v2/actor-task-publish-post
+     * @see https://docs.apify.com/api/v2/actor-task-put
      */
     async publish(): Promise<Task> {
-        const response = await this.httpClient.call({
-            url: this._url('publish'),
-            method: 'POST',
-            params: this._params(),
-        });
-
-        return cast(parseDateFields(pluckData(response.data)));
+        return this.update({ isPublic: true });
     }
 
     /**
-     * Unpublishes the task from its public landing page.
+     * Unpublishes the task from its public landing page, by setting `isPublic` through
+     * {@apilink TaskClient.update}.
      *
      * The public display configuration (`publicConfig`) is preserved, so the task can be
-     * published again without re-entering it. Requires write permission to both the task
-     * and its Actor.
-     *
-     * Unlike {@apilink TaskClient.publish}, this call is not idempotent: unpublishing a task
-     * that is not currently published throws an `ApifyApiError` (`cannot-unpublish-actor-task`).
+     * published again without re-entering it. Requires write permission to both the task and its
+     * Actor. Unpublishing a task that is not published does nothing.
      *
      * @returns The task object.
-     * @see https://docs.apify.com/api/v2/actor-task-unpublish-post
+     * @see https://docs.apify.com/api/v2/actor-task-put
      */
     async unpublish(): Promise<Task> {
-        const response = await this.httpClient.call({
-            url: this._url('unpublish'),
-            method: 'POST',
-            params: this._params(),
-        });
-
-        return cast(parseDateFields(pluckData(response.data)));
+        return this.update({ isPublic: false });
     }
 
     /**
@@ -339,6 +323,11 @@ export interface Task {
     options?: TaskOptions;
     input?: Dictionary | Dictionary[];
     actorStandby?: Partial<ActorStandby>;
+    /**
+     * Whether the task is published on its public landing page. Derived from
+     * `publicConfig.publishedAt` — set it on update to publish or unpublish the task.
+     */
+    isPublic?: boolean;
     publicConfig?: TaskPublicConfig | null;
 }
 
@@ -380,7 +369,7 @@ export interface TaskOptions {
  * Fields that can be updated when modifying a Task.
  */
 export type TaskUpdateData = Partial<
-    Pick<Task, 'name' | 'title' | 'description' | 'options' | 'input' | 'actorStandby'>
+    Pick<Task, 'name' | 'title' | 'description' | 'options' | 'input' | 'actorStandby' | 'isPublic'>
 > & { publicConfig?: Omit<TaskPublicConfig, 'publishedAt'> };
 
 /**

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -68,6 +68,44 @@ export class TaskClient extends ResourceClient {
     }
 
     /**
+     * Publishes the task on its public landing page.
+     *
+     * The task's Actor must be public and the task must have its public display configuration
+     * (`publicConfig`) set up via {@apilink TaskClient.update}.
+     *
+     * @returns The task object.
+     * @see https://docs.apify.com/api/v2/actor-task-publish-post
+     */
+    async publish(): Promise<Task> {
+        const response = await this.httpClient.call({
+            url: this._url('publish'),
+            method: 'POST',
+            params: this._params(),
+        });
+
+        return cast(parseDateFields(pluckData(response.data)));
+    }
+
+    /**
+     * Unpublishes the task from its public landing page.
+     *
+     * The public display configuration (`publicConfig`) is preserved, so the task can be
+     * published again without re-entering it.
+     *
+     * @returns The task object.
+     * @see https://docs.apify.com/api/v2/actor-task-unpublish-post
+     */
+    async unpublish(): Promise<Task> {
+        const response = await this.httpClient.call({
+            url: this._url('unpublish'),
+            method: 'POST',
+            params: this._params(),
+        });
+
+        return cast(parseDateFields(pluckData(response.data)));
+    }
+
+    /**
      * Deletes the Task.
      *
      * @see https://docs.apify.com/api/v2/actor-task-delete
@@ -293,6 +331,24 @@ export interface Task {
     options?: TaskOptions;
     input?: Dictionary | Dictionary[];
     actorStandby?: Partial<ActorStandby>;
+    publicConfig?: TaskPublicConfig | null;
+}
+
+/**
+ * Public-facing display configuration of a task's public landing page.
+ *
+ * The task is published when `publishedAt` is set and unpublished when it is `null`. The
+ * `publishedAt` field is read-only - use {@apilink TaskClient.publish} and
+ * {@apilink TaskClient.unpublish} to change the publication state.
+ */
+export interface TaskPublicConfig {
+    publishedAt: Date | null;
+    seoTitle?: string | null;
+    seoDescription?: string | null;
+    categorization?: string | null;
+    inputSchemaFields?: string[] | null;
+    datasetName?: string | null;
+    datasetView?: string | null;
 }
 
 /**
@@ -317,12 +373,12 @@ export interface TaskOptions {
  */
 export type TaskUpdateData = Partial<
     Pick<Task, 'name' | 'title' | 'description' | 'options' | 'input' | 'actorStandby'>
->;
+> & { publicConfig?: Omit<TaskPublicConfig, 'publishedAt'> | null };
 
 /**
  * Options for filtering the last run of a Task.
  */
-export interface TaskLastRunOptions extends ActorLastRunOptions {}
+export interface TaskLastRunOptions extends ActorLastRunOptions { }
 
 /**
  * Options for starting a Task.

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -71,7 +71,11 @@ export class TaskClient extends ResourceClient {
      * Publishes the task on its public landing page.
      *
      * The task's Actor must be public and the task must have its public display configuration
-     * (`publicConfig`) set up via {@apilink TaskClient.update}.
+     * (`publicConfig`) set up via {@apilink TaskClient.update}. Requires write permission to
+     * both the task and its Actor.
+     *
+     * Publishing an already published task is a no-op that returns the current state, so this
+     * call is safe to retry (unlike {@apilink TaskClient.unpublish}).
      *
      * @returns The task object.
      * @see https://docs.apify.com/api/v2/actor-task-publish-post
@@ -90,7 +94,11 @@ export class TaskClient extends ResourceClient {
      * Unpublishes the task from its public landing page.
      *
      * The public display configuration (`publicConfig`) is preserved, so the task can be
-     * published again without re-entering it.
+     * published again without re-entering it. Requires write permission to both the task
+     * and its Actor.
+     *
+     * Unlike {@apilink TaskClient.publish}, this call is not idempotent: unpublishing a task
+     * that is not currently published throws an `ApifyApiError` (`cannot-unpublish-actor-task`).
      *
      * @returns The task object.
      * @see https://docs.apify.com/api/v2/actor-task-unpublish-post
@@ -373,7 +381,7 @@ export interface TaskOptions {
  */
 export type TaskUpdateData = Partial<
     Pick<Task, 'name' | 'title' | 'description' | 'options' | 'input' | 'actorStandby'>
-> & { publicConfig?: Omit<TaskPublicConfig, 'publishedAt'> | null };
+> & { publicConfig?: Omit<TaskPublicConfig, 'publishedAt'> };
 
 /**
  * Options for filtering the last run of a Task.

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -378,7 +378,7 @@ export type TaskUpdateData = Partial<
 /**
  * Options for filtering the last run of a Task.
  */
-export interface TaskLastRunOptions extends ActorLastRunOptions { }
+export interface TaskLastRunOptions extends ActorLastRunOptions {}
 
 /**
  * Options for starting a Task.

--- a/test/mock_server/routes/tasks.ts
+++ b/test/mock_server/routes/tasks.ts
@@ -10,8 +10,6 @@ const ROUTES: MockServerRoute[] = [
     { id: 'update-task', method: 'PUT', path: '/:taskId' },
     { id: 'delete-task', method: 'DELETE', path: '/:taskId' },
     { id: 'get-task', method: 'GET', path: '/:taskId' },
-    { id: 'publish-task', method: 'POST', path: '/:taskId/publish' },
-    { id: 'unpublish-task', method: 'POST', path: '/:taskId/unpublish' },
     { id: 'list-runs', method: 'GET', path: '/:taskId/runs' },
     { id: 'run-task', method: 'POST', path: '/:taskId/runs', type: 'responseJsonMock' },
     { id: 'list-webhooks', method: 'GET', path: '/:taskId/webhooks' },

--- a/test/mock_server/routes/tasks.ts
+++ b/test/mock_server/routes/tasks.ts
@@ -10,6 +10,8 @@ const ROUTES: MockServerRoute[] = [
     { id: 'update-task', method: 'PUT', path: '/:taskId' },
     { id: 'delete-task', method: 'DELETE', path: '/:taskId' },
     { id: 'get-task', method: 'GET', path: '/:taskId' },
+    { id: 'publish-task', method: 'POST', path: '/:taskId/publish' },
+    { id: 'unpublish-task', method: 'POST', path: '/:taskId/unpublish' },
     { id: 'list-runs', method: 'GET', path: '/:taskId/runs' },
     { id: 'run-task', method: 'POST', path: '/:taskId/runs', type: 'responseJsonMock' },
     { id: 'list-webhooks', method: 'GET', path: '/:taskId/webhooks' },

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -99,26 +99,26 @@ describe('Task methods', () => {
 
         test('publish() works', async () => {
             const taskId = 'some-task-id';
+            const body = { isPublic: true };
 
             const res = await client.task(taskId).publish();
-            expect(res.id).toEqual('publish-task');
-            validateRequest({ query: {}, params: { taskId } });
+            validateRequest({ query: {}, params: { taskId }, body, endpointId: 'update-task' });
 
             const browserRes = await page.evaluate((id) => client.task(id).publish(), taskId);
             expect(browserRes).toEqual(res);
-            validateRequest({ query: {}, params: { taskId } });
+            validateRequest({ query: {}, params: { taskId }, body });
         });
 
         test('unpublish() works', async () => {
             const taskId = 'some-task-id';
+            const body = { isPublic: false };
 
             const res = await client.task(taskId).unpublish();
-            expect(res.id).toEqual('unpublish-task');
-            validateRequest({ query: {}, params: { taskId } });
+            validateRequest({ query: {}, params: { taskId }, body, endpointId: 'update-task' });
 
             const browserRes = await page.evaluate((id) => client.task(id).unpublish(), taskId);
             expect(browserRes).toEqual(res);
-            validateRequest({ query: {}, params: { taskId } });
+            validateRequest({ query: {}, params: { taskId }, body });
         });
 
         test('get() works', async () => {

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -97,6 +97,30 @@ describe('Task methods', () => {
             validateRequest({ query: {}, params: { taskId } });
         });
 
+        test('publish() works', async () => {
+            const taskId = 'some-task-id';
+
+            const res = await client.task(taskId).publish();
+            expect(res.id).toEqual('publish-task');
+            validateRequest({ query: {}, params: { taskId } });
+
+            const browserRes = await page.evaluate((id) => client.task(id).publish(), taskId);
+            expect(browserRes).toEqual(res);
+            validateRequest({ query: {}, params: { taskId } });
+        });
+
+        test('unpublish() works', async () => {
+            const taskId = 'some-task-id';
+
+            const res = await client.task(taskId).unpublish();
+            expect(res.id).toEqual('unpublish-task');
+            validateRequest({ query: {}, params: { taskId } });
+
+            const browserRes = await page.evaluate((id) => client.task(id).unpublish(), taskId);
+            expect(browserRes).toEqual(res);
+            validateRequest({ query: {}, params: { taskId } });
+        });
+
         test('get() works', async () => {
             const taskId = 'some-id';
 


### PR DESCRIPTION
Part of https://github.com/apify/apify-core/issues/29471

Add ability to publish and un-publish tasks via [new API ](https://github.com/apify/apify-core/pull/29623)

Blocked by https://github.com/apify/apify-core/pull/29623