### PR TITLE
chore: remove public-api report from docs team's CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 
 /docs/**/*.md @szaganek
 /docs/**/*.mdx @szaganek
+# exclude public-api reports from technical writer checks
+/docs/public-api/*.md


### PR DESCRIPTION
Related to #1008
