### PR TITLE
feat!: add ApifyApiError subclasses grouped by HTTP status

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Besides greatly simplifying the process of querying the Apify API, the client pr
 Based on the endpoint, the client automatically extracts the relevant data and returns it in the
 expected format. Date strings are automatically converted to `Date` objects. For exceptions,
 we throw an `ApifyApiError`, which wraps the plain JSON errors returned by API and enriches
-them with other context for easier debugging.
+them with other context for easier debugging. The error is an instance of the subclass matching the
+HTTP status code, such as `NotFoundError` or `RateLimitError`, so a `catch` block can tell them apart
+with `instanceof`.
 
 ### Retries with exponential backoff
 

--- a/docs/02_concepts/02_error-handling.md
+++ b/docs/02_concepts/02_error-handling.md
@@ -69,7 +69,7 @@ try {
     await client.actor('my-actor').call({ url: 'https://example.com' }, { memory: 32768 });
 } catch (error) {
     if (error instanceof ApifyApiError && error.type === 'actor-memory-limit-exceeded') {
-        // Not enough memory to run the Actor, so put the run back into the queue.
+        // The account has no memory left for another run, so wait and start it later.
     } else {
         throw error;
     }

--- a/docs/02_concepts/02_error-handling.md
+++ b/docs/02_concepts/02_error-handling.md
@@ -24,6 +24,58 @@ try {
 }
 ```
 
+## Telling API errors apart
+
+The client throws the <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> subclass that matches the HTTP status code of the response, so a `catch` block can branch on `instanceof` instead of comparing status codes:
+
+| Status | Subclass |
+| --- | --- |
+| 400 | <ApiLink to="class/InvalidRequestError">`InvalidRequestError`</ApiLink> |
+| 401 | <ApiLink to="class/UnauthorizedError">`UnauthorizedError`</ApiLink> |
+| 403 | <ApiLink to="class/ForbiddenError">`ForbiddenError`</ApiLink> |
+| 404 | <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> |
+| 409 | <ApiLink to="class/ConflictError">`ConflictError`</ApiLink> |
+| 429 | <ApiLink to="class/RateLimitError">`RateLimitError`</ApiLink> |
+| 5xx | <ApiLink to="class/ServerError">`ServerError`</ApiLink> |
+
+Any other status code throws a plain `ApifyApiError`. Every subclass extends `ApifyApiError`, so `instanceof ApifyApiError` still matches all of them.
+
+```js
+import { ApifyClient, NotFoundError, RateLimitError } from 'apify-client';
+
+const client = new ApifyClient({ token: 'MY-APIFY-TOKEN' });
+
+try {
+    await client.actor('my-actor').call({ url: 'https://example.com' });
+} catch (error) {
+    if (error instanceof NotFoundError) {
+        // The Actor doesn't exist, or the token can't see it.
+    } else if (error instanceof RateLimitError) {
+        // The retries are exhausted, so back off and try again later.
+    } else {
+        throw error;
+    }
+}
+```
+
+Errors with the same status code differ in `type`, the machine-readable identifier the API returns. The field is typed with the known values, so your editor autocompletes them:
+
+```js
+import { ApifyApiError, ApifyClient } from 'apify-client';
+
+const client = new ApifyClient({ token: 'MY-APIFY-TOKEN' });
+
+try {
+    await client.actor('my-actor').call({ url: 'https://example.com' }, { memory: 32768 });
+} catch (error) {
+    if (error instanceof ApifyApiError && error.type === 'actor-memory-limit-exceeded') {
+        // Not enough memory to run the Actor, so put the run back into the queue.
+    } else {
+        throw error;
+    }
+}
+```
+
 ## Invalid arguments
 
 Before sending a request, the client validates the arguments you passed. When a value doesn't match the expected shape, the client throws an <ApiLink to="class/ArgumentValidationError">`ArgumentValidationError`</ApiLink> without reaching the API. Its `message` names the offending field and the value it received. For programmatic inspection, `issues` carries the structured [zod](https://zod.dev) issues and `cause` carries the original `ZodError`.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -88,6 +88,15 @@ Some options were declared in the TypeScript types but always rejected by the cl
 
 The reverse also happened: `chunkSize` now works on every paginating `list()` method. In v2 only `DatasetClient.listItems()` accepted it - everywhere else it type-checked and then threw.
 
+## API errors are thrown as subclasses of `ApifyApiError`
+
+An error response from the API now throws the <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> subclass matching its HTTP status code: <ApiLink to="class/InvalidRequestError">`InvalidRequestError`</ApiLink> (400), <ApiLink to="class/UnauthorizedError">`UnauthorizedError`</ApiLink> (401), <ApiLink to="class/ForbiddenError">`ForbiddenError`</ApiLink> (403), <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> (404), <ApiLink to="class/ConflictError">`ConflictError`</ApiLink> (409), <ApiLink to="class/RateLimitError">`RateLimitError`</ApiLink> (429) or <ApiLink to="class/ServerError">`ServerError`</ApiLink> (5xx). Any other status code still throws a plain `ApifyApiError`. Every subclass extends `ApifyApiError`, so existing `instanceof ApifyApiError` checks keep working. For details, see [Telling API errors apart](../02_concepts/02_error-handling.md#telling-api-errors-apart).
+
+Two things change as a result:
+
+- `error.name`, and with it the first line of the printed stack, now carries the subclass name, such as `NotFoundError: Actor task was not found` instead of `ApifyApiError: Actor task was not found`. Log tooling that matches on the `ApifyApiError` name has to match the subclass names as well.
+- Methods that swallow a 404 response, such as `get()` returning `undefined` or `delete()` succeeding silently, now swallow every 404, whatever its `type`. In v2 they swallowed only the `record-not-found` and `record-or-token-not-found` types and threw for any other 404.
+
 ## Published types now follow the OpenAPI specification
 
 Every output type the client publishes, such as <ApiLink to="interface/Dataset">`Dataset`</ApiLink>, <ApiLink to="interface/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="interface/Build">`Build`</ApiLink>, <ApiLink to="interface/ActorRun">`ActorRun`</ApiLink>, <ApiLink to="interface/Webhook">`Webhook`</ApiLink>, <ApiLink to="interface/Schedule">`Schedule`</ApiLink>, <ApiLink to="interface/Task">`Task`</ApiLink>, <ApiLink to="interface/RequestQueue">`RequestQueue`</ApiLink>, and <ApiLink to="interface/User">`User`</ApiLink>, is now declared on top of a type generated from the published [OpenAPI specification](https://docs.apify.com/api/v2) instead of being hand-written. Several of the previous hand-written types were wrong, and some even contradicted the client's own runtime behavior. For example, `nextExclusiveStartKey` was typed as a required `string`, but `listKeys()` has always compared it to `null`.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -95,7 +95,7 @@ An error response from the API now throws the <ApiLink to="class/ApifyApiError">
 Two things change as a result:
 
 - `error.name`, and with it the first line of the printed stack, now carries the subclass name, such as `NotFoundError: Actor task was not found` instead of `ApifyApiError: Actor task was not found`. Log tooling that matches on the `ApifyApiError` name has to match the subclass names as well.
-- Methods that swallow a 404 response, such as `get()` returning `undefined` or `delete()` succeeding silently, now swallow every 404, whatever its `type`. In v2 they swallowed only the `record-not-found` and `record-or-token-not-found` types and threw for any other 404.
+- Methods that swallow a 404 response, such as `get()` returning `undefined` or `delete()` succeeding silently, now swallow every 404, whatever its `type`. In v2 they swallowed only the `record-not-found` and `record-or-token-not-found` types and threw for any other 404. The same helper backs <ApiLink to="class/RunClient#waitForFinish">`waitForFinish()`</ApiLink> and <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, which read a swallowed 404 as "the run is not visible yet", so a 404 that used to throw now keeps them polling until `waitSecs` runs out.
 
 ## Published types now follow the OpenAPI specification
 

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -16,6 +16,7 @@ import type http from 'node:http';
 import type https from 'node:https';
 import type { InternalAxiosRequestConfig } from 'axios';
 import type { JsonValue } from 'type-fest';
+import type { LiteralUnion } from 'type-fest';
 import { Log } from '@apify/log';
 import { Logger } from '@apify/log';
 import { LogLevel } from '@apify/log';
@@ -560,14 +561,18 @@ export class ApifyApiError extends Error {
     attempt: number;
     clientMethod: string;
     data?: Record<string, unknown>;
+    static fromResponse(response: AxiosResponse, attempt: number): ApifyApiError;
     httpMethod?: string;
     // (undocumented)
     name: string;
     originalStack: string;
     path?: string;
     statusCode: number;
-    type?: string;
+    type?: LiteralUnion<ApifyApiErrorType, string>;
 }
+
+// @public
+export type ApifyApiErrorType = Schemas['ErrorType'];
 
 // @public
 export class ApifyClient {
@@ -2397,6 +2402,10 @@ interface components {
 }
 
 // @public
+export class ConflictError extends ApifyApiError {
+}
+
+// @public
 export interface Current extends GeneratedCurrent {
 }
 
@@ -2621,6 +2630,10 @@ export type FinalActorVersion = ActorVersion & {
 
 // @public
 export interface FlatPricePerMonthActorPricingInfo extends GeneratedFlatPricePerMonthActorPricingInfo {
+}
+
+// @public
+export class ForbiddenError extends ApifyApiError {
 }
 
 // @public
@@ -2889,6 +2902,10 @@ interface HttpClientOptions {
 }
 
 // @public
+export class InvalidRequestError extends ApifyApiError {
+}
+
+// @public
 export class InvalidResponseBodyError extends Error {
     constructor(response: AxiosResponse, cause: Error);
     // (undocumented)
@@ -3085,6 +3102,10 @@ interface MonthlyUsageRePointed {
 }
 
 // @public
+export class NotFoundError extends ApifyApiError {
+}
+
+// @public
 export interface OpenApiDefinition {
     // (undocumented)
     components: {
@@ -3239,6 +3260,10 @@ export interface PricingInfo extends GeneratedCurrentPricingInfo {
 
 // @public
 export interface ProxyGroup extends GeneratedProxyGroup {
+}
+
+// @public
+export class RateLimitError extends ApifyApiError {
 }
 
 // Not exported by the entry point; reachable only as a referenced type.
@@ -3719,6 +3744,10 @@ interface ScheduleRePointed {
 type Schemas = components['schemas'];
 
 // @public
+export class ServerError extends ApifyApiError {
+}
+
+// @public
 export interface ServiceUsage {
     // (undocumented)
     [service: string]: UsageItem;
@@ -3906,6 +3935,10 @@ type Timezone = (typeof timezones)[number];
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
 const timezones: readonly ["Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", "Africa/Asmara", "Africa/Asmera", "Africa/Bamako", "Africa/Bangui", "Africa/Banjul", "Africa/Bissau", "Africa/Blantyre", "Africa/Brazzaville", "Africa/Bujumbura", "Africa/Cairo", "Africa/Casablanca", "Africa/Ceuta", "Africa/Conakry", "Africa/Dakar", "Africa/Dar_es_Salaam", "Africa/Djibouti", "Africa/Douala", "Africa/El_Aaiun", "Africa/Freetown", "Africa/Gaborone", "Africa/Harare", "Africa/Johannesburg", "Africa/Juba", "Africa/Kampala", "Africa/Khartoum", "Africa/Kigali", "Africa/Kinshasa", "Africa/Lagos", "Africa/Libreville", "Africa/Lome", "Africa/Luanda", "Africa/Lubumbashi", "Africa/Lusaka", "Africa/Malabo", "Africa/Maputo", "Africa/Maseru", "Africa/Mbabane", "Africa/Mogadishu", "Africa/Monrovia", "Africa/Nairobi", "Africa/Ndjamena", "Africa/Niamey", "Africa/Nouakchott", "Africa/Ouagadougou", "Africa/Porto-Novo", "Africa/Sao_Tome", "Africa/Timbuktu", "Africa/Tripoli", "Africa/Tunis", "Africa/Windhoek", "America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua", "America/Araguaina", "America/Argentina/Buenos_Aires", "America/Argentina/Catamarca", "America/Argentina/ComodRivadavia", "America/Argentina/Cordoba", "America/Argentina/Jujuy", "America/Argentina/La_Rioja", "America/Argentina/Mendoza", "America/Argentina/Rio_Gallegos", "America/Argentina/Salta", "America/Argentina/San_Juan", "America/Argentina/San_Luis", "America/Argentina/Tucuman", "America/Argentina/Ushuaia", "America/Aruba", "America/Asuncion", "America/Atikokan", "America/Atka", "America/Bahia", "America/Bahia_Banderas", "America/Barbados", "America/Belem", "America/Belize", "America/Blanc-Sablon", "America/Boa_Vista", "America/Bogota", "America/Boise", "America/Buenos_Aires", "America/Cambridge_Bay", "America/Campo_Grande", "America/Cancun", "America/Caracas", "America/Catamarca", "America/Cayenne", "America/Cayman", "America/Chicago", "America/Chihuahua", "America/Coral_Harbour", "America/Cordoba", "America/Costa_Rica", "America/Creston", "America/Cuiaba", "America/Curacao", "America/Danmarkshavn", "America/Dawson", "America/Dawson_Creek", "America/Denver", "America/Detroit", "America/Dominica", "America/Edmonton", "America/Eirunepe", "America/El_Salvador", "America/Ensenada", "America/Fort_Nelson", "America/Fort_Wayne", "America/Fortaleza", "America/Glace_Bay", "America/Godthab", "America/Goose_Bay", "America/Grand_Turk", "America/Grenada", "America/Guadeloupe", "America/Guatemala", "America/Guayaquil", "America/Guyana", "America/Halifax", "America/Havana", "America/Hermosillo", "America/Indiana/Indianapolis", "America/Indiana/Knox", "America/Indiana/Marengo", "America/Indiana/Petersburg", "America/Indiana/Tell_City", "America/Indiana/Vevay", "America/Indiana/Vincennes", "America/Indiana/Winamac", "America/Indianapolis", "America/Inuvik", "America/Iqaluit", "America/Jamaica", "America/Jujuy", "America/Juneau", "America/Kentucky/Louisville", "America/Kentucky/Monticello", "America/Knox_IN", "America/Kralendijk", "America/La_Paz", "America/Lima", "America/Los_Angeles", "America/Louisville", "America/Lower_Princes", "America/Maceio", "America/Managua", "America/Manaus", "America/Marigot", "America/Martinique", "America/Matamoros", "America/Mazatlan", "America/Mendoza", "America/Menominee", "America/Merida", "America/Metlakatla", "America/Mexico_City", "America/Miquelon", "America/Moncton", "America/Monterrey", "America/Montevideo", "America/Montreal", "America/Montserrat", "America/Nassau", "America/New_York", "America/Nipigon", "America/Nome", "America/Noronha", "America/North_Dakota/Beulah", "America/North_Dakota/Center", "America/North_Dakota/New_Salem", "America/Nuuk", "America/Ojinaga", "America/Panama", "America/Pangnirtung", "America/Paramaribo", "America/Phoenix", "America/Port-au-Prince", "America/Port_of_Spain", "America/Porto_Acre", "America/Porto_Velho", "America/Puerto_Rico", "America/Punta_Arenas", "America/Rainy_River", "America/Rankin_Inlet", "America/Recife", "America/Regina", "America/Resolute", "America/Rio_Branco", "America/Rosario", "America/Santa_Isabel", "America/Santarem", "America/Santiago", "America/Santo_Domingo", "America/Sao_Paulo", "America/Scoresbysund", "America/Shiprock", "America/Sitka", "America/St_Barthelemy", "America/St_Johns", "America/St_Kitts", "America/St_Lucia", "America/St_Thomas", "America/St_Vincent", "America/Swift_Current", "America/Tegucigalpa", "America/Thule", "America/Thunder_Bay", "America/Tijuana", "America/Toronto", "America/Tortola", "America/Vancouver", "America/Virgin", "America/Whitehorse", "America/Winnipeg", "America/Yakutat", "America/Yellowknife", "Antarctica/Casey", "Antarctica/Davis", "Antarctica/DumontDUrville", "Antarctica/Macquarie", "Antarctica/Mawson", "Antarctica/McMurdo", "Antarctica/Palmer", "Antarctica/Rothera", "Antarctica/South_Pole", "Antarctica/Syowa", "Antarctica/Troll", "Antarctica/Vostok", "Arctic/Longyearbyen", "Asia/Aden", "Asia/Almaty", "Asia/Amman", "Asia/Anadyr", "Asia/Aqtau", "Asia/Aqtobe", "Asia/Ashgabat", "Asia/Ashkhabad", "Asia/Atyrau", "Asia/Baghdad", "Asia/Bahrain", "Asia/Baku", "Asia/Bangkok", "Asia/Barnaul", "Asia/Beirut", "Asia/Bishkek", "Asia/Brunei", "Asia/Calcutta", "Asia/Chita", "Asia/Choibalsan", "Asia/Chongqing", "Asia/Chungking", "Asia/Colombo", "Asia/Dacca", "Asia/Damascus", "Asia/Dhaka", "Asia/Dili", "Asia/Dubai", "Asia/Dushanbe", "Asia/Famagusta", "Asia/Gaza", "Asia/Harbin", "Asia/Hebron", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Hovd", "Asia/Irkutsk", "Asia/Istanbul", "Asia/Jakarta", "Asia/Jayapura", "Asia/Jerusalem", "Asia/Kabul", "Asia/Kamchatka", "Asia/Karachi", "Asia/Kashgar", "Asia/Kathmandu", "Asia/Katmandu", "Asia/Khandyga", "Asia/Kolkata", "Asia/Krasnoyarsk", "Asia/Kuala_Lumpur", "Asia/Kuching", "Asia/Kuwait", "Asia/Macao", "Asia/Macau", "Asia/Magadan", "Asia/Makassar", "Asia/Manila", "Asia/Muscat", "Asia/Nicosia", "Asia/Novokuznetsk", "Asia/Novosibirsk", "Asia/Omsk", "Asia/Oral", "Asia/Phnom_Penh", "Asia/Pontianak", "Asia/Pyongyang", "Asia/Qatar", "Asia/Qostanay", "Asia/Qyzylorda", "Asia/Rangoon", "Asia/Riyadh", "Asia/Saigon", "Asia/Sakhalin", "Asia/Samarkand", "Asia/Seoul", "Asia/Shanghai", "Asia/Singapore", "Asia/Srednekolymsk", "Asia/Taipei", "Asia/Tashkent", "Asia/Tbilisi", "Asia/Tehran", "Asia/Tel_Aviv", "Asia/Thimbu", "Asia/Thimphu", "Asia/Tokyo", "Asia/Tomsk", "Asia/Ujung_Pandang", "Asia/Ulaanbaatar", "Asia/Ulan_Bator", "Asia/Urumqi", "Asia/Ust-Nera", "Asia/Vientiane", "Asia/Vladivostok", "Asia/Yakutsk", "Asia/Yangon", "Asia/Yekaterinburg", "Asia/Yerevan", "Atlantic/Azores", "Atlantic/Bermuda", "Atlantic/Canary", "Atlantic/Cape_Verde", "Atlantic/Faeroe", "Atlantic/Faroe", "Atlantic/Jan_Mayen", "Atlantic/Madeira", "Atlantic/Reykjavik", "Atlantic/South_Georgia", "Atlantic/St_Helena", "Atlantic/Stanley", "Australia/ACT", "Australia/Adelaide", "Australia/Brisbane", "Australia/Broken_Hill", "Australia/Canberra", "Australia/Currie", "Australia/Darwin", "Australia/Eucla", "Australia/Hobart", "Australia/LHI", "Australia/Lindeman", "Australia/Lord_Howe", "Australia/Melbourne", "Australia/NSW", "Australia/North", "Australia/Perth", "Australia/Queensland", "Australia/South", "Australia/Sydney", "Australia/Tasmania", "Australia/Victoria", "Australia/West", "Australia/Yancowinna", "Brazil/Acre", "Brazil/DeNoronha", "Brazil/East", "Brazil/West", "CET", "CST6CDT", "Canada/Atlantic", "Canada/Central", "Canada/Eastern", "Canada/Mountain", "Canada/Newfoundland", "Canada/Pacific", "Canada/Saskatchewan", "Canada/Yukon", "Chile/Continental", "Chile/EasterIsland", "Cuba", "EET", "EST", "EST5EDT", "Egypt", "Eire", "Etc/GMT", "Etc/GMT+0", "Etc/GMT+1", "Etc/GMT+10", "Etc/GMT+11", "Etc/GMT+12", "Etc/GMT+2", "Etc/GMT+3", "Etc/GMT+4", "Etc/GMT+5", "Etc/GMT+6", "Etc/GMT+7", "Etc/GMT+8", "Etc/GMT+9", "Etc/GMT-0", "Etc/GMT-1", "Etc/GMT-10", "Etc/GMT-11", "Etc/GMT-12", "Etc/GMT-13", "Etc/GMT-14", "Etc/GMT-2", "Etc/GMT-3", "Etc/GMT-4", "Etc/GMT-5", "Etc/GMT-6", "Etc/GMT-7", "Etc/GMT-8", "Etc/GMT-9", "Etc/GMT0", "Etc/Greenwich", "Etc/UCT", "Etc/UTC", "Etc/Universal", "Etc/Zulu", "Europe/Amsterdam", "Europe/Andorra", "Europe/Astrakhan", "Europe/Athens", "Europe/Belfast", "Europe/Belgrade", "Europe/Berlin", "Europe/Bratislava", "Europe/Brussels", "Europe/Bucharest", "Europe/Budapest", "Europe/Busingen", "Europe/Chisinau", "Europe/Copenhagen", "Europe/Dublin", "Europe/Gibraltar", "Europe/Guernsey", "Europe/Helsinki", "Europe/Isle_of_Man", "Europe/Istanbul", "Europe/Jersey", "Europe/Kaliningrad", "Europe/Kiev", "Europe/Kirov", "Europe/Lisbon", "Europe/Ljubljana", "Europe/London", "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta", "Europe/Mariehamn", "Europe/Minsk", "Europe/Monaco", "Europe/Moscow", "Europe/Nicosia", "Europe/Oslo", "Europe/Paris", "Europe/Podgorica", "Europe/Prague", "Europe/Riga", "Europe/Rome", "Europe/Samara", "Europe/San_Marino", "Europe/Sarajevo", "Europe/Saratov", "Europe/Simferopol", "Europe/Skopje", "Europe/Sofia", "Europe/Stockholm", "Europe/Tallinn", "Europe/Tirane", "Europe/Tiraspol", "Europe/Ulyanovsk", "Europe/Uzhgorod", "Europe/Vaduz", "Europe/Vatican", "Europe/Vienna", "Europe/Vilnius", "Europe/Volgograd", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zaporozhye", "Europe/Zurich", "GB", "GB-Eire", "GMT", "GMT+0", "GMT-0", "GMT0", "Greenwich", "HST", "Hongkong", "Iceland", "Indian/Antananarivo", "Indian/Chagos", "Indian/Christmas", "Indian/Cocos", "Indian/Comoro", "Indian/Kerguelen", "Indian/Mahe", "Indian/Maldives", "Indian/Mauritius", "Indian/Mayotte", "Indian/Reunion", "Iran", "Israel", "Jamaica", "Japan", "Kwajalein", "Libya", "MET", "MST", "MST7MDT", "Mexico/BajaNorte", "Mexico/BajaSur", "Mexico/General", "NZ", "NZ-CHAT", "Navajo", "PRC", "PST8PDT", "Pacific/Apia", "Pacific/Auckland", "Pacific/Bougainville", "Pacific/Chatham", "Pacific/Chuuk", "Pacific/Easter", "Pacific/Efate", "Pacific/Enderbury", "Pacific/Fakaofo", "Pacific/Fiji", "Pacific/Funafuti", "Pacific/Galapagos", "Pacific/Gambier", "Pacific/Guadalcanal", "Pacific/Guam", "Pacific/Honolulu", "Pacific/Johnston", "Pacific/Kiritimati", "Pacific/Kosrae", "Pacific/Kwajalein", "Pacific/Majuro", "Pacific/Marquesas", "Pacific/Midway", "Pacific/Nauru", "Pacific/Niue", "Pacific/Norfolk", "Pacific/Noumea", "Pacific/Pago_Pago", "Pacific/Palau", "Pacific/Pitcairn", "Pacific/Pohnpei", "Pacific/Ponape", "Pacific/Port_Moresby", "Pacific/Rarotonga", "Pacific/Saipan", "Pacific/Samoa", "Pacific/Tahiti", "Pacific/Tarawa", "Pacific/Tongatapu", "Pacific/Truk", "Pacific/Wake", "Pacific/Wallis", "Pacific/Yap", "Poland", "Portugal", "ROC", "ROK", "Singapore", "Turkey", "UCT", "US/Alaska", "US/Aleutian", "US/Arizona", "US/Central", "US/East-Indiana", "US/Eastern", "US/Hawaii", "US/Indiana-Starke", "US/Michigan", "US/Mountain", "US/Pacific", "US/Samoa", "UTC", "Universal", "W-SU", "WET", "Zulu"];
+
+// @public
+export class UnauthorizedError extends ApifyApiError {
+}
 
 // @public
 export interface UsageCycle extends GeneratedUsageCycle {

--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -216,17 +216,17 @@ export class ConflictError extends ApifyApiError {}
 
 /**
  * Thrown when the Apify API responds with HTTP 429 Too Many Requests. The client retries such
- * requests, so the error surfaces only once the retries are exhausted.
+ * requests, so the error surfaces once the retries are exhausted.
  */
 export class RateLimitError extends ApifyApiError {}
 
 /**
  * Thrown when the Apify API responds with an HTTP 5xx status. The client retries such requests,
- * so the error surfaces only once the retries are exhausted.
+ * so the error surfaces once the retries are exhausted.
  */
 export class ServerError extends ApifyApiError {}
 
-const ERROR_CLASS_BY_STATUS: Record<number, typeof ApifyApiError> = {
+const ERROR_CLASS_BY_STATUS: Partial<Record<number, typeof ApifyApiError>> = {
     400: InvalidRequestError,
     401: UnauthorizedError,
     403: ForbiddenError,

--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -1,7 +1,11 @@
 import type { AxiosResponse } from 'axios';
+import type { LiteralUnion } from 'type-fest';
 
 import { isomorphicBufferToString } from './body_parser.js';
+import type { ApifyApiErrorType } from './models.js';
 import { isBuffer } from './utils.js';
+
+export type { ApifyApiErrorType } from './models.js';
 
 /**
  * Examples of capturing groups for "...at ActorCollectionClient._list (/Users/..."
@@ -20,6 +24,13 @@ const CLIENT_METHOD_REGEX = /at( async)? ([A-Za-z]+(Collection)?Client)\._?([A-Z
  * errors and internal errors, which are automatically retried, or validation
  * errors, which are thrown immediately, because a correction by the user is
  * needed.
+ *
+ * The thrown error is an instance of the subclass matching the HTTP status code of the response:
+ * {@link InvalidRequestError} (400), {@link UnauthorizedError} (401), {@link ForbiddenError} (403),
+ * {@link NotFoundError} (404), {@link ConflictError} (409), {@link RateLimitError} (429) or
+ * {@link ServerError} (5xx). Any other status code is thrown as a plain `ApifyApiError`. Every
+ * subclass extends `ApifyApiError`, so `instanceof ApifyApiError` matches all of them. Errors that
+ * share a status code are told apart by their `type`.
  */
 export class ApifyApiError extends Error {
     override name: string;
@@ -36,9 +47,10 @@ export class ApifyApiError extends Error {
     statusCode: number;
 
     /**
-     * The type of the error, as returned by the API.
+     * The type of the error, as returned by the API. Typed as the known {@link ApifyApiErrorType}
+     * values for autocompletion, while still accepting any string the API may return.
      */
-    type?: string;
+    type?: LiteralUnion<ApifyApiErrorType, string>;
 
     /**
      * Number of the API call attempt.
@@ -117,6 +129,16 @@ export class ApifyApiError extends Error {
         this.data = errorData;
     }
 
+    /**
+     * Creates the error for a failed response as an instance of the subclass matching its HTTP status code.
+     * @hidden
+     */
+    static fromResponse(response: AxiosResponse, attempt: number): ApifyApiError {
+        const ErrorClass =
+            ERROR_CLASS_BY_STATUS[response.status] ?? (response.status >= 500 ? ServerError : ApifyApiError);
+        return new ErrorClass(response, attempt);
+    }
+
     private _safelyParsePathFromResponse(response: AxiosResponse) {
         const urlString = response.config?.url;
         let url;
@@ -140,7 +162,7 @@ export class ApifyApiError extends Error {
      *
      * Example:
      *
-     * ApifyApiError: Actor task was not found
+     * NotFoundError: Actor task was not found
      *   clientMethod: TaskClient.start
      *   statusCode: 404
      *   type: record-not-found
@@ -163,3 +185,52 @@ export class ApifyApiError extends Error {
         return `${name}: ${this.message}\n${stack}`;
     }
 }
+
+/**
+ * Thrown when the Apify API responds with HTTP 400 Bad Request, typically because the request
+ * failed validation.
+ */
+export class InvalidRequestError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with HTTP 401 Unauthorized, because the token is missing
+ * or invalid.
+ */
+export class UnauthorizedError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with HTTP 403 Forbidden, because the token lacks the
+ * permission for the operation.
+ */
+export class ForbiddenError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with HTTP 404 Not Found.
+ */
+export class NotFoundError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with HTTP 409 Conflict.
+ */
+export class ConflictError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with HTTP 429 Too Many Requests. The client retries such
+ * requests, so the error surfaces only once the retries are exhausted.
+ */
+export class RateLimitError extends ApifyApiError {}
+
+/**
+ * Thrown when the Apify API responds with an HTTP 5xx status. The client retries such requests,
+ * so the error surfaces only once the retries are exhausted.
+ */
+export class ServerError extends ApifyApiError {}
+
+const ERROR_CLASS_BY_STATUS: Record<number, typeof ApifyApiError> = {
+    400: InvalidRequestError,
+    401: UnauthorizedError,
+    403: ForbiddenError,
+    404: NotFoundError,
+    409: ConflictError,
+    429: RateLimitError,
+};

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -224,7 +224,7 @@ export class HttpClient {
                 this.stats.addRateLimitError(attempt);
             }
 
-            const apiError = new ApifyApiError(response, attempt);
+            const apiError = ApifyApiError.fromResponse(response, attempt);
             if (this._isStatusCodeRetryable(response.status)) {
                 if (requestIsStream) {
                     this._informAboutStreamNoRetry();

--- a/src/models.ts
+++ b/src/models.ts
@@ -68,6 +68,13 @@ export enum WebhookDispatchStatus {
 }
 
 /**
+ * Machine-readable type of an error returned by the Apify API, carried by `ApifyApiError.type`.
+ *
+ * Declared here, next to the other spec-derived types, and re-exported from `./apify_api_error`.
+ */
+export type ApifyApiErrorType = Schemas['ErrorType'];
+
+/**
  * Fields the API returns on a dataset that the OpenAPI spec does not describe yet.
  *
  * TODO: Remove once the spec covers them.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import type { JsonValue, TypedArray } from 'type-fest';
 import { z } from 'zod';
 
 import type { ApifyApiError } from './apify_api_error.js';
+import { NotFoundError } from './apify_api_error.js';
 import { parseArgument } from '@apify/validations';
 import type { ApifyResponse } from './http_client.js';
 import { ResponseValidationError } from './response_validation_error.js';
@@ -16,9 +17,6 @@ import type { WebhookUpdateData } from './resource_clients/webhook.js';
 // @ts-ignore if we enable `resolveJsonModule`, we end up with a `src` folder in `dist`
 import packageJson from '../package.json' with { type: 'json' };
 
-const NOT_FOUND_STATUS_CODE = 404;
-const RECORD_NOT_FOUND_TYPE = 'record-not-found';
-const RECORD_OR_TOKEN_NOT_FOUND_TYPE = 'record-or-token-not-found';
 const MIN_COMPRESS_BYTES = 1024;
 
 export { parseArgument };
@@ -91,15 +89,10 @@ export function pluckData<R>(obj: MaybeData<R>): R {
 }
 
 /**
- * If given HTTP error has NOT_FOUND_STATUS_CODE status code then returns undefined.
- * Otherwise rethrows error.
+ * Swallows a 404 Not Found API error and rethrows anything else.
  */
 export function catchNotFoundOrThrow(err: ApifyApiError): void {
-    const isNotFoundStatus = err.statusCode === NOT_FOUND_STATUS_CODE;
-    const isNotFoundMessage =
-        err.type === RECORD_NOT_FOUND_TYPE || err.type === RECORD_OR_TOKEN_NOT_FOUND_TYPE || err.httpMethod === 'head';
-    const isNotFoundError = isNotFoundStatus && isNotFoundMessage;
-    if (!isNotFoundError) throw err;
+    if (!(err instanceof NotFoundError)) throw err;
 }
 
 type ReturnJsonValue = string | number | boolean | null | Date | ReturnJsonObject | ReturnJsonArray;

--- a/test/apify_api_error.test.ts
+++ b/test/apify_api_error.test.ts
@@ -143,6 +143,7 @@ describe('ApifyApiError', () => {
             },
         });
     });
+
     describe('subclass by HTTP status', () => {
         const response = (status: number, data: unknown = { error: { type: 'some-type', message: 'Some message' } }) =>
             ({ status, data, config: { method: 'get', url: 'http://localhost/v2/acts' } }) as any;

--- a/test/apify_api_error.test.ts
+++ b/test/apify_api_error.test.ts
@@ -1,7 +1,17 @@
 import type { AddressInfo } from 'node:net';
 
 import type { Dictionary } from 'apify-client';
-import { ApifyApiError, ApifyClient } from 'apify-client';
+import {
+    ApifyApiError,
+    ApifyClient,
+    ConflictError,
+    ForbiddenError,
+    InvalidRequestError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    UnauthorizedError,
+} from 'apify-client';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { Browser, DEFAULT_OPTIONS } from './_helper.js';
@@ -31,7 +41,8 @@ describe('ApifyApiError', () => {
         } catch (err: any) {
             if (!(err instanceof ApifyApiError)) throw err;
 
-            expect(err.name).toEqual('ApifyApiError');
+            expect(err).toBeInstanceOf(UnauthorizedError);
+            expect(err.name).toEqual('UnauthorizedError');
             // This does not work in v10 and lower, but we want to be able to run tests for v10,
             // because some people might still use it. They will just see clientMethod: undefined.
             if (!process.version.startsWith('v10')) {
@@ -65,7 +76,7 @@ describe('ApifyApiError', () => {
             }
         }, method);
 
-        expect(error.name).toEqual('ApifyApiError');
+        expect(error.name).toEqual('UnauthorizedError');
         expect(error.clientMethod).toBe(`ActorCollectionClient.${method}`);
         expect(error.type).toEqual('token-not-provided');
         expect(error.message).toEqual('Authentication token was not provided');
@@ -92,7 +103,8 @@ describe('ApifyApiError', () => {
         } catch (err) {
             if (!(err instanceof ApifyApiError)) throw err;
 
-            expect(err.name).toEqual('ApifyApiError');
+            expect(err).toBeInstanceOf(InvalidRequestError);
+            expect(err.name).toEqual('InvalidRequestError');
             expect(err.type).toEqual('schema-validation-error');
             expect(err.data).toEqual({
                 invalidItems: {
@@ -123,12 +135,53 @@ describe('ApifyApiError', () => {
             datasetId,
             data,
         );
-        expect(error.name).toEqual('ApifyApiError');
+        expect(error.name).toEqual('InvalidRequestError');
         expect(error.type).toEqual('schema-validation-error');
         expect(error.data).toEqual({
             invalidItems: {
                 0: [`should have required property 'name'`],
             },
+        });
+    });
+    describe('subclass by HTTP status', () => {
+        const response = (status: number, data: unknown = { error: { type: 'some-type', message: 'Some message' } }) =>
+            ({ status, data, config: { method: 'get', url: 'http://localhost/v2/acts' } }) as any;
+
+        test.each([
+            { status: 400, name: 'InvalidRequestError', ErrorClass: InvalidRequestError },
+            { status: 401, name: 'UnauthorizedError', ErrorClass: UnauthorizedError },
+            { status: 403, name: 'ForbiddenError', ErrorClass: ForbiddenError },
+            { status: 404, name: 'NotFoundError', ErrorClass: NotFoundError },
+            { status: 409, name: 'ConflictError', ErrorClass: ConflictError },
+            { status: 429, name: 'RateLimitError', ErrorClass: RateLimitError },
+            { status: 500, name: 'ServerError', ErrorClass: ServerError },
+            { status: 503, name: 'ServerError', ErrorClass: ServerError },
+        ])('status $status creates $name', ({ status, name, ErrorClass }) => {
+            const error = ApifyApiError.fromResponse(response(status), 1);
+
+            expect(error).toBeInstanceOf(ErrorClass);
+            expect(error).toBeInstanceOf(ApifyApiError);
+            expect(error.name).toBe(name);
+            expect(error.stack).toMatch(new RegExp(`^${name}: Some message\n`));
+            expect(error.statusCode).toBe(status);
+            expect(error.type).toBe('some-type');
+            expect(error.message).toBe('Some message');
+            expect(error.path).toBe('/v2/acts');
+        });
+
+        test('an unmapped status stays a plain ApifyApiError', () => {
+            const error = ApifyApiError.fromResponse(response(418), 1);
+
+            expect(error.constructor).toBe(ApifyApiError);
+            expect(error.name).toBe('ApifyApiError');
+            expect(error.statusCode).toBe(418);
+        });
+
+        test('an unparsable body still picks the subclass', () => {
+            const error = ApifyApiError.fromResponse(response(404, Buffer.from('<not json>')), 1);
+
+            expect(error).toBeInstanceOf(NotFoundError);
+            expect(error.type).toBeUndefined();
         });
     });
 });

--- a/test/browser_bundle.test.ts
+++ b/test/browser_bundle.test.ts
@@ -43,6 +43,7 @@ describe('browser bundle', () => {
                 run: client.run('some-run').constructor.name as string,
                 build: client.build('some-build').constructor.name as string,
                 apiError: (window as any).Apify.ApifyApiError.name as string,
+                notFoundError: (window as any).Apify.NotFoundError.name as string,
             };
         });
 
@@ -51,5 +52,6 @@ describe('browser bundle', () => {
         expect(names.run).toBe('RunClient');
         expect(names.build).toBe('BuildClient');
         expect(names.apiError).toBe('ApifyApiError');
+        expect(names.notFoundError).toBe('NotFoundError');
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -18,25 +18,15 @@ describe('utils.pluckData()', () => {
 });
 
 describe('utils.catchNotFoundOrThrow()', () => {
-    test('works', () => {
-        const recordNotFoundError = new ApifyApiError(
-            { status: 404, data: { error: { type: 'record-not-found' } } } as any,
-            0,
-        );
-        const recordOrTokenNotFoundError = new ApifyApiError(
-            {
-                status: 404,
-                data: { error: { type: 'record-or-token-not-found' } },
-            } as any,
-            0,
-        );
-        const otherError = new ApifyApiError({ status: 404, data: { error: { type: 'page-not-found' } } } as any, 0);
-        const internalError = new ApifyApiError({ status: 500, data: { error: { type: 'internal-error' } } } as any, 0);
+    test('swallows a NotFoundError and rethrows anything else', () => {
+        const response = (status: number, type: string) => ({ status, data: { error: { type } } }) as any;
+        const recordNotFoundError = ApifyApiError.fromResponse(response(404, 'record-not-found'), 0);
+        const pageNotFoundError = ApifyApiError.fromResponse(response(404, 'page-not-found'), 0);
+        const internalError = ApifyApiError.fromResponse(response(500, 'internal-error'), 0);
         const otherGenericError = new Error('blabla');
 
         expect(utils.catchNotFoundOrThrow(recordNotFoundError)).toBeUndefined();
-        expect(utils.catchNotFoundOrThrow(recordOrTokenNotFoundError)).toBeUndefined();
-        expect(() => utils.catchNotFoundOrThrow(otherError)).toThrowError(otherError);
+        expect(utils.catchNotFoundOrThrow(pageNotFoundError)).toBeUndefined();
         expect(() => utils.catchNotFoundOrThrow(internalError)).toThrowError(internalError);
         expect(() => utils.catchNotFoundOrThrow(otherGenericError as any)).toThrowError(otherGenericError);
     });


### PR DESCRIPTION
The client now throws the `ApifyApiError` subclass matching the response's HTTP status code, so a `catch` block can branch on `instanceof` instead of comparing `statusCode` numbers or `type` strings. The split follows the status code because `type` is per-endpoint and has hundreds of values. Same approach and same class names as the Python client in apify/apify-client-python#737.

| Status | Class |
| --- | --- |
| 400 | `InvalidRequestError` |
| 401 | `UnauthorizedError` |
| 403 | `ForbiddenError` |
| 404 | `NotFoundError` |
| 409 | `ConflictError` |
| 429 | `RateLimitError` |
| 5xx | `ServerError` |

Any other status stays a plain `ApifyApiError`, and every subclass extends it, so existing `instanceof ApifyApiError` checks keep working. `HttpClient` builds the error through a hidden `ApifyApiError.fromResponse()` factory. The constructor is unchanged.

`type` is now typed as `LiteralUnion<ApifyApiErrorType, string>`, with `ApifyApiErrorType` coming from the spec's `ErrorType` enum. Editors autocomplete `err.type === 'actor-memory-limit-exceeded'`, which is what the Slack thread asked for, and any string the API returns still type-checks.

## Breaking changes

- `error.name` now holds the subclass name, so a printed stack starts with `NotFoundError: ...` instead of `ApifyApiError: ...`.
- `catchNotFoundOrThrow` checks `instanceof NotFoundError`, so `get()`-style methods swallow every 404 whatever its `type`. Before, only `record-not-found`, `record-or-token-not-found` and HEAD requests were swallowed. The Python client made the same change, and the v3 upgrading guide covers it.
- The same helper backs `waitForFinish()` and `call()`, which read a swallowed 404 as "the run isn't visible yet". A 404 that used to throw right away now keeps them polling until `waitSecs` runs out, and they end up throwing a generic error instead of the `ApifyApiError`. A token revoked mid-wait lands there.

Closes #709

*✍️ Drafted by Claude Code*
