### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,10 +32,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -53,10 +53,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -71,9 +71,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
@@ -88,10 +88,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Source code
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
             - name: Install pnpm and dependencies
@@ -106,7 +106,7 @@ jobs:
             - name: Run Lychee Link Checker
               id: lychee
               if: github.event_name == 'pull_request'
-              uses: lycheeverse/lychee-action@v2.9.0
+              uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
               with:
                   fail: false
                   args: >
@@ -124,7 +124,7 @@ jobs:
 
             - name: Find Comment
               if: github.event_name == 'pull_request'
-              uses: peter-evans/find-comment@v4
+              uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
               id: find-comment
               with:
                   issue-number: ${{ github.event.pull_request.number }}
@@ -132,7 +132,7 @@ jobs:
 
             - name: Links are passing
               if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code == 0 && steps.find-comment.outputs.comment-id
-              uses: peter-evans/create-or-update-comment@v5
+              uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
               with:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
@@ -144,7 +144,7 @@ jobs:
 
             - name: Links are failing
               if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != 0
-              uses: peter-evans/create-or-update-comment@v5
+              uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
               with:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,12 +18,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -54,15 +54,15 @@ jobs:
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
             - name: Set up GitHub Pages
-              uses: actions/configure-pages@v6
+              uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
             - name: Upload GitHub Pages artifact
-              uses: actions/upload-pages-artifact@v5
+              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
                   path: ./website/build
 
             - name: Deploy artifact to GitHub Pages
-              uses: actions/deploy-pages@v5
+              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
             - name: Invalidate CloudFront cache
               run: |

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -64,7 +64,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@{"message":"Not # master
+              uses: DamianReeves/write-file-action@d4ee8a06aec5db0c57a036b86f2f428e1f8b00e7 # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Wait for code checks to pass
         runs-on: ubuntu-latest
         steps:
-            - uses: lewagon/wait-on-check-action@v1.9.1
+            - uses: lewagon/wait-on-check-action@369769072fe522a3a8a85c03c96af1e5242a1994 # v1.9.1
               with:
                   ref: ${{ github.ref }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,12 +48,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -64,7 +64,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@master
+              uses: DamianReeves/write-file-action@{"message":"Not # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -25,11 +25,11 @@ jobs:
         name: Publish to NPM
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: ${{ inputs.ref }}
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@{"message":"Not # master
+              uses: DamianReeves/write-file-action@d4ee8a06aec5db0c57a036b86f2f428e1f8b00e7 # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,12 +55,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -71,7 +71,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@master
+              uses: DamianReeves/write-file-action@{"message":"Not # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite
@@ -93,7 +93,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - name: Create release
-              uses: softprops/action-gh-release@v3
+              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
               with:
                   tag_name: ${{ needs.release_metadata.outputs.tag_name }}
                   name: ${{ needs.release_metadata.outputs.version_number }}
@@ -117,14 +117,14 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: ${{ github.event.repository.default_branch }}
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                   fetch-depth: 0
 
             - name: Use Node.js
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 

--- a/.github/workflows/update-new-issue.yaml
+++ b/.github/workflows/update-new-issue.yaml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             # Add the "t-tooling" label to all new issues
-            - uses: actions/github-script@v9
+            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       github.rest.issues.addLabels({


### PR DESCRIPTION
This pins every third-party action in the workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

Same change as apify/crawlee#4051, rolled out team-wide. The trigger was the `v11` tag of `EndBug/add-and-commit` moving to a broken release that failed to load and killed the crawlee publish workflow. With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. Where `EndBug/add-and-commit` is used, it's pinned to v11.0.0, the last working release.

Own-org references (`apify/*`) stay on floating refs on purpose, since we control those repos.
