### PR TITLE
chore: support next major canaries and RC releases in the publish workflow

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -9,28 +9,55 @@ const PKG_JSON_PATH = path.join(__dirname, '..', '..', 'package.json');
 const pkgJson = require(PKG_JSON_PATH);
 
 const PACKAGE_NAME = pkgJson.name;
-const VERSION = pkgJson.version;
 
-const nextVersion = addBetaSuffixToVersion(VERSION);
+// The npm dist-tag we publish to is passed as the first CLI argument. A tag
+// ending in `v<major>` (e.g. `next-v3`) marks a pre-major release line:
+// package.json stays on the current major (2.x) and we publish betas of the
+// *next* major (3.0.0-beta.N) under that tag. (The tag isn't a bare `v3`
+// because npm refuses dist-tags that parse as a semver range.)
+// The `rc` tag works the same way but publishes release candidates of the
+// next major (e.g. 3.0.0-rc.N).
+const distTag = process.argv[2];
+const premajorMatch = /v(\d+)$/.exec(distTag ?? '');
+const premajor = premajorMatch ? Number(premajorMatch[1]) : null;
+const preid = distTag === 'rc' ? 'rc' : 'beta';
+
+const nextVersion = computeNextPrereleaseVersion(pkgJson.version, premajor);
 console.log(`before-deploy: Setting version to ${nextVersion}`);
 pkgJson.version = nextVersion;
 
 fs.writeFileSync(PKG_JSON_PATH, `${JSON.stringify(pkgJson, null, 2)}\n`);
 
