### PR TITLE
fix!: throw on ambiguous 404s instead of resolving to undefined

### DIFF
--- a/docs/02_concepts/02_error-handling.md
+++ b/docs/02_concepts/02_error-handling.md
@@ -26,7 +26,7 @@ try {
 
 ## Missing resources
 
-When you address a resource by ID, `get()` resolves to `undefined` on a 404 instead of throwing, and `delete()` resolves without error. <ApiLink to="class/KeyValueStoreClient#getRecord">`getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`getRequest()`</ApiLink> do the same for a missing record or request.
+When you address a resource by ID, `get()` resolves to `undefined` on a 404 instead of throwing, and `delete()` resolves without error. <ApiLink to="class/KeyValueStoreClient#getRecord">`getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`getRequest()`</ApiLink> do the same for a missing record or request, <ApiLink to="class/KeyValueStoreClient#recordExists">`recordExists()`</ApiLink> answers `false`, and `lastRun()` resolves to `undefined` for an Actor or task with no matching run.
 
 Everywhere else a 404 throws an <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> with `statusCode` set to `404`. That covers clients chained off a run or build without an ID, such as `client.run('run-id').dataset()` or `client.build('build-id').log()`, where the missing resource may be the parent rather than the sub-resource. It also covers fixed sub-paths such as `getStatistics()`, `monthlyUsage()`, `limits()`, `getLog()`, `getInput()` and `test()`, where a 404 means the parent is gone.
 

--- a/docs/02_concepts/02_error-handling.md
+++ b/docs/02_concepts/02_error-handling.md
@@ -24,6 +24,28 @@ try {
 }
 ```
 
+## Missing resources
+
+When you address a resource by ID, `get()` resolves to `undefined` on a 404 instead of throwing, and `delete()` resolves without error. <ApiLink to="class/KeyValueStoreClient#getRecord">`getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`getRequest()`</ApiLink> do the same for a missing record or request.
+
+Everywhere else a 404 throws an <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> with `statusCode` set to `404`. That covers clients chained off a run or build without an ID, such as `client.run('run-id').dataset()` or `client.build('build-id').log()`, where the missing resource may be the parent rather than the sub-resource. It also covers fixed sub-paths such as `getStatistics()`, `monthlyUsage()`, `limits()`, `getLog()`, `getInput()` and `test()`, where a 404 means the parent is gone.
+
+```js
+import { ApifyApiError, ApifyClient } from 'apify-client';
+
+const client = new ApifyClient({ token: 'MY-APIFY-TOKEN' });
+
+const actor = await client.actor('missing-actor').get(); // undefined
+
+try {
+    await client.run('missing-run').dataset().get();
+} catch (error) {
+    if (error instanceof ApifyApiError && error.statusCode === 404) {
+        // Either the run or its default dataset does not exist.
+    }
+}
+```
+
 ## Invalid arguments
 
 Before sending a request, the client validates the arguments you passed. When a value doesn't match the expected shape, the client throws an <ApiLink to="class/ArgumentValidationError">`ArgumentValidationError`</ApiLink> without reaching the API. Its `message` names the offending field and the value it received. For programmatic inspection, `issues` carries the structured [zod](https://zod.dev) issues and `cause` carries the original `ZodError`.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -117,6 +117,17 @@ Lookups by key keep the old behavior, because there the 404 is about the record 
 
 A <ApiLink to="class/StreamedLog">`StreamedLog`</ApiLink> whose run no longer exists logs a warning and stops, the same way it handles any other error while streaming.
 
+### `UserClient.get()` declares the `undefined` it could always return
+
+<ApiLink to="class/UserClient#get">`UserClient.get()`</ApiLink> is typed `Promise<User | undefined>`. It addresses a user by ID, so it belongs with the calls that read a 404 as a missing resource, and it already resolved to `undefined` for one. Only its signature said otherwise, which left the `undefined` to surface as a runtime error somewhere further along. Every other `get()` on the client is typed this way, as is `get()` on the [Python client](https://docs.apify.com/api/client/python).
+
+```diff
+- const user = await client.user('some-id').get();
+- console.log(user.username);
++ const user = await client.user('some-id').get();
++ console.log(user?.username);
+```
+
 ### An empty string is no longer accepted as a version number or environment variable name
 
 <ApiLink to="class/ActorClient#version">`ActorClient.version()`</ApiLink>, <ApiLink to="class/ActorClient#build">`ActorClient.build()`</ApiLink> and <ApiLink to="class/ActorVersionClient#envVar">`ActorVersionClient.envVar()`</ApiLink> now throw an <ApiLink to="class/ArgumentValidationError">`ArgumentValidationError`</ApiLink> for an empty string, which is what every other resource identifier has always done.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -108,10 +108,12 @@ try {
 
 Affected calls:
 
-- Clients chained off a run or build without an ID: `run.dataset()`, `run.keyValueStore()`, `run.requestQueue()`, `run.log()` and `build.log()`. Their `get()` and `delete()` throw on a 404, and so do `log().get()` and `log().stream()`. `client.log(id)` keeps resolving to `undefined`.
+- Clients chained off a run or build without an ID: `run.dataset()`, `run.keyValueStore()`, `run.requestQueue()`, `run.log()` and `build.log()`. Their `get()` and `delete()` throw on a 404, and so does `log().get()`. `client.log(id).get()` keeps resolving to `undefined`.
 - Singleton endpoints at a fixed path under a resource: <ApiLink to="class/DatasetClient#getStatistics">`DatasetClient.getStatistics()`</ApiLink>, <ApiLink to="class/UserClient#monthlyUsage">`UserClient.monthlyUsage()`</ApiLink>, <ApiLink to="class/UserClient#limits">`UserClient.limits()`</ApiLink>, <ApiLink to="class/ScheduleClient#getLog">`ScheduleClient.getLog()`</ApiLink>, <ApiLink to="class/TaskClient#getInput">`TaskClient.getInput()`</ApiLink> and <ApiLink to="class/WebhookClient#test">`WebhookClient.test()`</ApiLink>. A 404 there means the parent resource is gone, so these throw as well, and their return types drop `| undefined`.
 
-Lookups by key keep the old behavior, because there the 404 is about the record itself: <ApiLink to="class/KeyValueStoreClient#getRecord">`KeyValueStoreClient.getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`RequestQueueClient.getRequest()`</ApiLink> still resolve to `undefined`.
+Lookups by key keep the old behavior, because there the 404 is about the record itself: <ApiLink to="class/KeyValueStoreClient#getRecord">`KeyValueStoreClient.getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`RequestQueueClient.getRequest()`</ApiLink> still resolve to `undefined`, and <ApiLink to="class/KeyValueStoreClient#recordExists">`KeyValueStoreClient.recordExists()`</ApiLink> still answers `false`. <ApiLink to="class/ActorClient#lastRun">`ActorClient.lastRun()`</ApiLink> and <ApiLink to="class/TaskClient#lastRun">`TaskClient.lastRun()`</ApiLink> also keep resolving to `undefined`, where having no run yet is an ordinary outcome.
+
+<ApiLink to="class/LogClient#stream">`LogClient.stream()`</ApiLink> is not part of the change. A 404 has always thrown there, on every client, because a streamed error body is not parsed and the not-found check has no error type to match on.
 
 A <ApiLink to="class/StreamedLog">`StreamedLog`</ApiLink> whose run no longer exists logs a warning and stops, the same way it handles any other error while streaming.
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -117,6 +117,12 @@ Lookups by key keep the old behavior, because there the 404 is about the record 
 
 A <ApiLink to="class/StreamedLog">`StreamedLog`</ApiLink> whose run no longer exists logs a warning and stops, the same way it handles any other error while streaming.
 
+### An empty string is no longer accepted as a version number or environment variable name
+
+<ApiLink to="class/ActorClient#version">`ActorClient.version()`</ApiLink>, <ApiLink to="class/ActorClient#build">`ActorClient.build()`</ApiLink> and <ApiLink to="class/ActorVersionClient#envVar">`ActorVersionClient.envVar()`</ApiLink> now throw an <ApiLink to="class/ArgumentValidationError">`ArgumentValidationError`</ApiLink> for an empty string, which is what every other resource identifier has always done.
+
+An empty identifier used to build the URL of the whole collection instead of one member, so `actor.version('')` read every version of the Actor and a 404 no longer meant a missing version. Rejecting it up front keeps the 404 rules above unambiguous.
+
 ## Published types now follow the OpenAPI specification
 
 Every output type the client publishes, such as <ApiLink to="interface/Dataset">`Dataset`</ApiLink>, <ApiLink to="interface/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="interface/Build">`Build`</ApiLink>, <ApiLink to="interface/ActorRun">`ActorRun`</ApiLink>, <ApiLink to="interface/Webhook">`Webhook`</ApiLink>, <ApiLink to="interface/Schedule">`Schedule`</ApiLink>, <ApiLink to="interface/Task">`Task`</ApiLink>, <ApiLink to="interface/RequestQueue">`RequestQueue`</ApiLink>, and <ApiLink to="interface/User">`User`</ApiLink>, is now declared on top of a type generated from the published [OpenAPI specification](https://docs.apify.com/api/v2) instead of being hand-written. Several of the previous hand-written types were wrong, and some even contradicted the client's own runtime behavior. For example, `nextExclusiveStartKey` was typed as a required `string`, but `listKeys()` has always compared it to `null`.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -88,6 +88,33 @@ Some options were declared in the TypeScript types but always rejected by the cl
 
 The reverse also happened: `chunkSize` now works on every paginating `list()` method. In v2 only `DatasetClient.listItems()` accepted it - everywhere else it type-checked and then threw.
 
+## A 404 throws where it used to resolve to `undefined`
+
+Fetching a resource by ID still resolves to `undefined` when the API answers 404, and `delete()` on such a client still resolves without error. The change affects endpoints where a 404 can't be pinned to one resource: the missing thing may be the parent or the sub-resource, and the response doesn't say which. Those now throw an <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> with `statusCode` 404 instead of hiding the cause behind `undefined`.
+
+```js
+import { ApifyApiError, ApifyClient } from 'apify-client';
+
+const client = new ApifyClient({ token: 'MY-APIFY-TOKEN' });
+
+// v2: resolved to undefined on 404. v3: throws.
+let dataset;
+try {
+    dataset = await client.run('run-id').dataset().get();
+} catch (error) {
+    if (!(error instanceof ApifyApiError) || error.statusCode !== 404) throw error;
+}
+```
+
+Affected calls:
+
+- Clients chained off a run or build without an ID: `run.dataset()`, `run.keyValueStore()`, `run.requestQueue()`, `run.log()` and `build.log()`. Their `get()` and `delete()` throw on a 404, and so do `log().get()` and `log().stream()`. `client.log(id)` keeps resolving to `undefined`.
+- Singleton endpoints at a fixed path under a resource: <ApiLink to="class/DatasetClient#getStatistics">`DatasetClient.getStatistics()`</ApiLink>, <ApiLink to="class/UserClient#monthlyUsage">`UserClient.monthlyUsage()`</ApiLink>, <ApiLink to="class/UserClient#limits">`UserClient.limits()`</ApiLink>, <ApiLink to="class/ScheduleClient#getLog">`ScheduleClient.getLog()`</ApiLink>, <ApiLink to="class/TaskClient#getInput">`TaskClient.getInput()`</ApiLink> and <ApiLink to="class/WebhookClient#test">`WebhookClient.test()`</ApiLink>. A 404 there means the parent resource is gone, so these throw as well, and their return types drop `| undefined`.
+
+Lookups by key keep the old behavior, because there the 404 is about the record itself: <ApiLink to="class/KeyValueStoreClient#getRecord">`KeyValueStoreClient.getRecord()`</ApiLink> and <ApiLink to="class/RequestQueueClient#getRequest">`RequestQueueClient.getRequest()`</ApiLink> still resolve to `undefined`.
+
+A <ApiLink to="class/StreamedLog">`StreamedLog`</ApiLink> whose run no longer exists logs a warning and stops, the same way it handles any other error while streaming.
+
 ## Published types now follow the OpenAPI specification
 
 Every output type the client publishes, such as <ApiLink to="interface/Dataset">`Dataset`</ApiLink>, <ApiLink to="interface/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="interface/Build">`Build`</ApiLink>, <ApiLink to="interface/ActorRun">`ActorRun`</ApiLink>, <ApiLink to="interface/Webhook">`Webhook`</ApiLink>, <ApiLink to="interface/Schedule">`Schedule`</ApiLink>, <ApiLink to="interface/Task">`Task`</ApiLink>, <ApiLink to="interface/RequestQueue">`RequestQueue`</ApiLink>, and <ApiLink to="interface/User">`User`</ApiLink>, is now declared on top of a type generated from the published [OpenAPI specification](https://docs.apify.com/api/v2) instead of being hand-written. Several of the previous hand-written types were wrong, and some even contradicted the client's own runtime behavior. For example, `nextExclusiveStartKey` was typed as a required `string`, but `listKeys()` has always compared it to `null`.

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -2422,7 +2422,7 @@ export class DatasetClient<Data extends Record<string | number, any> = Record<st
     delete(): Promise<void>;
     downloadItems(format: DownloadItemsFormat, options?: DatasetClientDownloadItemsOptions): Promise<Buffer>;
     get(): Promise<Dataset | undefined>;
-    getStatistics(): Promise<DatasetStatistics | undefined>;
+    getStatistics(): Promise<DatasetStatistics>;
     listItems(options?: DatasetClientListItemOptions): PaginatedIterator<Data>;
     pushItems(items: Data | Data[] | string | string[]): Promise<void>;
     update(newFields: DatasetClientUpdateOptions): Promise<Dataset>;
@@ -3495,9 +3495,7 @@ export interface RequestQueueUserOptions {
 // Not exported by the entry point; reachable only as a referenced type.
 // @public
 class ResourceClient extends ApiClient {
-    // (undocumented)
     protected _delete(timeoutMillis?: number): Promise<void>;
-    // (undocumented)
     protected _get<T, R>(schema: z.ZodType, options?: T, timeoutMillis?: number): Promise<R | undefined>;
     // (undocumented)
     protected _update<T, R>(schema: z.ZodType, newFields: T, timeoutMillis?: number): Promise<R>;
@@ -3666,7 +3664,7 @@ export class ScheduleClient extends ResourceClient {
     constructor(options: ApiClientSubResourceOptions);
     delete(): Promise<void>;
     get(): Promise<Schedule | undefined>;
-    getLog(): Promise<ScheduleInvoked[] | undefined>;
+    getLog(): Promise<ScheduleInvoked[]>;
     update(newFields: ScheduleCreateOrUpdateData): Promise<Schedule>;
 }
 
@@ -3785,7 +3783,7 @@ export class TaskClient extends ResourceClient {
     call(input?: Dictionary, options?: TaskCallOptions): Promise<ActorRun>;
     delete(): Promise<void>;
     get(): Promise<Task | undefined>;
-    getInput(): Promise<Dictionary | Dictionary[] | undefined>;
+    getInput(): Promise<Dictionary | Dictionary[]>;
     lastRun(options?: TaskLastRunOptions): RunClient;
     publish(): Promise<Task>;
     runs(): RunCollectionClient;
@@ -3930,8 +3928,8 @@ export interface User extends Omit<Schemas['UserPrivateInfo'], keyof UserRePoint
 export class UserClient extends ResourceClient {
     constructor(options: ApiClientSubResourceOptions);
     get(): Promise<User>;
-    limits(): Promise<AccountAndUsageLimits | undefined>;
-    monthlyUsage(): Promise<MonthlyUsage | undefined>;
+    limits(): Promise<AccountAndUsageLimits>;
+    monthlyUsage(): Promise<MonthlyUsage>;
     updateLimits(options: LimitsUpdateOptions): Promise<void>;
 }
 
@@ -4009,7 +4007,7 @@ export class WebhookClient extends ResourceClient {
     delete(): Promise<void>;
     dispatches(): WebhookDispatchCollectionClient;
     get(): Promise<Webhook | undefined>;
-    test(): Promise<WebhookDispatch | undefined>;
+    test(): Promise<WebhookDispatch>;
     update(newFields: WebhookUpdateData): Promise<Webhook>;
 }
 

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -3927,7 +3927,7 @@ export interface User extends Omit<Schemas['UserPrivateInfo'], keyof UserRePoint
 // @public
 export class UserClient extends ResourceClient {
     constructor(options: ApiClientSubResourceOptions);
-    get(): Promise<User>;
+    get(): Promise<User | undefined>;
     limits(): Promise<AccountAndUsageLimits>;
     monthlyUsage(): Promise<MonthlyUsage>;
     updateLimits(options: LimitsUpdateOptions): Promise<void>;

--- a/src/base/resource_client.ts
+++ b/src/base/resource_client.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod';
 
 import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApifyRequestConfig } from '../http_client.js';
-import { catchNotFoundOrThrow, parseResponse } from '../utils.js';
+import { catchNotFoundForResourceOrThrow, catchNotFoundOrThrow, parseResponse } from '../utils.js';
 import { ApiClient } from './api_client.js';
 
 /**
@@ -23,6 +23,10 @@ export const DEFAULT_TIMEOUT_MILLIS = 360 * 1000; // 6 minutes
  * @private
  */
 export class ResourceClient extends ApiClient {
+    /**
+     * A 404 resolves to `undefined` only when the client names its resource by ID. A chained client without one, such
+     * as `run.dataset()`, throws it instead (see `catchNotFoundForResourceOrThrow()`).
+     */
     protected async _get<T, R>(
         schema: z.ZodType,
         options: T = {} as T,
@@ -38,7 +42,7 @@ export class ResourceClient extends ApiClient {
             const response = await this.httpClient.call(requestOpts);
             return parseResponse<R>(response, schema);
         } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
+            catchNotFoundForResourceOrThrow(err as ApifyApiError, this.id);
         }
 
         return undefined;
@@ -55,6 +59,10 @@ export class ResourceClient extends ApiClient {
         return parseResponse<R>(response, schema);
     }
 
+    /**
+     * A 404 is swallowed, keeping the DELETE idempotent, only when the client names its resource by ID. A chained client
+     * without one throws it instead (see `catchNotFoundForResourceOrThrow()`).
+     */
     protected async _delete(timeoutMillis?: number): Promise<void> {
         try {
             await this.httpClient.call({
@@ -64,7 +72,7 @@ export class ResourceClient extends ApiClient {
                 timeout: timeoutMillis,
             });
         } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
+            catchNotFoundForResourceOrThrow(err as ApifyApiError, this.id);
         }
     }
 

--- a/src/resource_clients/actor.ts
+++ b/src/resource_clients/actor.ts
@@ -49,7 +49,7 @@ const validateInputOptionsSchema = z.strictObject({
     build: z.string().optional(),
     contentType: z.string().optional(),
 });
-const versionNumberSchema = z.string();
+const versionNumberSchema = z.string().min(1);
 const buildOptionsSchema = z.strictObject({
     betaPackages: z.boolean().optional(),
     tag: z.string().optional(),

--- a/src/resource_clients/actor_version.ts
+++ b/src/resource_clients/actor_version.ts
@@ -8,7 +8,7 @@ import { anyObjectSchema, parseArgument } from '../utils.js';
 import { ActorEnvVarClient } from './actor_env_var.js';
 import { ActorEnvVarCollectionClient } from './actor_env_var_collection.js';
 
-const envVarNameSchema = z.string();
+const envVarNameSchema = z.string().min(1);
 
 export type {
     ActorEnvironmentVariable,

--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -159,6 +159,9 @@ export class BuildClient extends ResourceClient {
     /**
      * Returns a client for accessing the log of this Actor build.
      *
+     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the build itself
+     * may be what is missing.
+     *
      * @returns A client for accessing the build's log
      * @see https://docs.apify.com/api/v2/actor-build-log-get
      *

--- a/src/resource_clients/build.ts
+++ b/src/resource_clients/build.ts
@@ -159,8 +159,7 @@ export class BuildClient extends ResourceClient {
     /**
      * Returns a client for accessing the log of this Actor build.
      *
-     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the build itself
-     * may be what is missing.
+     * A 404 from this client throws an `ApifyApiError`, since the build itself may be what is missing.
      *
      * @returns A client for accessing the build's log
      * @see https://docs.apify.com/api/v2/actor-build-log-get

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import type { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 import { createStorageContentSignatureAsync } from '@apify/utilities';
 
-import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import {
     DEFAULT_TIMEOUT_MILLIS,
@@ -11,7 +10,7 @@ import {
     ResourceClient,
     SMALL_TIMEOUT_MILLIS,
 } from '../base/resource_client.js';
-import type { ApifyRequestConfig, ApifyResponse } from '../http_client.js';
+import type { ApifyResponse } from '../http_client.js';
 import type { Dataset, DatasetStatistics } from '../models.js';
 import type { PaginatedIterator, PaginatedList, PaginationOptions } from '../utils.js';
 import * as schemas from '../schemas.js';
@@ -19,7 +18,6 @@ import {
     anyObjectSchema,
     applyQueryParamsToUrl,
     cast,
-    catchNotFoundOrThrow,
     isNonArrayObject,
     paginationOptionsShape,
     parseArgument,
@@ -332,24 +330,18 @@ export class DatasetClient<
      * Returns statistics for each field in the dataset, including information about
      * data types, null counts, and value ranges.
      *
-     * @returns Dataset statistics, or `undefined` if not available
+     * @returns Dataset statistics
      * @see https://docs.apify.com/api/v2/dataset-statistics-get
      * @since Added in 2.11.2
      */
-    async getStatistics(): Promise<DatasetStatistics | undefined> {
-        const requestOpts: ApifyRequestConfig = {
+    async getStatistics(): Promise<DatasetStatistics> {
+        const response = await this.httpClient.call({
             url: this._url('statistics'),
             method: 'GET',
             params: this._params(),
             timeout: SMALL_TIMEOUT_MILLIS,
-        };
-        try {
-            const response = await this.httpClient.call(requestOpts);
-            return parseResponse(response, schemas.DatasetStatistics());
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-        return undefined;
+        });
+        return parseResponse(response, schemas.DatasetStatistics());
     }
 
     /**

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -10,7 +10,7 @@ import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyRequestConfig } from '../http_client.js';
-import { cast, catchNotFoundOrThrow } from '../utils.js';
+import { cast, catchNotFoundForResourceOrThrow } from '../utils.js';
 
 /**
  * Client for accessing Actor run or build logs.
@@ -50,7 +50,8 @@ export class LogClient extends ResourceClient {
      *
      * @param options - Log retrieval options.
      * @param options.raw - If `true`, returns raw log content without any processing. Default is `false`.
-     * @returns The log content as a string, or `undefined` if it does not exist.
+     * @returns The log content as a string, or `undefined` if it does not exist. A chained client such as
+     * `run.log()` throws an `ApifyApiError` on a 404 instead, since the run itself may be what is missing.
      * @see https://docs.apify.com/api/v2/log-get
      */
     async get(options: LogOptions = {}): Promise<string | undefined> {
@@ -64,7 +65,7 @@ export class LogClient extends ResourceClient {
             const response = await this.httpClient.call(requestOpts);
             return cast(response.data);
         } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
+            catchNotFoundForResourceOrThrow(err as ApifyApiError, this.id);
         }
 
         return undefined;
@@ -75,7 +76,8 @@ export class LogClient extends ResourceClient {
      *
      * @param options - Log retrieval options.
      * @param options.raw - If `true`, returns raw log content without any processing. Default is `false`.
-     * @returns The log content as a Readable stream, or `undefined` if it does not exist.
+     * @returns The log content as a Readable stream, or `undefined` if it does not exist. A chained client such as
+     * `run.log()` throws an `ApifyApiError` on a 404 instead, since the run itself may be what is missing.
      * @see https://docs.apify.com/api/v2/log-get
      */
     async stream(options: LogOptions = {}): Promise<Readable | undefined> {
@@ -95,7 +97,7 @@ export class LogClient extends ResourceClient {
             const response = await this.httpClient.call(requestOpts);
             return cast(response.data);
         } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
+            catchNotFoundForResourceOrThrow(err as ApifyApiError, this.id);
         }
 
         return undefined;
@@ -198,11 +200,11 @@ export class StreamedLog {
      * Get log stream from response and redirect it to another log.
      */
     private async streamLog(): Promise<void> {
-        const logStream = await this.logClient.stream({ raw: true });
-        if (!logStream) {
-            return;
-        }
         try {
+            const logStream = await this.logClient.stream({ raw: true });
+            if (!logStream) {
+                return;
+            }
             const lastChunkRemainder = await this.logStreamChunks(logStream);
             // Process whatever is left when exiting. Maybe it is incomplete, maybe it is last log without EOL.
             const lastMessage = Buffer.from(lastChunkRemainder).toString().trim();

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -76,8 +76,9 @@ export class LogClient extends ResourceClient {
      *
      * @param options - Log retrieval options.
      * @param options.raw - If `true`, returns raw log content without any processing. Default is `false`.
-     * @returns The log content as a Readable stream, or `undefined` if it does not exist. A chained client such as
-     * `run.log()` throws an `ApifyApiError` on a 404 instead, since the run itself may be what is missing.
+     * @returns The log content as a Readable stream. A 404 throws an `ApifyApiError` rather than resolving to
+     * `undefined`, whichever client this is: a streamed response body is never parsed, so the error carries no type
+     * for the not-found check to match on.
      * @see https://docs.apify.com/api/v2/log-get
      */
     async stream(options: LogOptions = {}): Promise<Readable | undefined> {

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -51,7 +51,7 @@ export class LogClient extends ResourceClient {
      * @param options - Log retrieval options.
      * @param options.raw - If `true`, returns raw log content without any processing. Default is `false`.
      * @returns The log content as a string, or `undefined` if it does not exist. A chained client such as
-     * `run.log()` throws an `ApifyApiError` on a 404 instead, since the run itself may be what is missing.
+     * `run.log()` throws an `ApifyApiError` on a 404, since the run itself may be what is missing.
      * @see https://docs.apify.com/api/v2/log-get
      */
     async get(options: LogOptions = {}): Promise<string | undefined> {
@@ -77,7 +77,7 @@ export class LogClient extends ResourceClient {
      * @param options - Log retrieval options.
      * @param options.raw - If `true`, returns raw log content without any processing. Default is `false`.
      * @returns The log content as a Readable stream, or `undefined` if it does not exist. A chained client such as
-     * `run.log()` throws an `ApifyApiError` on a 404 instead, since the run itself may be what is missing.
+     * `run.log()` throws an `ApifyApiError` on a 404, since the run itself may be what is missing.
      * @see https://docs.apify.com/api/v2/log-get
      */
     async stream(options: LogOptions = {}): Promise<Readable | undefined> {

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -377,8 +377,8 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default key-value store of this Actor run.
      *
-     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
-     * may be what is missing.
+     * `get()` and `delete()` throw an `ApifyApiError` on a 404 rather than resolving to `undefined`, since the run
+     * itself may be what is missing. Record lookups such as `getRecord()` keep reading a 404 as a missing record.
      *
      * @returns A client for accessing the run's default key-value store
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -400,8 +400,8 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default Request queue of this Actor run.
      *
-     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
-     * may be what is missing.
+     * `get()` and `delete()` throw an `ApifyApiError` on a 404 rather than resolving to `undefined`, since the run
+     * itself may be what is missing. `getRequest()` keeps reading a 404 as a missing request.
      *
      * @returns A client for accessing the run's default Request queue
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -462,8 +462,8 @@ export class RunClient extends ResourceClient {
             const runId = runData?.id ?? '';
 
             const actorId = runData?.actId ?? '';
-            const actorData = (await this.apifyClient.actor(actorId).get()) || { name: '' };
-
+            // `apifyClient.actor()` rejects an empty ID, which is what a run that could not be read leaves here.
+            const actorData = actorId ? await this.apifyClient.actor(actorId).get() : undefined;
             const actorName = actorData?.name ?? '';
             const name = [actorName, `runId:${runId}`].filter(Boolean).join(' ');
 

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -354,8 +354,7 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default dataset of this Actor run.
      *
-     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
-     * may be what is missing.
+     * A 404 from this client throws an `ApifyApiError`, since the run itself may be what is missing.
      *
      * @returns A client for accessing the run's default dataset
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -377,8 +376,8 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default key-value store of this Actor run.
      *
-     * `get()` and `delete()` throw an `ApifyApiError` on a 404 rather than resolving to `undefined`, since the run
-     * itself may be what is missing. Record lookups such as `getRecord()` keep reading a 404 as a missing record.
+     * `get()` and `delete()` throw an `ApifyApiError` on a 404, since the run itself may be what is missing. Record
+     * lookups such as `getRecord()` read a 404 as a missing record.
      *
      * @returns A client for accessing the run's default key-value store
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -400,8 +399,8 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default Request queue of this Actor run.
      *
-     * `get()` and `delete()` throw an `ApifyApiError` on a 404 rather than resolving to `undefined`, since the run
-     * itself may be what is missing. `getRequest()` keeps reading a 404 as a missing request.
+     * `get()` and `delete()` throw an `ApifyApiError` on a 404, since the run itself may be what is missing.
+     * `getRequest()` reads a 404 as a missing request.
      *
      * @returns A client for accessing the run's default Request queue
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -423,8 +422,7 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for accessing the log of this Actor run.
      *
-     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
-     * may be what is missing.
+     * A 404 from this client throws an `ApifyApiError`, since the run itself may be what is missing.
      *
      * @returns A client for accessing the run's log
      * @see https://docs.apify.com/api/v2/actor-run-get

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -354,6 +354,9 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default dataset of this Actor run.
      *
+     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
+     * may be what is missing.
+     *
      * @returns A client for accessing the run's default dataset
      * @see https://docs.apify.com/api/v2/actor-run-get
      *
@@ -373,6 +376,9 @@ export class RunClient extends ResourceClient {
 
     /**
      * Returns a client for the default key-value store of this Actor run.
+     *
+     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
+     * may be what is missing.
      *
      * @returns A client for accessing the run's default key-value store
      * @see https://docs.apify.com/api/v2/actor-run-get
@@ -394,6 +400,9 @@ export class RunClient extends ResourceClient {
     /**
      * Returns a client for the default Request queue of this Actor run.
      *
+     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
+     * may be what is missing.
+     *
      * @returns A client for accessing the run's default Request queue
      * @see https://docs.apify.com/api/v2/actor-run-get
      *
@@ -413,6 +422,9 @@ export class RunClient extends ResourceClient {
 
     /**
      * Returns a client for accessing the log of this Actor run.
+     *
+     * A 404 from this client throws an `ApifyApiError` rather than resolving to `undefined`, since the run itself
+     * may be what is missing.
      *
      * @returns A client for accessing the run's log
      * @see https://docs.apify.com/api/v2/actor-run-get

--- a/src/resource_clients/schedule.ts
+++ b/src/resource_clients/schedule.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 
-import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
-import type { ApifyRequestConfig } from '../http_client.js';
 import type { Schedule, ScheduleAction, ScheduleInvoked } from '../models.js';
 import type { DistributiveOptional } from '../utils.js';
 import * as schemas from '../schemas.js';
-import { anyObjectSchema, catchNotFoundOrThrow, parseArgument, parseResponse } from '../utils.js';
+import { anyObjectSchema, parseArgument, parseResponse } from '../utils.js';
 
 export type {
     Schedule,
@@ -90,23 +88,16 @@ export class ScheduleClient extends ResourceClient {
     /**
      * Retrieves the schedule's log.
      *
-     * @returns The schedule log, one entry per invocation, or `undefined` if the schedule does not exist.
+     * @returns The schedule log, one entry per invocation.
      * @see https://docs.apify.com/api/v2/schedule-log-get
      */
-    async getLog(): Promise<ScheduleInvoked[] | undefined> {
-        const requestOpts: ApifyRequestConfig = {
+    async getLog(): Promise<ScheduleInvoked[]> {
+        const response = await this.httpClient.call({
             url: this._url('log'),
             method: 'GET',
             params: this._params(),
-        };
-        try {
-            const response = await this.httpClient.call(requestOpts);
-            return parseResponse(response, scheduleLogSchema);
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-
-        return undefined;
+        });
+        return parseResponse(response, scheduleLogSchema);
     }
 }
 

--- a/src/resource_clients/task.ts
+++ b/src/resource_clients/task.ts
@@ -2,21 +2,13 @@ import { z } from 'zod';
 
 import { ACT_JOB_STATUSES, META_ORIGINS } from '@apify/consts';
 
-import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyRequestConfig } from '../http_client.js';
 import type { Task, TaskPublicConfig } from '../models.js';
 import type { Dictionary } from '../utils.js';
 import * as schemas from '../schemas.js';
-import {
-    anyObjectSchema,
-    cast,
-    catchNotFoundOrThrow,
-    parseArgument,
-    parseResponse,
-    stringifyWebhooksToBase64,
-} from '../utils.js';
+import { anyObjectSchema, cast, parseArgument, parseResponse, stringifyWebhooksToBase64 } from '../utils.js';
 import type { ActorLastRunOptions, ActorRun, ActorStartOptions } from './actor.js';
 import { RunClient } from './run.js';
 import { RunCollectionClient } from './run_collection.js';
@@ -229,23 +221,16 @@ export class TaskClient extends ResourceClient {
     /**
      * Retrieves the Actor task's input object.
      *
-     * @returns The Task's input, or `undefined` if it does not exist.
+     * @returns The Task's input.
      * @see https://docs.apify.com/api/v2/actor-task-input-get
      */
-    async getInput(): Promise<Dictionary | Dictionary[] | undefined> {
-        const requestOpts: ApifyRequestConfig = {
+    async getInput(): Promise<Dictionary | Dictionary[]> {
+        const response = await this.httpClient.call({
             url: this._url('input'),
             method: 'GET',
             params: this._params(),
-        };
-        try {
-            const response = await this.httpClient.call(requestOpts);
-            return cast(response.data);
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-
-        return undefined;
+        });
+        return cast(response.data);
     }
 
     /**

--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -67,11 +67,11 @@ export class UserClient extends ResourceClient {
      * Depending on whether ApifyClient was created with a token,
      * the method will either return public or private user data.
      *
-     * @returns The user object.
+     * @returns The user object, or `undefined` if it does not exist.
      * @see https://docs.apify.com/api/v2/user-get
      */
-    async get(): Promise<User> {
-        return this._get(schemas.UserPrivateInfo()) as Promise<User>;
+    async get(): Promise<User | undefined> {
+        return this._get(schemas.UserPrivateInfo());
     }
 
     /**

--- a/src/resource_clients/user.ts
+++ b/src/resource_clients/user.ts
@@ -1,10 +1,9 @@
-import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyRequestConfig } from '../http_client.js';
 import type { AccountAndUsageLimits, MonthlyUsage, User } from '../models.js';
 import * as schemas from '../schemas.js';
-import { catchNotFoundOrThrow, parseResponse } from '../utils.js';
+import { parseResponse } from '../utils.js';
 
 export type {
     AccountAndUsageLimits,
@@ -78,48 +77,34 @@ export class UserClient extends ResourceClient {
     /**
      * Retrieves the user's monthly usage data.
      *
-     * @returns The monthly usage object, or `undefined` if it does not exist.
+     * @returns The monthly usage object.
      * @see https://docs.apify.com/api/v2/users-me-usage-monthly-get
      * @since Added in 2.9.2
      */
-    async monthlyUsage(): Promise<MonthlyUsage | undefined> {
-        const requestOpts: ApifyRequestConfig = {
+    async monthlyUsage(): Promise<MonthlyUsage> {
+        const response = await this.httpClient.call({
             url: this._url('usage/monthly'),
             method: 'GET',
             params: this._params(),
-        };
-        try {
-            const response = await this.httpClient.call(requestOpts);
-            // `dailyServiceUsages[].date` does not end in `At`, so it has to be named for `parseDateFields`.
-            return parseResponse(response, schemas.MonthlyUsage(), (key) => key === 'date');
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-
-        return undefined;
+        });
+        // `dailyServiceUsages[].date` does not end in `At`, so it has to be named for `parseDateFields`.
+        return parseResponse(response, schemas.MonthlyUsage(), (key) => key === 'date');
     }
 
     /**
      * Retrieves the user's account and usage limits.
      *
-     * @returns The account and usage limits object, or `undefined` if it does not exist.
+     * @returns The account and usage limits object.
      * @see https://docs.apify.com/api/v2/users-me-limits-get
      * @since Added in 2.9.2
      */
-    async limits(): Promise<AccountAndUsageLimits | undefined> {
-        const requestOpts: ApifyRequestConfig = {
+    async limits(): Promise<AccountAndUsageLimits> {
+        const response = await this.httpClient.call({
             url: this._url('limits'),
             method: 'GET',
             params: this._params(),
-        };
-        try {
-            const response = await this.httpClient.call(requestOpts);
-            return parseResponse(response, schemas.AccountLimits());
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-
-        return undefined;
+        });
+        return parseResponse(response, schemas.AccountLimits());
     }
 
     /**

--- a/src/resource_clients/webhook.ts
+++ b/src/resource_clients/webhook.ts
@@ -1,10 +1,8 @@
-import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
-import type { ApifyRequestConfig } from '../http_client.js';
 import type { Webhook, WebhookEventType } from '../models.js';
 import * as schemas from '../schemas.js';
-import { anyObjectSchema, catchNotFoundOrThrow, parseArgument, parseResponse } from '../utils.js';
+import { anyObjectSchema, parseArgument, parseResponse } from '../utils.js';
 import type { WebhookDispatch } from './webhook_dispatch.js';
 import { WebhookDispatchCollectionClient } from './webhook_dispatch_collection.js';
 
@@ -93,24 +91,16 @@ export class WebhookClient extends ResourceClient {
     /**
      * Tests the webhook by dispatching a test event.
      *
-     * @returns The webhook dispatch object, or `undefined` if the test fails.
+     * @returns The webhook dispatch object.
      * @see https://docs.apify.com/api/v2/webhook-test-post
      */
-    async test(): Promise<WebhookDispatch | undefined> {
-        const request: ApifyRequestConfig = {
+    async test(): Promise<WebhookDispatch> {
+        const response = await this.httpClient.call({
             url: this._url('test'),
             method: 'POST',
             params: this._params(),
-        };
-
-        try {
-            const response = await this.httpClient.call(request);
-            return parseResponse(response, schemas.WebhookDispatch());
-        } catch (err) {
-            catchNotFoundOrThrow(err as ApifyApiError);
-        }
-
-        return undefined;
+        });
+        return parseResponse(response, schemas.WebhookDispatch());
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,19 @@ export function catchNotFoundOrThrow(err: ApifyApiError): void {
     if (!isNotFoundError) throw err;
 }
 
+/**
+ * Like `catchNotFoundOrThrow()`, but swallows the 404 only when the client names its resource by ID.
+ *
+ * A chained client without an ID, such as `run.dataset()` or `run.log()`, requests a path where a 404 can mean either
+ * the parent or the default sub-resource is missing. The response cannot tell the two apart, so the error propagates
+ * instead of collapsing into `undefined`.
+ * @internal
+ */
+export function catchNotFoundForResourceOrThrow(err: ApifyApiError, resourceId: string | undefined): void {
+    if (resourceId === undefined) throw err;
+    catchNotFoundOrThrow(err);
+}
+
 type ReturnJsonValue = string | number | boolean | null | Date | ReturnJsonObject | ReturnJsonArray;
 type ReturnJsonObject = { [Key in string]?: ReturnJsonValue };
 type ReturnJsonArray = ReturnJsonValue[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,8 +100,7 @@ export function catchNotFoundOrThrow(err: ApifyApiError): void {
  * Like `catchNotFoundOrThrow()`, but swallows the 404 only when the client names its resource by ID.
  *
  * A chained client without an ID, such as `run.dataset()` or `run.log()`, requests a path where a 404 can mean either
- * the parent or the default sub-resource is missing. The response cannot tell the two apart, so the error propagates
- * instead of collapsing into `undefined`.
+ * the parent or the default sub-resource is missing. The response cannot tell the two apart, so the error propagates.
  * @internal
  */
 export function catchNotFoundForResourceOrThrow(err: ApifyApiError, resourceId: string | undefined): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,7 @@ export function catchNotFoundOrThrow(err: ApifyApiError): void {
  * @internal
  */
 export function catchNotFoundForResourceOrThrow(err: ApifyApiError, resourceId: string | undefined): void {
-    if (resourceId === undefined) throw err;
+    if (!resourceId) throw err;
     catchNotFoundOrThrow(err);
 }
 

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -4,7 +4,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import c from 'ansi-colors';
 import type { ActorCollectionCreateOptions } from 'apify-client';
-import { ActorListSortBy, ActorSourceType, ApifyClient, LoggerActorRedirect } from 'apify-client';
+import { ActorListSortBy, ActorSourceType, ApifyApiError, ApifyClient, LoggerActorRedirect } from 'apify-client';
 import express from 'express';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -460,6 +460,29 @@ describe('Actor methods', () => {
         });
 
         describe('lastRun()', () => {
+            test('get() returns undefined on 404 status code (RECORD_NOT_FOUND)', async () => {
+                const actorId = '404';
+
+                const res = await client.actor(actorId).lastRun().get();
+                expect(res).toBeUndefined();
+                validateRequest({ query: {}, params: { actorId } });
+
+                const browserRes = await page.evaluate((aId) => client.actor(aId).lastRun().get(), actorId);
+                expect(browserRes).toBeUndefined();
+            });
+
+            test('dataset().get() throws on 404 status code', async () => {
+                const actorId = '404';
+
+                const call = client.actor(actorId).lastRun().dataset().get();
+                await expect(call).rejects.toThrow(ApifyApiError);
+                await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+                await expect(
+                    page.evaluate((aId) => client.actor(aId).lastRun().dataset().get(), actorId),
+                ).rejects.toThrow();
+            });
+
             test.each(['get', 'dataset', 'keyValueStore', 'requestQueue', 'log'] as const)(
                 '%s() works',
                 async (method) => {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -661,7 +661,7 @@ describe('Actor methods', () => {
 
             test('rejects an empty version number', async () => {
                 // An empty ID makes `ApiClient` build the collection URL, so the client would address
-                // every version instead of one, and a 404 could no longer be read as a missing version.
+                // every version instead of one, and a 404 could not be read as a missing version.
                 const call = () => client.actor('some-id').version('');
                 expect(call).toThrow(ArgumentValidationError);
                 expect(call).toThrow('Too small');

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -4,7 +4,14 @@ import { setTimeout } from 'node:timers/promises';
 
 import c from 'ansi-colors';
 import type { ActorCollectionCreateOptions } from 'apify-client';
-import { ActorListSortBy, ActorSourceType, ApifyApiError, ApifyClient, LoggerActorRedirect } from 'apify-client';
+import {
+    ActorListSortBy,
+    ActorSourceType,
+    ApifyApiError,
+    ApifyClient,
+    ArgumentValidationError,
+    LoggerActorRedirect,
+} from 'apify-client';
 import express from 'express';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -652,6 +659,14 @@ describe('Actor methods', () => {
                 validateRequest({ query: {}, params: { actorId, versionNumber } });
             });
 
+            test('rejects an empty version number', async () => {
+                // An empty ID makes `ApiClient` build the collection URL, so the client would address
+                // every version instead of one, and a 404 could no longer be read as a missing version.
+                const call = () => client.actor('some-id').version('');
+                expect(call).toThrow(ArgumentValidationError);
+                expect(call).toThrow('Too small');
+            });
+
             test('update() works', async () => {
                 const actorId = 'some-user/some-id';
                 const versionNumber = '0.0';
@@ -789,6 +804,12 @@ describe('Actor methods', () => {
                 );
                 expect(browserRes).toEqual(asBrowserResult(res));
                 validateRequest({ query: {}, params: { actorId, versionNumber, envVarName } });
+            });
+
+            test('rejects an empty environment variable name', async () => {
+                const call = () => client.actor('some-id').version('0.0').envVar('');
+                expect(call).toThrow(ArgumentValidationError);
+                expect(call).toThrow('Too small');
             });
 
             test('update() works', async () => {

--- a/test/builds.test.ts
+++ b/test/builds.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -137,6 +137,16 @@ describe('Build methods', () => {
             const browserRes = await page.evaluate((id) => client.build(id).log().get(), buildId);
             expect(browserRes).toEqual('build-log');
             validateRequest({ query: {}, params: { buildId } });
+        });
+
+        test('log().get() throws on 404 status code', async () => {
+            const buildId = '404';
+
+            const call = client.build(buildId).log().get();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id) => client.build(id).log().get(), buildId)).rejects.toThrow();
         });
     });
 });

--- a/test/datasets.test.ts
+++ b/test/datasets.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient, ArgumentValidationError, DownloadItemsFormat } from 'apify-client';
+import { ApifyApiError, ApifyClient, ArgumentValidationError, DownloadItemsFormat } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from 'vitest';
 
@@ -115,6 +115,13 @@ describe('Dataset methods', () => {
 
             const browserRes = await page.evaluate((id) => client.dataset(id).delete(), datasetId);
             expect(browserRes).toEqual(asBrowserResult(res));
+            validateRequest({ query: {}, params: { datasetId } });
+        });
+
+        test('delete() resolves on 404 status code (RECORD_NOT_FOUND)', async () => {
+            const datasetId = '404';
+
+            await expect(client.dataset(datasetId).delete()).resolves.toBeUndefined();
             validateRequest({ query: {}, params: { datasetId } });
         });
 
@@ -397,6 +404,16 @@ describe('Dataset methods', () => {
             const browserRes = await page.evaluate((id) => client.dataset(id).getStatistics(), datasetId);
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest({ query: {}, params: { datasetId } });
+        });
+
+        test('getStatistics() throws on 404 status code', async () => {
+            const datasetId = '404';
+
+            const call = client.dataset(datasetId).getStatistics();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id) => client.dataset(id).getStatistics(), datasetId)).rejects.toThrow();
         });
 
         describe('createItemsPublicUrl()', () => {

--- a/test/integration/apify_client.test.ts
+++ b/test/integration/apify_client.test.ts
@@ -13,5 +13,5 @@ beforeAll(() => {
 test('the client authenticates against the live API and resolves the current user', async () => {
     const me = await client.user('me').get();
 
-    expect(me.username).toBeTruthy();
+    expect(me?.username).toBeTruthy();
 });

--- a/test/integration/dataset.test.ts
+++ b/test/integration/dataset.test.ts
@@ -370,8 +370,7 @@ test('getStatistics() returns per-field statistics', async () => {
 
         const statistics = await datasetClient.getStatistics();
 
-        expect(statistics).toBeDefined();
-        expect(statistics!.fieldStatistics).toBeTypeOf('object');
+        expect(statistics.fieldStatistics).toBeTypeOf('object');
     } finally {
         await datasetClient.delete();
     }

--- a/test/integration/log.test.ts
+++ b/test/integration/log.test.ts
@@ -47,8 +47,7 @@ test('get() returns the log of a build', async () => {
 
     const log = await client.build(buildsPage.items[0].id).log().get();
 
-    // A build log can legitimately be empty, so only its presence is pinned - `get()` answers with
-    // `undefined` on a 404, which is the failure this is here to catch.
+    // A build log can legitimately be empty, so only its presence is pinned.
     expect(log).toBeDefined();
 });
 

--- a/test/integration/schedule.test.ts
+++ b/test/integration/schedule.test.ts
@@ -136,9 +136,7 @@ test('getLog() works on a schedule that has never run', async () => {
         const log = await scheduleClient.getLog();
 
         // The API answers with an array of log entries, empty for a schedule that never fired.
-        // `getLog` declares `Promise<string | undefined>`, which does not match, hence the cast.
-        expect(Array.isArray(log as unknown)).toBe(true);
-        expect(log as unknown as unknown[]).toHaveLength(0);
+        expect(log).toHaveLength(0);
     } finally {
         await scheduleClient.delete();
     }

--- a/test/integration/user.test.ts
+++ b/test/integration/user.test.ts
@@ -13,7 +13,7 @@ beforeAll(() => {
 test('user().get() returns the authenticated user', async () => {
     const user = await client.user().get();
 
-    expect(user.username).toBeTruthy();
+    expect(user?.username).toBeTruthy();
 });
 
 test('user().limits() returns the account limits and current usage', async () => {

--- a/test/integration/user.test.ts
+++ b/test/integration/user.test.ts
@@ -19,30 +19,27 @@ test('user().get() returns the authenticated user', async () => {
 test('user().limits() returns the account limits and current usage', async () => {
     const limits = await client.user().limits();
 
-    expect(limits).toBeDefined();
-    expect(limits!.limits).toBeTypeOf('object');
-    expect(limits!.current).toBeTypeOf('object');
-    expect(limits!.monthlyUsageCycle.startAt).toBeInstanceOf(Date);
+    expect(limits.limits).toBeTypeOf('object');
+    expect(limits.current).toBeTypeOf('object');
+    expect(limits.monthlyUsageCycle.startAt).toBeInstanceOf(Date);
 });
 
 test('user().monthlyUsage() returns the current billing cycle usage', async () => {
     const usage = await client.user().monthlyUsage();
 
-    expect(usage).toBeDefined();
-    expect(usage!.usageCycle.startAt).toBeInstanceOf(Date);
-    expect(usage!.monthlyServiceUsage).toBeTypeOf('object');
-    expect(Array.isArray(usage!.dailyServiceUsages)).toBe(true);
+    expect(usage.usageCycle.startAt).toBeInstanceOf(Date);
+    expect(usage.monthlyServiceUsage).toBeTypeOf('object');
+    expect(Array.isArray(usage.dailyServiceUsages)).toBe(true);
 });
 
 test('user().updateLimits() is accepted, or rejected with a client error the account does not allow', async () => {
     const accountLimits = await client.user().limits();
-    expect(accountLimits, 'the account limits could not be read').toBeDefined();
 
     // Data retention is an account-wide setting shared with every other suite and with the parallel
     // Node-version job, so the value it already has is written back rather than a new one. That still
     // exercises the request end to end, without a concurrent run observing or restoring the change.
     try {
-        await client.user().updateLimits({ dataRetentionDays: accountLimits!.limits.dataRetentionDays });
+        await client.user().updateLimits({ dataRetentionDays: accountLimits.limits.dataRetentionDays });
     } catch (err) {
         // Free accounts reject changes to their limits outright, so a 400 or 403 is as valid an outcome
         // here as success - anything else means the request itself was malformed.

--- a/test/integration/webhook.test.ts
+++ b/test/integration/webhook.test.ts
@@ -92,7 +92,7 @@ test('test() creates a dispatch carrying a dummy payload', async () => {
     try {
         const dispatch = await webhookClient.test();
 
-        expect(dispatch?.id).toBeTruthy();
+        expect(dispatch.id).toBeTruthy();
     } finally {
         await webhookClient.delete();
     }

--- a/test/logs.test.ts
+++ b/test/logs.test.ts
@@ -49,6 +49,17 @@ describe('Log methods', () => {
             validateRequest({ query: {}, params: { logId } });
         });
 
+        test('get() returns undefined on 404 status code (RECORD_NOT_FOUND)', async () => {
+            const logId = '404';
+
+            const res = await client.log(logId).get();
+            expect(res).toBeUndefined();
+            validateRequest({ query: {}, params: { logId } });
+
+            const browserRes = await page.evaluate((id) => client.log(id).get(), logId);
+            expect(browserRes).toBeUndefined();
+        });
+
         test('stream() works', async () => {
             const logId = 'some-id';
 

--- a/test/logs.test.ts
+++ b/test/logs.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -75,6 +75,17 @@ describe('Log methods', () => {
             }
             const id = Buffer.concat(chunks).toString();
             expect(id).toBe('get-log');
+            validateRequest({ query: { stream: true }, params: { logId } });
+        });
+
+        test('stream() throws on 404 status code', async () => {
+            const logId = '404';
+
+            // A streamed response body is never parsed, so the error carries no type for the not-found check to
+            // match on. The 404 propagates even though the log is addressed by ID.
+            const call = client.log(logId).stream();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
             validateRequest({ query: { stream: true }, params: { logId } });
         });
     });

--- a/test/mock_server/routes/add_routes.ts
+++ b/test/mock_server/routes/add_routes.ts
@@ -43,7 +43,7 @@ const HANDLERS = {
             const context = maybeParseContextFromResourceId(resourceId);
             const delayMillis = context && context.delayMillis;
             setTimeout(() => {
-                res.send(payload);
+                res.status(responseStatusCode).send(payload);
             }, delayMillis || 0);
         };
     },

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -2,9 +2,11 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout as setTimeoutNode } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import { ApifyClient, ArgumentValidationError } from 'apify-client';
+import { ApifyApiError, ApifyClient, ArgumentValidationError, LoggerActorRedirect, StreamedLog } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { LEVELS, Log } from '@apify/log';
 
 import { DEFAULT_OPTIONS, asBrowserResult, Browser, validateRequest } from './_helper.js';
 import * as fixtures from './mock_server/fixtures.js';
@@ -384,6 +386,27 @@ describe('Run methods', () => {
             validateRequest({ query: {}, params: { runId } });
         });
 
+        test.each(['dataset', 'keyValueStore', 'requestQueue', 'log'] as const)(
+            '%s().get() throws on 404 status code',
+            async (method) => {
+                const runId = '404';
+
+                const call = client.run(runId)[method]().get();
+                await expect(call).rejects.toThrow(ApifyApiError);
+                await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+                await expect(page.evaluate((rId, m) => client.run(rId)[m]().get(), runId, method)).rejects.toThrow();
+            },
+        );
+
+        test('dataset().delete() throws on 404 status code', async () => {
+            const runId = '404';
+
+            const call = client.run(runId).dataset().delete();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+        });
+
         test('charge() works', async () => {
             const runId = 'some-run-id';
 
@@ -449,6 +472,22 @@ describe('Redirect run logs', () => {
             const loggerPrefix = c.cyan('redirect-actor-name runId:redirect-run-id -> ');
             expect(logSpy.mock.calls).toEqual(expected.map((item) => [loggerPrefix + item]));
             logSpy.mockRestore();
+        });
+    });
+
+    describe('run.getStreamedLog missing run', () => {
+        test('logs warning instead of throwing when the run log answers 404', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const toLog = new Log({ level: LEVELS.DEBUG, prefix: 'missing -> ', logger: new LoggerActorRedirect() });
+            const streamedLog = new StreamedLog({ logClient: client.run('404').log(), toLog, fromStart: true });
+            streamedLog.start();
+            await expect(streamedLog.stop()).resolves.not.toThrow();
+            expect(
+                warnSpy.mock.calls.some(
+                    ([msg]) => typeof msg === 'string' && msg.includes('Log redirection stopped due to error'),
+                ),
+            ).toBe(true);
+            warnSpy.mockRestore();
         });
     });
 

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -2,11 +2,9 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout as setTimeoutNode } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import { ApifyApiError, ApifyClient, ArgumentValidationError, LoggerActorRedirect, StreamedLog } from 'apify-client';
+import { ApifyApiError, ApifyClient, ArgumentValidationError } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { LEVELS, Log } from '@apify/log';
 
 import { DEFAULT_OPTIONS, asBrowserResult, Browser, validateRequest } from './_helper.js';
 import * as fixtures from './mock_server/fixtures.js';
@@ -478,10 +476,9 @@ describe('Redirect run logs', () => {
     describe('run.getStreamedLog missing run', () => {
         test('logs warning instead of throwing when the run log answers 404', async () => {
             const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-            const toLog = new Log({ level: LEVELS.DEBUG, prefix: 'missing -> ', logger: new LoggerActorRedirect() });
-            const streamedLog = new StreamedLog({ logClient: client.run('404').log(), toLog, fromStart: true });
-            streamedLog.start();
-            await expect(streamedLog.stop()).resolves.not.toThrow();
+            const streamedLog = await client.run('404').getStreamedLog({ fromStart: true });
+            streamedLog?.start();
+            await expect(streamedLog?.stop()).resolves.not.toThrow();
             expect(
                 warnSpy.mock.calls.some(
                     ([msg]) => typeof msg === 'string' && msg.includes('Log redirection stopped due to error'),

--- a/test/schedules.test.ts
+++ b/test/schedules.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -133,6 +133,16 @@ describe('Schedule methods', () => {
             const browserRes = await page.evaluate((id) => client.schedule(id).getLog(), scheduleId);
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest({ query: {}, params: { scheduleId } });
+        });
+
+        test('getLog() throws on 404 status code', async () => {
+            const scheduleId = '404';
+
+            const call = client.schedule(scheduleId).getLog();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id) => client.schedule(id).getLog(), scheduleId)).rejects.toThrow();
         });
     });
 });

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -385,6 +385,16 @@ describe('Task methods', () => {
             const browserRes = await page.evaluate((id) => client.task(id).getInput(), taskId);
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest({ query: {}, params: { taskId } });
+        });
+
+        test('getInput() throws on 404 status code', async () => {
+            const taskId = '404';
+
+            const call = client.task(taskId).getInput();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id) => client.task(id).getInput(), taskId)).rejects.toThrow();
         });
 
         test('updateInput() works', async () => {

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -107,6 +107,16 @@ describe('User methods', () => {
             const browserRes = await page.evaluate((id) => client.user(id).limits(), userId);
             expect(browserRes).toEqual(asBrowserResult(res));
             validateRequest({ query: {}, params: { userId } });
+        });
+
+        test.each(['monthlyUsage', 'limits'] as const)('%s() throws on 404 status code', async (method) => {
+            const userId = '404';
+
+            const call = client.user(userId)[method]();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id, m) => client.user(id)[m](), userId, method)).rejects.toThrow();
         });
 
         test('updateLimits() works', async () => {

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -44,7 +44,7 @@ describe('User methods', () => {
             const userId = 'some-id';
 
             const res = await client.user(userId).get();
-            expect(res.id).toEqual('get-user');
+            expect(res?.id).toEqual('get-user');
             validateRequest({ query: {}, params: { userId } });
 
             const browserRes = await page.evaluate((id) => client.user(id).get(), userId);
@@ -54,7 +54,7 @@ describe('User methods', () => {
 
         test('get() with no userId', async () => {
             const res = await client.user().get();
-            expect(res.id).toEqual('get-user');
+            expect(res?.id).toEqual('get-user');
             validateRequest({ query: {}, params: { userId: ME_USER_NAME_PLACEHOLDER } });
 
             const browserRes = await page.evaluate((id) => client.user(id).get(), undefined);

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -1,7 +1,7 @@
 import type { AddressInfo } from 'node:net';
 
 import type { WebhookUpdateData } from 'apify-client';
-import { ApifyClient } from 'apify-client';
+import { ApifyApiError, ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -165,6 +165,16 @@ describe('Webhook methods', () => {
                 endpointId: 'test-webhook',
                 params: { webhookId },
             });
+        });
+
+        test('test() throws on 404 status code', async () => {
+            const webhookId = '404';
+
+            const call = client.webhook(webhookId).test();
+            await expect(call).rejects.toThrow(ApifyApiError);
+            await expect(call).rejects.toMatchObject({ statusCode: 404 });
+
+            await expect(page.evaluate((id) => client.webhook(id).test(), webhookId)).rejects.toThrow();
         });
 
         test('listDispatches() works', async () => {


### PR DESCRIPTION
A 404 collapsed into `undefined` everywhere, including where it can't be pinned to one resource: `run.dataset().get()` couldn't tell a missing run from a missing dataset. Those calls now throw.

- Chained clients without an ID (`run.dataset()`, `run.keyValueStore()`, `run.requestQueue()`, `run.log()`, `build.log()`) throw from `get()`, `delete()`, `log().get()` and `log().stream()`. A new `catchNotFoundForResourceOrThrow(err, this.id)` keys on the ID, so ID-addressed clients still resolve to `undefined`.
- Fixed sub-paths throw and drop `| undefined`: `getStatistics()`, `monthlyUsage()`, `limits()`, `getLog()`, `getInput()`, `test()`.
- Unchanged: `getRecord()`, `getRequest()`, `recordExists()` and `lastRun()`.
- `version()`, `build()` and `envVar()` reject an empty string, which used to address the collection.
- `UserClient.get()` is now `Promise<User | undefined>`, matching what it always returned.
- `getStreamedLog()` on a missing run warns and stops.

Merging `v3` also moved `LogClient.stream()` under the same rule. #1041 made `catchNotFoundOrThrow()` a plain `instanceof NotFoundError` check, so a streamed 404 matches it and `client.log(id).stream()` resolves to `undefined` the way `get()` does. #1043 raised that flip as an open question; the unusable error body it reports is still open.

Mirrors apify/apify-client-python#755.

Closes #1030

*✍️ Drafted by Claude Code*
