### PR TITLE
fix!: type the Actor run input on ActorClient and RunClient

### DIFF
--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -166,3 +166,14 @@ Two return types change as a result of describing what the endpoints really retu
 
 - <ApiLink to="class/ScheduleClient#getLog">`ScheduleClient.getLog()`</ApiLink> was typed as a `string`, even though the endpoint returns the log as a list of entries. It's now typed as <ApiLink to="interface/ScheduleInvoked">`ScheduleInvoked[]`</ApiLink>, each entry carrying `message`, `level` and `createdAt`.
 - <ApiLink to="interface/TaskPublicConfig">`TaskPublicConfig`</ApiLink> now follows the specification: `publishedAt` is optional and read-only, and `categorization`, which the specification doesn't describe, is gone from the type.
+
+## Actor run input is no longer `unknown`
+
+<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink> and <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles. To start an Actor without input, omit the argument or pass `undefined`.
+
+```diff
+- await client.actor('my-actor').call(null, { memory: 1024 }); // v2
++ await client.actor('my-actor').call(undefined, { memory: 1024 }); // v3
+```
+
+Nothing changes at runtime. `TaskClient.start()` and `call()` keep taking a `Dictionary`: a task's input overrides are merged into the input saved on the task, so they're always an object.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -169,7 +169,7 @@ Two return types change as a result of describing what the endpoints really retu
 
 ## Actor run input is no longer `unknown`
 
-<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink> and <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles. To start an Actor without input, omit the argument or pass `undefined`.
+<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink> and <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles, and neither does a value typed `unknown`, which has to be narrowed or cast first. To start an Actor without input, omit the argument or pass `undefined`.
 
 ```diff
 - await client.actor('my-actor').call(null, { memory: 1024 }); // v2

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -169,13 +169,24 @@ Two return types change as a result of describing what the endpoints really retu
 
 ## Actor run input is no longer `unknown`
 
-<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> and <ApiLink to="class/RunClient#metamorph">`RunClient.metamorph()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles, and neither does a value typed `unknown`, which has to be narrowed or cast first. To start an Actor without input, omit the argument or pass `undefined`.
+<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> and <ApiLink to="class/RunClient#metamorph">`RunClient.metamorph()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client cannot send.
+
+An input the client serializes to JSON is now typed `ActorInput`, an alias for `object`. A number, a boolean or `null` stops compiling, and so does a value typed `unknown`, which has to be narrowed or cast first. To run an Actor without input, omit the argument or pass `undefined`.
 
 ```diff
 - await client.actor('my-actor').call(null, { memory: 1024 }); // v2
 + await client.actor('my-actor').call(undefined, { memory: 1024 }); // v3
 ```
 
+A body the client passes through untouched is typed `ActorRawInput`, a `string` or a `Buffer`, and each of the four methods takes it through a second overload that also requires `contentType`. In v2 a raw body without a `contentType` compiled, and the API then stored it under the default `application/json; charset=utf-8`, which a form body or a PDF is not:
+
+```diff
+- await client.actor('my-actor').start('some=body'); // v2
++ await client.actor('my-actor').start('some=body', { // v3
++     contentType: 'application/x-www-form-urlencoded',
++ });
+```
+
 `metamorph()`'s `input` is optional now, so `metamorph('target-actor')` compiles where it previously needed an explicit `undefined`.
 
-Nothing changes at runtime. `TaskClient.start()` and `call()` keep taking a `Dictionary`: a task's input overrides are merged into the input saved on the task, so they're always an object.
+Nothing changes at runtime. `TaskClient.start()` and `call()` keep taking a `Dictionary`: a task's input overrides are merged into the input saved on the task, so they are always an object.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -284,20 +284,18 @@ Two options that carried a `@deprecated` marker throughout v2 have been removed.
 
 <ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> and <ApiLink to="class/RunClient#metamorph">`RunClient.metamorph()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client cannot send.
 
-An input the client serializes to JSON is now typed `ActorInput`, an alias for `object`. A number, a boolean or `null` stops compiling, and so does a value typed `unknown`, which has to be narrowed or cast first. To run an Actor without input, omit the argument or pass `undefined`.
+The input is now typed `ActorInput`, an alias for `object`: the client serializes it to JSON, so it is an object or an array. Any other value stops compiling, including a value typed `unknown`, which has to be narrowed or cast first. To run an Actor without input, omit the argument or pass `undefined`.
 
 ```diff
 - await client.actor('my-actor').call(null, { memory: 1024 }); // v2
 + await client.actor('my-actor').call(undefined, { memory: 1024 }); // v3
 ```
 
-A body the client passes through untouched is typed `ActorRawInput`, a `string` or a `Buffer`, and each of the four methods takes it through a second overload that also requires `contentType`. In v2 a raw body without a `contentType` compiled, and the API then stored it under the default `application/json; charset=utf-8`, which a form body or a PDF is not:
+A raw `string` body stops compiling too, with or without a `contentType`. Pass the input as an object and let the client serialize it:
 
 ```diff
-- await client.actor('my-actor').start('some=body'); // v2
-+ await client.actor('my-actor').start('some=body', { // v3
-+     contentType: 'application/x-www-form-urlencoded',
-+ });
+- await client.actor('my-actor').start('some=body', { contentType: 'application/x-www-form-urlencoded' }); // v2
++ await client.actor('my-actor').start({ some: 'body' }); // v3
 ```
 
 `metamorph()`'s `input` is optional now, so `metamorph('target-actor')` compiles where it previously needed an explicit `undefined`.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -284,7 +284,7 @@ Two options that carried a `@deprecated` marker throughout v2 have been removed.
 
 <ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> and <ApiLink to="class/RunClient#metamorph">`RunClient.metamorph()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client cannot send.
 
-The input is now typed `ActorInput`, an alias for `object`: the client serializes it to JSON, so it is an object or an array. Any other value stops compiling, including a value typed `unknown`, which has to be narrowed or cast first. To run an Actor without input, omit the argument or pass `undefined`.
+The input is now typed `ActorInput`, an alias for `object`, so it's an object or an array that the client serializes into the request body. Any other value stops compiling, including a value typed `unknown`, which has to be narrowed or cast first. To run an Actor without input, omit the argument or pass `undefined`.
 
 ```diff
 - await client.actor('my-actor').call(null, { memory: 1024 }); // v2
@@ -297,6 +297,8 @@ A raw `string` body stops compiling too, with or without a `contentType`. Pass t
 - await client.actor('my-actor').start('some=body', { contentType: 'application/x-www-form-urlencoded' }); // v2
 + await client.actor('my-actor').start({ some: 'body' }); // v3
 ```
+
+Dropping the `contentType` sends the body as JSON, so the run's `INPUT` record changes content type with it. To keep the form encoding, pass the object and the option together: the client form-encodes an object whenever `contentType` is `application/x-www-form-urlencoded`.
 
 `metamorph()`'s `input` is optional now, so `metamorph('target-actor')` compiles where it previously needed an explicit `undefined`.
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -169,11 +169,13 @@ Two return types change as a result of describing what the endpoints really retu
 
 ## Actor run input is no longer `unknown`
 
-<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink> and <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles, and neither does a value typed `unknown`, which has to be narrowed or cast first. To start an Actor without input, omit the argument or pass `undefined`.
+<ApiLink to="class/ActorClient#start">`ActorClient.start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, <ApiLink to="class/ActorClient#validateInput">`validateInput()`</ApiLink> and <ApiLink to="class/RunClient#metamorph">`RunClient.metamorph()`</ApiLink> took their `input` as `unknown`, so any value compiled, including ones the client can't send. The parameter is now `ActorInput`, an alias for `object | string`: a JSON-serializable object or array, or a `string` or `Buffer` sent as-is when `contentType` is set. A number, a boolean or `null` no longer compiles, and neither does a value typed `unknown`, which has to be narrowed or cast first. To start an Actor without input, omit the argument or pass `undefined`.
 
 ```diff
 - await client.actor('my-actor').call(null, { memory: 1024 }); // v2
 + await client.actor('my-actor').call(undefined, { memory: 1024 }); // v3
 ```