-function addBetaSuffixToVersion(version) {
-    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
-    const versions = JSON.parse(versionString);
+function computeNextPrereleaseVersion(version, premajorVersion) {
+    const versionsString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
+    const versions = JSON.parse(versionsString);
 
-    if (versions.some((v) => v === version)) {
+    let base = version;
+
+    if (distTag === 'rc') {
+        // Release candidates of the next major: package.json stays on the
+        // current major (e.g. 2.25.1) and we publish 3.0.0-rc.N.
+        const [major] = base.split('.').map(Number);
+        base = `${major + 1}.0.0`;
+    } else if (premajorVersion !== null) {
+        // Pre-major release line: keep package.json on the current major and
+        // publish betas of the next major (e.g. 2.25.1 -> 3.0.0-beta.N). Only
+        // the -beta.N suffix advances between publishes.
+        base = `${premajorVersion}.0.0`;
+    } else if (versions.some((v) => v === base)) {
         console.error(
-            `before-deploy: A release with version ${version} already exists. Please increment version accordingly.`,
+            `before-deploy: A release with version ${base} already exists. Please increment version accordingly.`,
         );
         process.exit(1);
     }
 
+    // Only consider the same pre-release series, so the beta and rc counters
+    // advance independently (3.0.0-rc.N must not push 3.0.0-beta.N forward).
     const prereleaseNumbers = versions
-        .filter((v) => v.startsWith(version) && v.includes('-'))
-        .map((v) => Number(v.match(/\.(\d+)$/)[1]));
+        .filter((v) => v.startsWith(`${base}-${preid}.`))
+        .map((v) => Number(v.match(/\.(\d+)$/)?.[1]))
+        .filter((n) => !Number.isNaN(n));
     const lastPrereleaseNumber = Math.max(-1, ...prereleaseNumbers);
-    return `${version}-beta.${lastPrereleaseNumber + 1}`;
+
+    return `${base}-${preid}.${lastPrereleaseNumber + 1}`;
 }

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,10 +5,11 @@ name: Check
 on:
     pull_request:
 
-    # Push to master will trigger code checks
+    # Push to master or v3 will trigger code checks
     push:
         branches:
             - master
+            - v3
         tags-ignore:
             - '**' # Ignore all tags to prevent duplicate builds when tags are pushed.
 

--- a/.github/workflows/pre_release_next_major.yaml
+++ b/.github/workflows/pre_release_next_major.yaml
@@ -1,0 +1,39 @@
+name: Create a next major pre-release
+
+on:
+    # Push to v3 will deploy a beta version of the next major (3.0.0-beta.N)
+    # under the next-v3 dist-tag. Unlike the pre-releases from master, this
+    # produces no changelog and no commit on the branch.
+    push:
+        branches:
+            - v3
+        tags-ignore:
+            - '**' # Ignore all tags to prevent duplicate builds when tags are pushed.
+
+concurrency:
+    group: release
+    cancel-in-progress: false
+
+jobs:
+    wait_for_checks:
+        if: "!startsWith(github.event.head_commit.message, 'docs') && !startsWith(github.event.head_commit.message, 'ci') && startsWith(github.repository, 'apify/')"
+        name: Wait for code checks to pass
+        runs-on: ubuntu-latest
+        steps:
+            - uses: lewagon/wait-on-check-action@369769072fe522a3a8a85c03c96af1e5242a1994 # v1.9.1
+              with:
+                  ref: ${{ github.ref }}
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  check-regexp: (Build & Test .*|Lint|Docs build)
+                  wait-interval: 5
+
+    publish_to_npm:
+        needs: [wait_for_checks]
+        name: Publish to NPM
+        runs-on: ubuntu-latest
+        steps:
+            - name: Execute publish workflow
+              uses: apify/actions/execute-workflow@v1.4.1
+              with:
+                  workflow: publish_to_npm.yaml
+                  inputs: '{ "ref": "${{ github.sha }}", "tag": "next-v3" }'

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -15,10 +15,12 @@ on:
                 options:
                     - latest
                     - beta
+                    - next-v3
+                    - rc
 
 permissions:
     id-token: write # Required for OIDC
-    contents: read
+    contents: write # Required to push RC git tags
 
 jobs:
     publish_to_npm:
@@ -28,6 +30,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: ${{ inputs.ref }}
+                  token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             - name: Use Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
@@ -35,10 +38,18 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.4.1
-            - name: Check version consistency and bump pre-release version (beta only)
-              if: ${{ inputs.tag == 'beta' }}
-              run: node ./.github/scripts/before-beta-release.js
+            - name: Check version consistency and bump pre-release version (pre-release tags only)
+              if: ${{ inputs.tag != 'latest' }}
+              run: node ./.github/scripts/before-beta-release.js ${{ inputs.tag }}
             - name: Build module
               run: pnpm build
             - name: Publish to NPM
               run: pnpm publish --tag ${{ inputs.tag }} --no-git-checks
+            # RC releases produce no changelog and no commit on the branch, only a git
+            # tag pointing at the released commit (the version bump lives only on npm).
+            - name: Create git tag
+              if: ${{ inputs.tag == 'rc' }}
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  git tag "v$VERSION"
+                  git push origin "refs/tags/v$VERSION"


### PR DESCRIPTION
Adds publishing for the next major line to the `v3` branch, same setup as in apify-sdk-js (apify/apify-sdk-js#698) and crawlee (apify/crawlee#4009).

Automatic canaries: the new `pre_release_next_major.yaml` workflow publishes `3.0.0-beta.N` under the `next-v3` dist-tag on every push to `v3`. Unlike the pre-releases from master, it produces no changelog and no commit; `package.json` stays on the current 2.x version. `check.yaml` now also runs on pushes to `v3` so the publish can wait for the checks.

Manual RC releases: dispatching `publish_to_npm.yaml` with `tag: rc` publishes the next free `3.0.0-rc.N` under the `rc` dist-tag and pushes a `v3.0.0-rc.N` git tag pointing at the released commit. Same as the canaries, no changelog and nothing committed to the branch; the version bump lives only on npm.

`before-beta-release.js` now takes the dist-tag as an argument and derives the version from it: `next-v3` publishes betas of the major named by the tag, `rc` publishes release candidates of the next major, and the plain `beta` flow from master keeps its current behavior. The prerelease counter is scoped per preid (`beta.` vs `rc.`) so the two series advance independently, and the scan no longer matches unrelated versions through the old `startsWith` check (`2.25.1` vs `2.25.10`).

Verified the version math against live npm data: `rc` computes 3.0.0-rc.0, `next-v3` computes 3.0.0-beta.0, `beta` computes 2.25.1-beta.8 (current beta is 2.25.1-beta.7).

Everything lives on the `v3` branch only: push-triggered workflows run from the pushed branch's files, `execute-workflow` dispatches on the caller's ref, and manual dispatches use the file from the branch selected in the run dropdown. `master` needs no changes.