+
+`metamorph()`'s `input` is optional now, so `metamorph('target-actor')` compiles where it previously needed an explicit `undefined`.
 
 Nothing changes at runtime. `TaskClient.start()` and `call()` keep taking a `Dictionary`: a task's input overrides are merged into the input saved on the task, so they're always an object.

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -89,23 +89,14 @@ export class ActorClient extends ResourceClient {
     build(versionNumber: string, options?: ActorBuildOptions): Promise<Build>;
     builds(): BuildCollectionClient;
     call(input?: ActorInput, options?: ActorCallOptions): Promise<ActorRun>;
-    call(input: ActorRawInput, options: ActorCallOptions & {
-        contentType: string;
-    }): Promise<ActorRun>;
     defaultBuild(options?: BuildClientGetOptions): Promise<BuildClient>;
     delete(): Promise<void>;
     get(): Promise<Actor | undefined>;
     lastRun(options?: ActorLastRunOptions): RunClient;
     runs(): RunCollectionClient;
     start(input?: ActorInput, options?: ActorStartOptions): Promise<ActorRun>;
-    start(input: ActorRawInput, options: ActorStartOptions & {
-        contentType: string;
-    }): Promise<ActorRun>;
     update(newFields: ActorUpdateOptions): Promise<Actor>;
     validateInput(input?: ActorInput, options?: ActorValidateInputOptions): Promise<boolean>;
-    validateInput(input: ActorRawInput, options: ActorValidateInputOptions & {
-        contentType: string;
-    }): Promise<boolean>;
     version(versionNumber: string): ActorVersionClient;
     versions(): ActorVersionCollectionClient;
     webhooks(): WebhookCollectionClient;
@@ -229,9 +220,6 @@ export enum ActorListSortBy {
     // (undocumented)
     LAST_RUN_STARTED_AT = "stats.lastRunStartedAt"
 }
-
-// @public
-export type ActorRawInput = string | Buffer;
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
@@ -3584,9 +3572,6 @@ export class RunClient extends ResourceClient {
     keyValueStore(): KeyValueStoreClient;
     log(): LogClient;
     metamorph(targetActorId: string, input?: ActorInput, options?: RunMetamorphOptions): Promise<ActorRun>;
-    metamorph(targetActorId: string, input: ActorRawInput, options: RunMetamorphOptions & {
-        contentType: string;
-    }): Promise<ActorRun>;
     reboot(): Promise<ActorRun>;
     requestQueue(): RequestQueueClient;
     resurrect(options?: RunResurrectOptions): Promise<ActorRun>;

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -3559,7 +3559,7 @@ export class RunClient extends ResourceClient {
     getStreamedLog(options?: GetStreamedLogOptions): Promise<StreamedLog | undefined>;
     keyValueStore(): KeyValueStoreClient;
     log(): LogClient;
-    metamorph(targetActorId: string, input: unknown, options?: RunMetamorphOptions): Promise<ActorRun>;
+    metamorph(targetActorId: string, input?: ActorInput, options?: RunMetamorphOptions): Promise<ActorRun>;
     reboot(): Promise<ActorRun>;
     requestQueue(): RequestQueueClient;
     resurrect(options?: RunResurrectOptions): Promise<ActorRun>;

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -86,15 +86,15 @@ export class ActorClient extends ResourceClient {
     constructor(options: ApiClientSubResourceOptions);
     build(versionNumber: string, options?: ActorBuildOptions): Promise<Build>;
     builds(): BuildCollectionClient;
-    call(input?: unknown, options?: ActorCallOptions): Promise<ActorRun>;
+    call(input?: ActorInput, options?: ActorCallOptions): Promise<ActorRun>;
     defaultBuild(options?: BuildClientGetOptions): Promise<BuildClient>;
     delete(): Promise<void>;
     get(): Promise<Actor | undefined>;
     lastRun(options?: ActorLastRunOptions): RunClient;
     runs(): RunCollectionClient;
-    start(input?: unknown, options?: ActorStartOptions): Promise<ActorRun>;
+    start(input?: ActorInput, options?: ActorStartOptions): Promise<ActorRun>;
     update(newFields: ActorUpdateOptions): Promise<Actor>;
-    validateInput(input?: unknown, options?: ActorValidateInputOptions): Promise<boolean>;
+    validateInput(input?: ActorInput, options?: ActorValidateInputOptions): Promise<boolean>;
     version(versionNumber: string): ActorVersionClient;
     versions(): ActorVersionCollectionClient;
     webhooks(): WebhookCollectionClient;
@@ -208,6 +208,9 @@ export type ActorEnvVarListResult = Pick<PaginatedList<ActorEnvironmentVariable>
 // @public
 export interface ActorExampleRunInput extends GeneratedExampleRunInput {
 }
+
+// @public
+export type ActorInput = object | string;
 
 // @public
 export interface ActorLastRunOptions {

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -3605,7 +3605,6 @@ export interface RunGetOptions {
 export interface RunMetamorphOptions {
     // (undocumented)
     build?: string;
-    // (undocumented)
     contentType?: string;
 }
 

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -87,14 +87,23 @@ export class ActorClient extends ResourceClient {
     build(versionNumber: string, options?: ActorBuildOptions): Promise<Build>;
     builds(): BuildCollectionClient;
     call(input?: ActorInput, options?: ActorCallOptions): Promise<ActorRun>;
+    call(input: ActorRawInput, options: ActorCallOptions & {
+        contentType: string;
+    }): Promise<ActorRun>;
     defaultBuild(options?: BuildClientGetOptions): Promise<BuildClient>;
     delete(): Promise<void>;
     get(): Promise<Actor | undefined>;
     lastRun(options?: ActorLastRunOptions): RunClient;
     runs(): RunCollectionClient;
     start(input?: ActorInput, options?: ActorStartOptions): Promise<ActorRun>;
+    start(input: ActorRawInput, options: ActorStartOptions & {
+        contentType: string;
+    }): Promise<ActorRun>;
     update(newFields: ActorUpdateOptions): Promise<Actor>;
     validateInput(input?: ActorInput, options?: ActorValidateInputOptions): Promise<boolean>;
+    validateInput(input: ActorRawInput, options: ActorValidateInputOptions & {
+        contentType: string;
+    }): Promise<boolean>;
     version(versionNumber: string): ActorVersionClient;
     versions(): ActorVersionCollectionClient;
     webhooks(): WebhookCollectionClient;
@@ -210,7 +219,7 @@ export interface ActorExampleRunInput extends GeneratedExampleRunInput {
 }
 
 // @public
-export type ActorInput = object | string;
+export type ActorInput = object;
 
 // @public
 export interface ActorLastRunOptions {
@@ -226,6 +235,9 @@ export enum ActorListSortBy {
     // (undocumented)
     LAST_RUN_STARTED_AT = "stats.lastRunStartedAt"
 }
+
+// @public
+export type ActorRawInput = string | Buffer;
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
@@ -3560,6 +3572,9 @@ export class RunClient extends ResourceClient {
     keyValueStore(): KeyValueStoreClient;
     log(): LogClient;
     metamorph(targetActorId: string, input?: ActorInput, options?: RunMetamorphOptions): Promise<ActorRun>;
+    metamorph(targetActorId: string, input: ActorRawInput, options: RunMetamorphOptions & {
+        contentType: string;
+    }): Promise<ActorRun>;
     reboot(): Promise<ActorRun>;
     requestQueue(): RequestQueueClient;
     resurrect(options?: RunResurrectOptions): Promise<ActorRun>;

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -555,8 +555,8 @@ export type ActorUpdateOptions = Partial<
 >;
 
 /**
- * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call} and
- * {@link ActorClient.validateInput}.
+ * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call},
+ * {@link ActorClient.validateInput} and {@link RunClient.metamorph}.
  *
  * Without `contentType` in the options, the input is serialized to JSON, so it is an object or an array.
  * With `contentType`, the input is sent as the request body as-is, so it is a `string` or a `Buffer`.

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -161,8 +161,7 @@ export class ActorClient extends ResourceClient {
      * asynchronously and this method returns immediately without waiting for completion.
      * Use the {@link call} method if you want to wait for the Actor to finish.
      *
-     * @param input - Input for the Actor. A JSON-serializable object or array, or a `string` or `Buffer` sent
-     *                as-is when `contentType` is specified in options. Omit it to run the Actor without input.
+     * @param input - Input for the Actor, serialized to JSON. Omit it to run the Actor without input.
      * @param options - Run configuration options
      * @param options.build - Tag or number of the build to run (e.g., `'beta'` or `'1.2.345'`). If not provided, uses the default build.
      * @param options.memory - Memory in megabytes allocated for the run. If not provided, uses the Actor's default memory setting.
@@ -171,7 +170,6 @@ export class ActorClient extends ResourceClient {
      * @param options.webhooks - Webhooks to trigger when the Actor run reaches a specific state (e.g., `SUCCEEDED`, `FAILED`).
      * @param options.maxItems - Maximum number of dataset items that will be charged (only for pay-per-result Actors).
      * @param options.maxTotalChargeUsd - Maximum cost in USD (only for pay-per-event Actors).
-     * @param options.contentType - Content type of the input. If specified, input must be a string or Buffer.
      * @returns The Actor run object with status, usage, and storage IDs
      * @see https://docs.apify.com/api/v2/act-runs-post
      *
@@ -188,9 +186,38 @@ export class ActorClient extends ResourceClient {
      * );
      * ```
      */
-    async start(input?: ActorInput, options: ActorStartOptions = {}): Promise<ActorRun> {
-        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
-        // arbitrary body, e.g. a PDF buffer.
+    async start(input?: ActorInput, options?: ActorStartOptions): Promise<ActorRun>;
+
+    /**
+     * Starts the Actor with a raw request body and immediately returns the Run object.
+     *
+     * @param input - Body to send as the Actor's `INPUT`, passed through untouched.
+     * @param options - Run configuration options, the same as for an object input
+     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
+     * @returns The Actor run object with status, usage, and storage IDs
+     * @see https://docs.apify.com/api/v2/act-runs-post
+     *
+     * @example
+     * ```javascript
+     * const run = await client.actor('my-actor').start('some=body', {
+     *   contentType: 'application/x-www-form-urlencoded',
+     * });
+     * ```
+     */
+    async start(input: ActorRawInput, options: ActorStartOptions & { contentType: string }): Promise<ActorRun>;
+
+    async start(input?: ActorInput | ActorRawInput, options: ActorStartOptions = {}): Promise<ActorRun> {
+        return this._startRun(input, options);
+    }
+
+    /**
+     * The body behind the {@link start} overloads, also used by {@link call}.
+     */
+    private async _startRun(
+        input: ActorInput | ActorRawInput | undefined,
+        options: ActorStartOptions,
+    ): Promise<ActorRun> {
+        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
         const parsed = parseArgument(options, startOptionsSchema, 'ActorStartOptions');
 
         const {
@@ -242,8 +269,7 @@ export class ActorClient extends ResourceClient {
      * by polling the run status. It optionally streams logs to the console or a custom Log instance.
      * By default, it waits indefinitely unless the `waitSecs` option is provided.
      *
-     * @param input - Input for the Actor. A JSON-serializable object or array, or a `string` or `Buffer` sent
-     *                as-is when `contentType` is specified in options. Omit it to run the Actor without input.
+     * @param input - Input for the Actor, serialized to JSON. Omit it to run the Actor without input.
      * @param options - Run configuration options (extends all options from {@link start})
      * @param options.waitSecs - Maximum time to wait for the run to finish, in seconds. If omitted, waits indefinitely.
      * @param options.log - Log instance for streaming run logs. Use `'default'` for console output, `null` to disable logging, or provide a custom Log instance.
@@ -272,13 +298,32 @@ export class ActorClient extends ResourceClient {
      * const run = await client.actor('my-actor').call({ url: 'https://example.com' }, { log });
      * ```
      */
-    async call(input?: ActorInput, options: ActorCallOptions = {}): Promise<ActorRun> {
-        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
-        // arbitrary body, e.g. a PDF buffer.
+    async call(input?: ActorInput, options?: ActorCallOptions): Promise<ActorRun>;
+
+    /**
+     * Starts the Actor with a raw request body and waits for it to finish before returning the Run object.
+     *
+     * @param input - Body to send as the Actor's `INPUT`, passed through untouched.
+     * @param options - Run configuration options, the same as for an object input
+     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
+     * @returns The finished Actor run object with final status (`SUCCEEDED`, `FAILED`, `ABORTED`, or `TIMED-OUT`)
+     * @see https://docs.apify.com/api/v2/act-runs-post
+     *
+     * @example
+     * ```javascript
+     * const run = await client.actor('my-actor').call('some=body', {
+     *   contentType: 'application/x-www-form-urlencoded',
+     * });
+     * ```
+     */
+    async call(input: ActorRawInput, options: ActorCallOptions & { contentType: string }): Promise<ActorRun>;
+
+    async call(input?: ActorInput | ActorRawInput, options: ActorCallOptions = {}): Promise<ActorRun> {
+        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
         const parsed = parseArgument(options, callOptionsSchema, 'ActorCallOptions');
 
         const { waitSecs, log, ...startOptions } = parsed;
-        const { id } = await this.start(input, startOptions);
+        const { id } = await this._startRun(input, startOptions);
 
         // Calling root client because we need access to top level API.
         // Creating a new instance of RunClient here would only allow
@@ -303,12 +348,10 @@ export class ActorClient extends ResourceClient {
      * invalid, the API responds with an error that is thrown as an `ApifyApiError` describing the
      * validation problem.
      *
-     * @param input - Input to validate against the Actor's input schema. A JSON-serializable object or
-     *                array, or a `string` or `Buffer` sent as-is when `contentType` is specified in options.
+     * @param input - Input to validate against the Actor's input schema, serialized to JSON.
      * @param options - Validation options
      * @param options.build - Tag or number of the build whose input schema the input is validated against
      *                         (e.g., `'latest'` or `'1.2.345'`). If not provided, uses the default build.
-     * @param options.contentType - Content type of the input. If specified, input must be a string or Buffer.
      * @returns `true` if the input is valid. Invalid input causes the underlying API call to throw an `ApifyApiError`.
      * @see https://docs.apify.com/api/v2/act-validate-input-post
      *
@@ -325,9 +368,25 @@ export class ActorClient extends ResourceClient {
      * ```
      * @since Added in 2.24.0
      */
-    async validateInput(input?: ActorInput, options: ActorValidateInputOptions = {}): Promise<boolean> {
-        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
-        // arbitrary body, e.g. a PDF buffer.
+    async validateInput(input?: ActorInput, options?: ActorValidateInputOptions): Promise<boolean>;
+
+    /**
+     * Validates a raw request body against the Actor's input schema.
+     *
+     * @param input - Body to validate, passed through untouched.
+     * @param options - Validation options, the same as for an object input
+     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
+     * @returns `true` if the input is valid. Invalid input causes the underlying API call to throw an `ApifyApiError`.
+     * @see https://docs.apify.com/api/v2/act-validate-input-post
+     * @since Added in 2.24.0
+     */
+    async validateInput(
+        input: ActorRawInput,
+        options: ActorValidateInputOptions & { contentType: string },
+    ): Promise<boolean>;
+
+    async validateInput(input?: ActorInput | ActorRawInput, options: ActorValidateInputOptions = {}): Promise<boolean> {
+        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
         const parsed = parseArgument(options, validateInputOptionsSchema, 'ActorValidateInputOptions');
 
         const request: ApifyRequestConfig = {
@@ -558,10 +617,19 @@ export type ActorUpdateOptions = Partial<
  * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call},
  * {@link ActorClient.validateInput} and {@link RunClient.metamorph}.
  *
- * Without `contentType` in the options, the input is serialized to JSON, so it is an object or an array.
- * With `contentType`, the input is sent as the request body as-is, so it is a `string` or a `Buffer`.
+ * The client serializes it to JSON, so it is an object or an array. To send a body the client should pass
+ * through untouched, use an {@link ActorRawInput} instead.
  */
-export type ActorInput = object | string;
+export type ActorInput = object;
+
+/**
+ * A raw Actor run input, sent as the request body untouched.
+ *
+ * It has to be paired with a `contentType`, which becomes the body's `Content-Type` header and the content
+ * type of the run's `INPUT` record. Without one the API stores the body under the default
+ * `application/json; charset=utf-8`, which a raw body generally is not.
+ */
+export type ActorRawInput = string | Buffer;
 
 export interface ActorStartOptions {
     /**
@@ -571,10 +639,9 @@ export interface ActorStartOptions {
     build?: string;
 
     /**
-     * Content type for the `input`. If not specified,
-     * `input` is expected to be an object that will be stringified to JSON and content type set to
-     * `application/json; charset=utf-8`. If `options.contentType` is specified, then `input` must be a
-     * `String` or `Buffer`.
+     * Content type of the request body, which becomes the content type of the run's `INPUT` record.
+     * Defaults to `application/json; charset=utf-8`, matching the JSON an object input is serialized to.
+     * Required when passing a raw `string` or `Buffer` body.
      */
     contentType?: string;
 
@@ -672,10 +739,9 @@ export interface ActorValidateInputOptions {
     build?: string;
 
     /**
-     * Content type for the `input`. If not specified,
-     * `input` is expected to be an object that will be stringified to JSON and content type set to
-     * `application/json; charset=utf-8`. If `options.contentType` is specified, then `input` must be a
-     * `String` or `Buffer`.
+     * Content type of the request body, which becomes the content type of the run's `INPUT` record.
+     * Defaults to `application/json; charset=utf-8`, matching the JSON an object input is serialized to.
+     * Required when passing a raw `string` or `Buffer` body.
      */
     contentType?: string;
 }

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -186,38 +186,7 @@ export class ActorClient extends ResourceClient {
      * );
      * ```
      */
-    async start(input?: ActorInput, options?: ActorStartOptions): Promise<ActorRun>;
-
-    /**
-     * Starts the Actor with a raw request body and immediately returns the Run object.
-     *
-     * @param input - Body to send as the Actor's `INPUT`, passed through untouched.
-     * @param options - Run configuration options, the same as for an object input
-     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
-     * @returns The Actor run object with status, usage, and storage IDs
-     * @see https://docs.apify.com/api/v2/act-runs-post
-     *
-     * @example
-     * ```javascript
-     * const run = await client.actor('my-actor').start('some=body', {
-     *   contentType: 'application/x-www-form-urlencoded',
-     * });
-     * ```
-     */
-    async start(input: ActorRawInput, options: ActorStartOptions & { contentType: string }): Promise<ActorRun>;
-
-    async start(input?: ActorInput | ActorRawInput, options: ActorStartOptions = {}): Promise<ActorRun> {
-        return this._startRun(input, options);
-    }
-
-    /**
-     * The body behind the {@link start} overloads, also used by {@link call}.
-     */
-    private async _startRun(
-        input: ActorInput | ActorRawInput | undefined,
-        options: ActorStartOptions,
-    ): Promise<ActorRun> {
-        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
+    async start(input?: ActorInput, options: ActorStartOptions = {}): Promise<ActorRun> {
         const parsed = parseArgument(options, startOptionsSchema, 'ActorStartOptions');
 
         const {
@@ -298,32 +267,11 @@ export class ActorClient extends ResourceClient {
      * const run = await client.actor('my-actor').call({ url: 'https://example.com' }, { log });
      * ```
      */
-    async call(input?: ActorInput, options?: ActorCallOptions): Promise<ActorRun>;
-
-    /**
-     * Starts the Actor with a raw request body and waits for it to finish before returning the Run object.
-     *
-     * @param input - Body to send as the Actor's `INPUT`, passed through untouched.
-     * @param options - Run configuration options, the same as for an object input
-     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
-     * @returns The finished Actor run object with final status (`SUCCEEDED`, `FAILED`, `ABORTED`, or `TIMED-OUT`)
-     * @see https://docs.apify.com/api/v2/act-runs-post
-     *
-     * @example
-     * ```javascript
-     * const run = await client.actor('my-actor').call('some=body', {
-     *   contentType: 'application/x-www-form-urlencoded',
-     * });
-     * ```
-     */
-    async call(input: ActorRawInput, options: ActorCallOptions & { contentType: string }): Promise<ActorRun>;
-
-    async call(input?: ActorInput | ActorRawInput, options: ActorCallOptions = {}): Promise<ActorRun> {
-        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
+    async call(input?: ActorInput, options: ActorCallOptions = {}): Promise<ActorRun> {
         const parsed = parseArgument(options, callOptionsSchema, 'ActorCallOptions');
 
         const { waitSecs, log, ...startOptions } = parsed;
-        const { id } = await this._startRun(input, startOptions);
+        const { id } = await this.start(input, startOptions);
 
         // Calling root client because we need access to top level API.
         // Creating a new instance of RunClient here would only allow
@@ -368,25 +316,7 @@ export class ActorClient extends ResourceClient {
      * ```
      * @since Added in 2.24.0
      */
-    async validateInput(input?: ActorInput, options?: ActorValidateInputOptions): Promise<boolean>;
-
-    /**
-     * Validates a raw request body against the Actor's input schema.
-     *
-     * @param input - Body to validate, passed through untouched.
-     * @param options - Validation options, the same as for an object input
-     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
-     * @returns `true` if the input is valid. Invalid input causes the underlying API call to throw an `ApifyApiError`.
-     * @see https://docs.apify.com/api/v2/act-validate-input-post
-     * @since Added in 2.24.0
-     */
-    async validateInput(
-        input: ActorRawInput,
-        options: ActorValidateInputOptions & { contentType: string },
-    ): Promise<boolean>;
-
-    async validateInput(input?: ActorInput | ActorRawInput, options: ActorValidateInputOptions = {}): Promise<boolean> {
-        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
+    async validateInput(input?: ActorInput, options: ActorValidateInputOptions = {}): Promise<boolean> {
         const parsed = parseArgument(options, validateInputOptionsSchema, 'ActorValidateInputOptions');
 
         const request: ApifyRequestConfig = {
@@ -617,19 +547,9 @@ export type ActorUpdateOptions = Partial<
  * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call},
  * {@link ActorClient.validateInput} and {@link RunClient.metamorph}.
  *
- * The client serializes it to JSON, so it is an object or an array. To send a body the client should pass
- * through untouched, use an {@link ActorRawInput} instead.
+ * The client serializes it to JSON, so it is an object or an array.
  */
 export type ActorInput = object;
-
-/**
- * A raw Actor run input, sent as the request body untouched.
- *
- * It has to be paired with a `contentType`, which becomes the body's `Content-Type` header and the content
- * type of the run's `INPUT` record. Without one the API stores the body under the default
- * `application/json; charset=utf-8`, which a raw body generally is not.
- */
-export type ActorRawInput = string | Buffer;
 
 export interface ActorStartOptions {
     /**
@@ -640,8 +560,7 @@ export interface ActorStartOptions {
 
     /**
      * Content type of the request body, which becomes the content type of the run's `INPUT` record.
-     * Defaults to `application/json; charset=utf-8`, matching the JSON an object input is serialized to.
-     * Required when passing a raw `string` or `Buffer` body.
+     * Defaults to `application/json; charset=utf-8`, matching the JSON the input is serialized to.
      */
     contentType?: string;
 
@@ -740,8 +659,7 @@ export interface ActorValidateInputOptions {
 
     /**
      * Content type of the request body, which becomes the content type of the run's `INPUT` record.
-     * Defaults to `application/json; charset=utf-8`, matching the JSON an object input is serialized to.
-     * Required when passing a raw `string` or `Buffer` body.
+     * Defaults to `application/json; charset=utf-8`, matching the JSON the input is serialized to.
      */
     contentType?: string;
 }

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -547,7 +547,8 @@ export type ActorUpdateOptions = Partial<
  * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call},
  * {@link ActorClient.validateInput} and {@link RunClient.metamorph}.
  *
- * The client serializes it to JSON, so it is an object or an array.
+ * An object or an array. Declared as `object` rather than an index-signature type such as
+ * `Dictionary`, which would reject a caller's own `interface`.
  */
 export type ActorInput = object;
 
@@ -560,7 +561,8 @@ export interface ActorStartOptions {
 
     /**
      * Content type of the request body, which becomes the content type of the run's `INPUT` record.
-     * Defaults to `application/json; charset=utf-8`, matching the JSON the input is serialized to.
+     * Without it, an input is serialized to JSON and sent as `application/json`. Pairing an object
+     * with `application/x-www-form-urlencoded` form-encodes it instead.
      */
     contentType?: string;
 
@@ -658,8 +660,9 @@ export interface ActorValidateInputOptions {
     build?: string;
 
     /**
-     * Content type of the request body, which becomes the content type of the run's `INPUT` record.
-     * Defaults to `application/json; charset=utf-8`, matching the JSON the input is serialized to.
+     * Content type of the request body carrying the input to validate. Without it, the input is
+     * serialized to JSON and sent as `application/json`. Pairing an object with
+     * `application/x-www-form-urlencoded` form-encodes it instead.
      */
     contentType?: string;
 }

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -161,8 +161,8 @@ export class ActorClient extends ResourceClient {
      * asynchronously and this method returns immediately without waiting for completion.
      * Use the {@link call} method if you want to wait for the Actor to finish.
      *
-     * @param input - Input for the Actor. Can be any JSON-serializable value (object, array, string, number).
-     *                If `contentType` is specified in options, input should be a string or Buffer.
+     * @param input - Input for the Actor. A JSON-serializable object or array, or a `string` or `Buffer` sent
+     *                as-is when `contentType` is specified in options. Omit it to run the Actor without input.
      * @param options - Run configuration options
      * @param options.build - Tag or number of the build to run (e.g., `'beta'` or `'1.2.345'`). If not provided, uses the default build.
      * @param options.memory - Memory in megabytes allocated for the run. If not provided, uses the Actor's default memory setting.
@@ -188,9 +188,9 @@ export class ActorClient extends ResourceClient {
      * );
      * ```
      */
-    async start(input?: unknown, options: ActorStartOptions = {}): Promise<ActorRun> {
-        // input can be anything, so no point in validating it. E.g. if you set content-type to application/pdf
-        // then it will process input as a buffer.
+    async start(input?: ActorInput, options: ActorStartOptions = {}): Promise<ActorRun> {
+        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
+        // arbitrary body, e.g. a PDF buffer.
         const parsed = parseArgument(options, startOptionsSchema, 'ActorStartOptions');
 
         const {
@@ -242,8 +242,8 @@ export class ActorClient extends ResourceClient {
      * by polling the run status. It optionally streams logs to the console or a custom Log instance.
      * By default, it waits indefinitely unless the `waitSecs` option is provided.
      *
-     * @param input - Input for the Actor. Can be any JSON-serializable value (object, array, string, number).
-     *                If `contentType` is specified in options, input should be a string or Buffer.
+     * @param input - Input for the Actor. A JSON-serializable object or array, or a `string` or `Buffer` sent
+     *                as-is when `contentType` is specified in options. Omit it to run the Actor without input.
      * @param options - Run configuration options (extends all options from {@link start})
      * @param options.waitSecs - Maximum time to wait for the run to finish, in seconds. If omitted, waits indefinitely.
      * @param options.log - Log instance for streaming run logs. Use `'default'` for console output, `null` to disable logging, or provide a custom Log instance.
@@ -272,9 +272,9 @@ export class ActorClient extends ResourceClient {
      * const run = await client.actor('my-actor').call({ url: 'https://example.com' }, { log });
      * ```
      */
-    async call(input?: unknown, options: ActorCallOptions = {}): Promise<ActorRun> {
-        // input can be anything, so no point in validating it. E.g. if you set content-type to application/pdf
-        // then it will process input as a buffer.
+    async call(input?: ActorInput, options: ActorCallOptions = {}): Promise<ActorRun> {
+        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
+        // arbitrary body, e.g. a PDF buffer.
         const parsed = parseArgument(options, callOptionsSchema, 'ActorCallOptions');
 
         const { waitSecs, log, ...startOptions } = parsed;
@@ -303,9 +303,8 @@ export class ActorClient extends ResourceClient {
      * invalid, the API responds with an error that is thrown as an `ApifyApiError` describing the
      * validation problem.
      *
-     * @param input - Input to validate against the Actor's input schema. Can be any JSON-serializable
-     *                value (object, array, string, number). If `contentType` is specified in options,
-     *                input should be a string or Buffer.
+     * @param input - Input to validate against the Actor's input schema. A JSON-serializable object or
+     *                array, or a `string` or `Buffer` sent as-is when `contentType` is specified in options.
      * @param options - Validation options
      * @param options.build - Tag or number of the build whose input schema the input is validated against
      *                         (e.g., `'latest'` or `'1.2.345'`). If not provided, uses the default build.
@@ -326,9 +325,9 @@ export class ActorClient extends ResourceClient {
      * ```
      * @since Added in 2.24.0
      */
-    async validateInput(input?: unknown, options: ActorValidateInputOptions = {}): Promise<boolean> {
-        // input can be anything, so no point in validating it. E.g. if you set content-type to application/pdf
-        // then it will process input as a buffer.
+    async validateInput(input?: ActorInput, options: ActorValidateInputOptions = {}): Promise<boolean> {
+        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
+        // arbitrary body, e.g. a PDF buffer.
         const parsed = parseArgument(options, validateInputOptionsSchema, 'ActorValidateInputOptions');
 
         const request: ApifyRequestConfig = {
@@ -554,6 +553,15 @@ export type ActorUpdateOptions = Partial<
         | 'taggedBuilds'
     >
 >;
+
+/**
+ * Input for an Actor run, as taken by {@link ActorClient.start}, {@link ActorClient.call} and
+ * {@link ActorClient.validateInput}.
+ *
+ * Without `contentType` in the options, the input is serialized to JSON, so it is an object or an array.
+ * With `contentType`, the input is sent as the request body as-is, so it is a `string` or a `Buffer`.
+ */
+export type ActorInput = object | string;
 
 export interface ActorStartOptions {
     /**

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -9,7 +9,7 @@ import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyResponse } from '../http_client.js';
 import * as schemas from '../schemas.js';
 import { anyObjectSchema, isNode, parseArgument, parseResponse } from '../utils.js';
-import type { ActorInput, ActorRawInput, ActorRun } from './actor.js';
+import type { ActorInput, ActorRun } from './actor.js';
 import { DatasetClient } from './dataset.js';
 import { KeyValueStoreClient } from './key_value_store.js';
 import { LogClient, LoggerActorRedirect, StreamedLog } from './log.js';
@@ -160,31 +160,8 @@ export class RunClient extends ResourceClient {
      * console.log(`Run ${metamorphedRun.id} is now running ${metamorphedRun.actId}`);
      * ```
      */
-    async metamorph(targetActorId: string, input?: ActorInput, options?: RunMetamorphOptions): Promise<ActorRun>;
-
-    /**
-     * Transforms the Actor run into a run of another Actor with a raw request body as its input.
-     *
-     * @param targetActorId - ID or username/name of the target Actor
-     * @param input - Body to send as the target Actor's `INPUT`, passed through untouched.
-     * @param options - Metamorph options, the same as for an object input
-     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
-     * @returns The metamorphed ActorRun object (same ID, but now running the target Actor)
-     * @see https://docs.apify.com/api/v2/actor-run-metamorph-post
-     */
-    async metamorph(
-        targetActorId: string,
-        input: ActorRawInput,
-        options: RunMetamorphOptions & { contentType: string },
-    ): Promise<ActorRun>;
-
-    async metamorph(
-        targetActorId: string,
-        input?: ActorInput | ActorRawInput,
-        options: RunMetamorphOptions = {},
-    ): Promise<ActorRun> {
+    async metamorph(targetActorId: string, input?: ActorInput, options: RunMetamorphOptions = {}): Promise<ActorRun> {
         parseArgument(targetActorId, targetActorIdSchema);
-        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
         const parsed = parseArgument(options, metamorphOptionsSchema, 'RunMetamorphOptions');
 
         const safeTargetActorId = this._toSafeId(targetActorId);

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -9,7 +9,7 @@ import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyResponse } from '../http_client.js';
 import * as schemas from '../schemas.js';
 import { anyObjectSchema, isNode, parseArgument, parseResponse } from '../utils.js';
-import type { ActorInput, ActorRun } from './actor.js';
+import type { ActorInput, ActorRawInput, ActorRun } from './actor.js';
 import { DatasetClient } from './dataset.js';
 import { KeyValueStoreClient } from './key_value_store.js';
 import { LogClient, LoggerActorRedirect, StreamedLog } from './log.js';
@@ -144,11 +144,9 @@ export class RunClient extends ResourceClient {
      * This is useful for chaining Actor executions or implementing complex workflows.
      *
      * @param targetActorId - ID or username/name of the target Actor
-     * @param input - Input for the target Actor. A JSON-serializable object or array, or a `string` or `Buffer`
-     *                sent as-is when `contentType` is specified in options. Omit it to metamorph without input.
+     * @param input - Input for the target Actor, serialized to JSON. Omit it to metamorph without input.
      * @param options - Metamorph options
      * @param options.build - Tag or number of the target Actor's build to run. Default is the target Actor's default build.
-     * @param options.contentType - Content type of the input. If specified, input must be a string or Buffer.
      * @returns The metamorphed ActorRun object (same ID, but now running the target Actor)
      * @see https://docs.apify.com/api/v2/actor-run-metamorph-post
      *
@@ -162,10 +160,31 @@ export class RunClient extends ResourceClient {
      * console.log(`Run ${metamorphedRun.id} is now running ${metamorphedRun.actId}`);
      * ```
      */
-    async metamorph(targetActorId: string, input?: ActorInput, options: RunMetamorphOptions = {}): Promise<ActorRun> {
+    async metamorph(targetActorId: string, input?: ActorInput, options?: RunMetamorphOptions): Promise<ActorRun>;
+
+    /**
+     * Transforms the Actor run into a run of another Actor with a raw request body as its input.
+     *
+     * @param targetActorId - ID or username/name of the target Actor
+     * @param input - Body to send as the target Actor's `INPUT`, passed through untouched.
+     * @param options - Metamorph options, the same as for an object input
+     * @param options.contentType - Content type of the body, e.g. `'application/pdf'`. Required for a raw body.
+     * @returns The metamorphed ActorRun object (same ID, but now running the target Actor)
+     * @see https://docs.apify.com/api/v2/actor-run-metamorph-post
+     */
+    async metamorph(
+        targetActorId: string,
+        input: ActorRawInput,
+        options: RunMetamorphOptions & { contentType: string },
+    ): Promise<ActorRun>;
+
+    async metamorph(
+        targetActorId: string,
+        input?: ActorInput | ActorRawInput,
+        options: RunMetamorphOptions = {},
+    ): Promise<ActorRun> {
         parseArgument(targetActorId, targetActorIdSchema);
-        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
-        // arbitrary body, e.g. a PDF buffer.
+        // The API validates the input, and with a custom `contentType` it is an arbitrary body.
         const parsed = parseArgument(options, metamorphOptionsSchema, 'RunMetamorphOptions');
 
         const safeTargetActorId = this._toSafeId(targetActorId);

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -497,6 +497,11 @@ export interface RunAbortOptions {
  * Options for metamorphing a Run into another Actor.
  */
 export interface RunMetamorphOptions {
+    /**
+     * Content type of the request body, which becomes the content type of the run's `INPUT` record.
+     * Without it, an input is serialized to JSON and sent as `application/json`. Pairing an object
+     * with `application/x-www-form-urlencoded` form-encodes it instead.
+     */
     contentType?: string;
     build?: string;
 }

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -9,7 +9,7 @@ import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyResponse } from '../http_client.js';
 import * as schemas from '../schemas.js';
 import { anyObjectSchema, isNode, parseArgument, parseResponse } from '../utils.js';
-import type { ActorRun } from './actor.js';
+import type { ActorInput, ActorRun } from './actor.js';
 import { DatasetClient } from './dataset.js';
 import { KeyValueStoreClient } from './key_value_store.js';
 import { LogClient, LoggerActorRedirect, StreamedLog } from './log.js';
@@ -144,7 +144,8 @@ export class RunClient extends ResourceClient {
      * This is useful for chaining Actor executions or implementing complex workflows.
      *
      * @param targetActorId - ID or username/name of the target Actor
-     * @param input - Input for the target Actor. Can be any JSON-serializable value.
+     * @param input - Input for the target Actor. A JSON-serializable object or array, or a `string` or `Buffer`
+     *                sent as-is when `contentType` is specified in options. Omit it to metamorph without input.
      * @param options - Metamorph options
      * @param options.build - Tag or number of the target Actor's build to run. Default is the target Actor's default build.
      * @param options.contentType - Content type of the input. If specified, input must be a string or Buffer.
@@ -161,9 +162,10 @@ export class RunClient extends ResourceClient {
      * console.log(`Run ${metamorphedRun.id} is now running ${metamorphedRun.actId}`);
      * ```
      */
-    async metamorph(targetActorId: string, input: unknown, options: RunMetamorphOptions = {}): Promise<ActorRun> {
+    async metamorph(targetActorId: string, input?: ActorInput, options: RunMetamorphOptions = {}): Promise<ActorRun> {
         parseArgument(targetActorId, targetActorIdSchema);
-        // input can be anything, pointless to validate
+        // The input is not validated here: the API validates it, and with a custom `contentType` it is an
+        // arbitrary body, e.g. a PDF buffer.
         const parsed = parseArgument(options, metamorphOptionsSchema, 'RunMetamorphOptions');
 
         const safeTargetActorId = this._toSafeId(targetActorId);

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -202,6 +202,31 @@ describe('Actor methods', () => {
             });
         });
 
+        test('start() encodes the input for a non-JSON contentType', async () => {
+            const actorId = 'some-id';
+            const contentType = 'application/x-www-form-urlencoded';
+            const input = { some: 'body' };
+
+            const res = await client.actor(actorId).start(input, { contentType });
+            expect(res.id).toEqual('run-actor');
+            // The mock server parses the form-encoded body back into an object.
+            validateRequest({
+                params: { actorId },
+                body: { some: 'body' },
+                additionalHeaders: { 'content-type': contentType },
+            });
+
+            const browserRes = await page.evaluate((id, i, opts) => client.actor(id).start(i, opts), actorId, input, {
+                contentType,
+            });
+            expect(browserRes).toEqual(asBrowserResult(res));
+            validateRequest({
+                params: { actorId },
+                body: { some: 'body' },
+                additionalHeaders: { 'content-type': contentType },
+            });
+        });
+
         test('start() works with functions in input', async () => {
             const actorId = 'some-id';
             const input = {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import type { ActorCollectionCreateOptions, ActorCollectionListOptions, ActorInput, ActorVersion } from 'apify-client';
+import type { ActorCollectionCreateOptions, ActorCollectionListOptions, ActorVersion } from 'apify-client';
 import {
     ActorListSortBy,
     ActorSourceType,
@@ -14,7 +14,7 @@ import {
 } from 'apify-client';
 import express from 'express';
 import type { Page } from 'puppeteer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { META_ORIGINS, WEBHOOK_EVENT_TYPES } from '@apify/consts';
 import { LEVELS, Log } from '@apify/log';
@@ -442,34 +442,6 @@ describe('Actor methods', () => {
 
             // Reset the shared mock response so the 404 status does not leak into later tests.
             mockServer.setResponse(null);
-        });
-
-        test('an object input needs no contentType, a raw body does not compile without one', () => {
-            // A user's own interface has to stay assignable, which a `Record`-based input type would not allow.
-            interface UserInput {
-                url: string;
-            }
-
-            expectTypeOf<UserInput>().toExtend<ActorInput>();
-            expectTypeOf<UserInput[]>().toExtend<ActorInput>();
-            expectTypeOf<unknown>().not.toExtend<ActorInput>();
-
-            const actor = client.actor('some-id');
-
-            expectTypeOf(actor.start).toBeCallableWith();
-            expectTypeOf(actor.start).toBeCallableWith({ url: 'https://example.com' } satisfies UserInput);
-            expectTypeOf(actor.call).toBeCallableWith({ url: 'https://example.com' }, { waitSecs: 10 });
-            expectTypeOf(actor.start).toBeCallableWith('some=body', {
-                contentType: 'application/x-www-form-urlencoded',
-            });
-            expectTypeOf(actor.start).toBeCallableWith(Buffer.from('some body'), { contentType: 'application/pdf' });
-
-            // @ts-expect-error a raw body has to be paired with a contentType
-            expectTypeOf(actor.start).toBeCallableWith('some=body');
-            // @ts-expect-error a raw body has to be paired with a contentType
-            expectTypeOf(actor.call).toBeCallableWith('some=body', { memory: 512 });
-            // @ts-expect-error a raw body has to be paired with a contentType
-            expectTypeOf(actor.validateInput).toBeCallableWith(JSON.stringify({ url: 'https://example.com' }));
         });
 
         test('build() works', async () => {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -3,11 +3,11 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import type { ActorCollectionCreateOptions } from 'apify-client';
+import type { ActorCollectionCreateOptions, ActorInput } from 'apify-client';
 import { ActorListSortBy, ActorSourceType, ApifyClient, LoggerActorRedirect } from 'apify-client';
 import express from 'express';
 import type { Page } from 'puppeteer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import { META_ORIGINS, WEBHOOK_EVENT_TYPES } from '@apify/consts';
 import { LEVELS, Log } from '@apify/log';
@@ -432,6 +432,21 @@ describe('Actor methods', () => {
 
             // Reset the shared mock response so the 404 status does not leak into later tests.
             mockServer.setResponse(null);
+        });
+
+        test('start(), call() and validateInput() take the same input type', () => {
+            const actor = client.actor('some-id');
+            expectTypeOf(actor.start).parameter(0).toEqualTypeOf<ActorInput | undefined>();
+            expectTypeOf(actor.call).parameter(0).toEqualTypeOf<ActorInput | undefined>();
+            expectTypeOf(actor.validateInput).parameter(0).toEqualTypeOf<ActorInput | undefined>();
+
+            expectTypeOf<{ url: string }>().toExtend<ActorInput>();
+            expectTypeOf<string[]>().toExtend<ActorInput>();
+            expectTypeOf<string>().toExtend<ActorInput>();
+            expectTypeOf<Buffer>().toExtend<ActorInput>();
+            expectTypeOf<number>().not.toExtend<ActorInput>();
+            expectTypeOf<boolean>().not.toExtend<ActorInput>();
+            expectTypeOf<null>().not.toExtend<ActorInput>();
         });
 
         test('build() works', async () => {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -434,26 +434,32 @@ describe('Actor methods', () => {
             mockServer.setResponse(null);
         });
 
-        test('start(), call() and validateInput() take the same input type', () => {
-            // An interface gets no implicit index signature, so a `Record`-based input type rejects it.
+        test('an object input needs no contentType, a raw body does not compile without one', () => {
+            // A user's own interface has to stay assignable, which a `Record`-based input type would not allow.
             interface UserInput {
                 url: string;
             }
 
-            const actor = client.actor('some-id');
-            expectTypeOf(actor.start).parameter(0).toEqualTypeOf<ActorInput | undefined>();
-            expectTypeOf(actor.call).parameter(0).toEqualTypeOf<ActorInput | undefined>();
-            expectTypeOf(actor.validateInput).parameter(0).toEqualTypeOf<ActorInput | undefined>();
-
-            expectTypeOf<{ url: string }>().toExtend<ActorInput>();
             expectTypeOf<UserInput>().toExtend<ActorInput>();
-            expectTypeOf<string[]>().toExtend<ActorInput>();
-            expectTypeOf<string>().toExtend<ActorInput>();
-            expectTypeOf<Buffer>().toExtend<ActorInput>();
-            expectTypeOf<number>().not.toExtend<ActorInput>();
-            expectTypeOf<boolean>().not.toExtend<ActorInput>();
-            expectTypeOf<null>().not.toExtend<ActorInput>();
+            expectTypeOf<UserInput[]>().toExtend<ActorInput>();
             expectTypeOf<unknown>().not.toExtend<ActorInput>();
+
+            const actor = client.actor('some-id');
+
+            expectTypeOf(actor.start).toBeCallableWith();
+            expectTypeOf(actor.start).toBeCallableWith({ url: 'https://example.com' } satisfies UserInput);
+            expectTypeOf(actor.call).toBeCallableWith({ url: 'https://example.com' }, { waitSecs: 10 });
+            expectTypeOf(actor.start).toBeCallableWith('some=body', {
+                contentType: 'application/x-www-form-urlencoded',
+            });
+            expectTypeOf(actor.start).toBeCallableWith(Buffer.from('some body'), { contentType: 'application/pdf' });
+
+            // @ts-expect-error a raw body has to be paired with a contentType
+            expectTypeOf(actor.start).toBeCallableWith('some=body');
+            // @ts-expect-error a raw body has to be paired with a contentType
+            expectTypeOf(actor.call).toBeCallableWith('some=body', { memory: 512 });
+            // @ts-expect-error a raw body has to be paired with a contentType
+            expectTypeOf(actor.validateInput).toBeCallableWith(JSON.stringify({ url: 'https://example.com' }));
         });
 
         test('build() works', async () => {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -156,8 +156,7 @@ describe('Actor methods', () => {
 
         test('start() works', async () => {
             const actorId = 'some-id';
-            const contentType = 'application/x-www-form-urlencoded';
-            const input = 'some=body';
+            const input = { some: 'body' };
 
             const query = {
                 timeout: 120,
@@ -165,32 +164,24 @@ describe('Actor methods', () => {
                 build: '1.2.0',
             };
 
-            const res = await client.actor(actorId).start(input, { contentType, ...query });
+            const res = await client.actor(actorId).start(input, query);
             expect(res.id).toEqual('run-actor');
-            validateRequest({
-                query,
-                params: { actorId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
-            });
+            validateRequest({ query, params: { actorId }, body: input });
 
-            const browserRes = await page.evaluate((id, i, opts) => client.actor(id).start(i, opts), actorId, input, {
-                contentType,
-                ...query,
-            });
-            expect(browserRes).toEqual(asBrowserResult(res));
-            validateRequest({
+            const browserRes = await page.evaluate(
+                (id, i, opts) => client.actor(id).start(i, opts),
+                actorId,
+                input,
                 query,
-                params: { actorId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
-            });
+            );
+            expect(browserRes).toEqual(asBrowserResult(res));
+            validateRequest({ query, params: { actorId }, body: input });
         });
 
-        test('start() works with pre-stringified JSON', async () => {
+        test('start() passes contentType through as the request header', async () => {
             const actorId = 'some-id';
             const contentType = 'application/json; charset=utf-8';
-            const input = JSON.stringify({ some: 'body' });
+            const input = { some: 'body' };
 
             const res = await client.actor(actorId).start(input, { contentType });
             expect(res.id).toEqual('run-actor');
@@ -278,8 +269,7 @@ describe('Actor methods', () => {
 
         test('call() works', async () => {
             const actorId = 'some-id';
-            const contentType = 'application/x-www-form-urlencoded';
-            const input = 'some=body';
+            const input = { some: 'body' };
             const timeout = 120;
             const memory = 256;
             const build = '1.2.0';
@@ -290,7 +280,6 @@ describe('Actor methods', () => {
 
             mockServer.setResponse({ body });
             const res = await client.actor(actorId).call(input, {
-                contentType,
                 memory,
                 timeout,
                 build,
@@ -307,8 +296,7 @@ describe('Actor methods', () => {
                     build,
                 },
                 params: { actorId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
+                body: input,
             });
 
             const callBrowserRes = await page.evaluate(
@@ -316,7 +304,6 @@ describe('Actor methods', () => {
                 actorId,
                 input,
                 {
-                    contentType,
                     memory,
                     timeout,
                     build,
@@ -332,8 +319,7 @@ describe('Actor methods', () => {
                     build,
                 },
                 params: { actorId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
+                body: input,
             });
         });
 

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -435,18 +435,25 @@ describe('Actor methods', () => {
         });
 
         test('start(), call() and validateInput() take the same input type', () => {
+            // An interface gets no implicit index signature, so a `Record`-based input type rejects it.
+            interface UserInput {
+                url: string;
+            }
+
             const actor = client.actor('some-id');
             expectTypeOf(actor.start).parameter(0).toEqualTypeOf<ActorInput | undefined>();
             expectTypeOf(actor.call).parameter(0).toEqualTypeOf<ActorInput | undefined>();
             expectTypeOf(actor.validateInput).parameter(0).toEqualTypeOf<ActorInput | undefined>();
 
             expectTypeOf<{ url: string }>().toExtend<ActorInput>();
+            expectTypeOf<UserInput>().toExtend<ActorInput>();
             expectTypeOf<string[]>().toExtend<ActorInput>();
             expectTypeOf<string>().toExtend<ActorInput>();
             expectTypeOf<Buffer>().toExtend<ActorInput>();
             expectTypeOf<number>().not.toExtend<ActorInput>();
             expectTypeOf<boolean>().not.toExtend<ActorInput>();
             expectTypeOf<null>().not.toExtend<ActorInput>();
+            expectTypeOf<unknown>().not.toExtend<ActorInput>();
         });
 
         test('build() works', async () => {

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -2,9 +2,10 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout as setTimeoutNode } from 'node:timers/promises';
 
 import c from 'ansi-colors';
+import type { ActorInput } from 'apify-client';
 import { ApifyClient, ArgumentValidationError } from 'apify-client';
 import type { Page } from 'puppeteer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import { DEFAULT_OPTIONS, asBrowserResult, Browser, validateRequest } from './_helper.js';
 import * as fixtures from './mock_server/fixtures.js';
@@ -278,6 +279,10 @@ describe('Run methods', () => {
             );
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest(expectedRequest);
+        });
+
+        test('metamorph() takes the same input type as the Actor run methods', () => {
+            expectTypeOf(client.run('some-run-id').metamorph).parameter(1).toEqualTypeOf<ActorInput | undefined>();
         });
 
         test('reboot() works', async () => {

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -2,7 +2,6 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout as setTimeoutNode } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import type { ActorInput } from 'apify-client';
 import { ApifyClient, ArgumentValidationError } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
@@ -281,8 +280,17 @@ describe('Run methods', () => {
             validateRequest(expectedRequest);
         });
 
-        test('metamorph() takes the same input type as the Actor run methods', () => {
-            expectTypeOf(client.run('some-run-id').metamorph).parameter(1).toEqualTypeOf<ActorInput | undefined>();
+        test('metamorph() does not compile with a raw body and no contentType', () => {
+            const run = client.run('some-run-id');
+
+            expectTypeOf(run.metamorph).toBeCallableWith('target-actor');
+            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', { url: 'https://example.com' });
+            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', 'some=body', {
+                contentType: 'application/x-www-form-urlencoded',
+            });
+
+            // @ts-expect-error a raw body has to be paired with a contentType
+            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', 'some=body');
         });
 
         test('reboot() works', async () => {

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -4,7 +4,7 @@ import { setTimeout as setTimeoutNode } from 'node:timers/promises';
 import c from 'ansi-colors';
 import { ApifyApiError, ApifyClient, ArgumentValidationError } from 'apify-client';
 import type { Page } from 'puppeteer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DEFAULT_OPTIONS, asBrowserResult, Browser, validateRequest } from './_helper.js';
 import * as fixtures from './mock_server/fixtures.js';
@@ -278,19 +278,6 @@ describe('Run methods', () => {
             );
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest(expectedRequest);
-        });
-
-        test('metamorph() does not compile with a raw body and no contentType', () => {
-            const run = client.run('some-run-id');
-
-            expectTypeOf(run.metamorph).toBeCallableWith('target-actor');
-            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', { url: 'https://example.com' });
-            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', 'some=body', {
-                contentType: 'application/x-www-form-urlencoded',
-            });
-
-            // @ts-expect-error a raw body has to be paired with a contentType
-            expectTypeOf(run.metamorph).toBeCallableWith('target-actor', 'some=body');
         });
 
         test('reboot() works', async () => {

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -176,14 +176,10 @@ describe('Run methods', () => {
         test('metamorph() works', async () => {
             const runId = 'some-run-id';
             const targetActorId = 'some-target-id';
-            const contentType = 'application/x-www-form-urlencoded';
-            const input = 'some=body';
+            const input = { some: 'body' };
             const build = '1.2.0';
 
-            const options = {
-                build,
-                contentType,
-            };
+            const options = { build };
 
             const actualQuery = {
                 targetActorId,
@@ -195,8 +191,7 @@ describe('Run methods', () => {
                 endpointId: 'metamorph-run',
                 query: actualQuery,
                 params: { runId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
+                body: input,
             });
 
             const browserRes = await page.evaluate(
@@ -212,16 +207,15 @@ describe('Run methods', () => {
             validateRequest({
                 query: actualQuery,
                 params: { runId },
-                body: { some: 'body' },
-                additionalHeaders: { 'content-type': contentType },
+                body: input,
             });
         });
 
-        test('metamorph() works with pre-stringified JSON input', async () => {
+        test('metamorph() passes contentType through as the request header', async () => {
             const runId = 'some-run-id';
             const targetActorId = 'some-target-id';
             const contentType = 'application/json; charset=utf-8';
-            const input = JSON.stringify({ foo: 'bar' });
+            const input = { foo: 'bar' };
 
             const expectedRequest = {
                 query: { targetActorId },


### PR DESCRIPTION
`ActorClient.start()`, `call()`, `validateInput()` and `RunClient.metamorph()` took `input` as `unknown`, so anything compiled, including values the client can't send. They now take `ActorInput`, an alias for `object`: a JSON-serializable object or array. A string, a number, a boolean, `null` and values typed `unknown` stop compiling. Nothing changes at runtime. `metamorph()`'s `input` becomes optional too.

The raw `string` body that v2 accepted alongside `contentType` is left out on purpose, as non-JSON Actor input is being sunset. The `contentType` option itself stays.

The issue asked for `Dictionary`, the type `TaskClient` uses. That rejects anything typed by your own `interface`, which gets no index signature. Task input keeps `Dictionary` because its overrides merge into the input saved on the task.

The `ActorStandby` fields from the issue's second comment are already on `v3` via #985. `apify-sdk-js` forwards `input?: unknown` into this client, so it needs the same retyping before it bumps.

Closes #818

*✍️ Drafted by Claude Code*
