### PR TITLE
test: drop stale result-type workarounds from integration tests

### DIFF
--- a/test/integration/actor.test.ts
+++ b/test/integration/actor.test.ts
@@ -42,12 +42,6 @@ async function createActor(options: { title?: string } = {}): Promise<Actor> {
 }
 
 /**
- * The listing endpoint returns `stats`, but `ActorCollectionListItem` does not declare it yet. Read it
- * through this shape so the sorting assertions stay honest until the type catches up.
- */
-type ListItemWithStats = ActorCollectionListItem & { stats?: { lastRunStartedAt?: Date } };
-
-/**
  * Sort keys of the Actors in a listing that have actually run.
  *
  * An Actor that never ran carries no `lastRunStartedAt`, and where the API places those in the ordering
@@ -55,7 +49,7 @@ type ListItemWithStats = ActorCollectionListItem & { stats?: { lastRunStartedAt?
  * run feed assertions do.
  */
 function lastRunSortKeys(items: ActorCollectionListItem[]): number[] {
-    return (items as ListItemWithStats[])
+    return items
         .map((item) => item.stats?.lastRunStartedAt?.getTime())
         .filter((value): value is number => value !== undefined);
 }

--- a/test/integration/actor.test.ts
+++ b/test/integration/actor.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 
-import type {
-    Actor,
-    ActorChargeEvent,
-    ActorCollectionListItem,
-    ApifyClient,
-    PricePerDatasetItemActorPricingInfo,
-    PricePerEventActorPricingInfo,
-} from 'apify-client';
+import type { Actor, ActorCollectionListItem, ApifyClient } from 'apify-client';
 import { ActorListSortBy, ActorSourceType } from 'apify-client';
 
 import { makeClient } from './_fixtures.js';
@@ -269,27 +262,12 @@ test('webhooks().list() is empty for a newly created Actor', async () => {
     }
 });
 
-/**
- * The tiered pricing shapes below are not declared on the v3 types yet, so the assertions read them
- * through these local shapes. Pinning the field names here is what would catch an alias being
- * dropped once the types do declare them.
- */
-type TieredPricePerDatasetItem = PricePerDatasetItemActorPricingInfo & {
-    tieredPricing?: Record<string, { tieredPricePerUnitUsd: number }>;
-};
-
-type TieredChargeEvent = ActorChargeEvent & {
-    eventTieredPricingUsd?: Record<string, unknown>;
-    isPrimaryEvent?: boolean;
-    isOneTimeEvent?: boolean;
-};
-
 test('get() returns tiered PRICE_PER_DATASET_ITEM pricing with its tiers intact', async () => {
     const actor = await client.actor(ALL_PRICING_VARIANTS_ACTOR).get();
     expect(actor?.pricingInfos?.length).toBeGreaterThan(0);
 
     const tieredEntries = (actor!.pricingInfos ?? [])
-        .filter((info): info is TieredPricePerDatasetItem => info.pricingModel === 'PRICE_PER_DATASET_ITEM')
+        .filter((info) => info.pricingModel === 'PRICE_PER_DATASET_ITEM')
         .filter((info) => info.tieredPricing !== undefined);
 
     expect(
@@ -322,8 +300,8 @@ test('get() returns tiered PAY_PER_EVENT charge events with their flags intact',
     expect(actor?.pricingInfos?.length).toBeGreaterThan(0);
 
     const tieredEvents = (actor!.pricingInfos ?? [])
-        .filter((info): info is PricePerEventActorPricingInfo => info.pricingModel === 'PAY_PER_EVENT')
-        .flatMap((info) => Object.values(info.pricingPerEvent.actorChargeEvents ?? {}) as TieredChargeEvent[])
+        .filter((info) => info.pricingModel === 'PAY_PER_EVENT')
+        .flatMap((info) => Object.values(info.pricingPerEvent.actorChargeEvents ?? {}))
         .filter((event) => event.eventTieredPricingUsd !== undefined);
 
     expect(

--- a/test/integration/build.test.ts
+++ b/test/integration/build.test.ts
@@ -22,9 +22,6 @@ const SMALL_MIN_MEMORY_ACTOR = 'apify/instagram-profile-scraper';
  */
 const CI_ORIGIN_ACTOR = 'apify/cheerio-scraper';
 
-/** The listing endpoint returns `actId`, but `BuildCollectionClientListItem` does not declare it yet. */
-type ListItemWithActorId = BuildCollectionClientListItem & { actId?: string };
-
 let client: ApifyClient;
 
 beforeAll(() => {
@@ -55,7 +52,7 @@ test('builds().list() returns the builds of a public Actor', async () => {
     const buildsPage = await client.actor(HELLO_WORLD_ACTOR).builds().list({ limit: 10 });
 
     expect(buildsPage.items.length).toBeGreaterThan(0);
-    const firstBuild = buildsPage.items[0] as ListItemWithActorId;
+    const firstBuild = buildsPage.items[0];
     expect(firstBuild.id).toBeTruthy();
     expect(firstBuild.actId).toBeTruthy();
 });
@@ -108,7 +105,7 @@ test('builds().list() is async-iterable and yields the builds of an Actor', asyn
     }
 
     expect(collected.length).toBeGreaterThanOrEqual(1);
-    for (const build of collected as ListItemWithActorId[]) {
+    for (const build of collected) {
         expect(build.id).toBeTruthy();
         expect(build.actId).toBeTruthy();
     }

--- a/test/integration/request_queue.test.ts
+++ b/test/integration/request_queue.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, expect, test } from 'vitest';
 
-import type { ApifyClient, RequestQueue, RequestQueueClient, RequestQueueClientGetRequestResult } from 'apify-client';
+import type { ApifyClient, RequestQueue, RequestQueueClient } from 'apify-client';
 
 import { makeClient } from './_fixtures.js';
 import { collectUntilPresent, getRandomResourceName, pollUntilCondition, randomId } from './_utils.js';
@@ -14,12 +14,6 @@ beforeAll(() => {
 async function createQueue(label = 'queue'): Promise<RequestQueue> {
     return client.requestQueues().getOrCreate(getRandomResourceName(label));
 }
-
-/**
- * `getRequest()` returns `userData`, but `RequestQueueClientGetRequestResult` does not declare it.
- * Read it through this shape so the round-trip assertion stays honest until the type catches up.
- */
-type RequestWithUserData = RequestQueueClientGetRequestResult & { userData?: Record<string, unknown> };
 
 /**
  * Poll the queue until `expectedCount` requests are visible.
@@ -181,10 +175,10 @@ test('updateRequest() changes the method and user data of an existing request', 
         });
         expect(updateResult.requestId).toBe(addResult.requestId);
 
-        const updatedRequest = (await pollUntilCondition(
+        const updatedRequest = await pollUntilCondition(
             () => queueClient.getRequest(addResult.requestId),
             (result) => result?.method === 'POST',
-        )) as RequestWithUserData | undefined;
+        );
         expect(updatedRequest?.method).toBe('POST');
         expect(updatedRequest?.userData).toEqual({ updated: true });
     } finally {

--- a/test/integration/schedule.test.ts
+++ b/test/integration/schedule.test.ts
@@ -136,9 +136,7 @@ test('getLog() works on a schedule that has never run', async () => {
         const log = await scheduleClient.getLog();
 
         // The API answers with an array of log entries, empty for a schedule that never fired.
-        // `getLog` declares `Promise<string | undefined>`, which does not match, hence the cast.
-        expect(Array.isArray(log as unknown)).toBe(true);
-        expect(log as unknown as unknown[]).toHaveLength(0);
+        expect(log).toEqual([]);
     } finally {
         await scheduleClient.delete();
     }

--- a/test/integration/schedule.test.ts
+++ b/test/integration/schedule.test.ts
@@ -135,7 +135,6 @@ test('getLog() works on a schedule that has never run', async () => {
     try {
         const log = await scheduleClient.getLog();
 
-        // The API answers with an array of log entries, empty for a schedule that never fired.
         expect(log).toEqual([]);
     } finally {
         await scheduleClient.delete();


### PR DESCRIPTION
The four result types #999 reported as incomplete are all typed on `v3`, so the integration-test casts that worked around them are stale.

`ScheduleClient.getLog()` has returned `Promise<ScheduleInvoked[] | undefined>` since #1016, so the double `as unknown` in `schedule.test.ts` collapses to `expect(log).toEqual([])`. `ActorCollectionListItem.stats`, `BuildShort.actId` and `RequestBase.userData` have come from the OpenAPI spec since #985, so `ListItemWithStats`, `ListItemWithActorId` and `RequestWithUserData` are removed along with their casts.

`actor.test.ts` carried two more local shapes of the same kind, `TieredPricePerDatasetItem` and `TieredChargeEvent`, under a comment claiming the tiered-pricing fields were undeclared. They are declared: `PricePerDatasetItemActorPricingInfo.tieredPricing`, and `ActorChargeEvent.eventTieredPricingUsd` / `isPrimaryEvent` / `isOneTimeEvent`. The local `eventTieredPricingUsd?: Record<string, unknown>` was wider than the real `TieredPricingPerEvent`, so it hid the field names it claimed to pin. Without them, filtering on `pricingModel` narrows the pricing union on its own.

I traced each field from the spec through `src/generated/api.ts` and the generated zod schema to the published type, against `v2-2026-08-31T125154Z`, the stamp recorded in `package.json`. The four affected integration files pass against the live API (65 tests). Two of the assertions tolerate a missing field, so I also probed the listing endpoints directly: every listed Actor carried `stats.lastRunStartedAt` as a real `Date`, and the builds carried `actId`.

The tiered-pricing edits are type- and comment-level, so they were not re-run against the API. Their narrowing is checked by tsc instead: swapping the discriminant to `FLAT_PRICE_PER_MONTH` or `FREE` makes it reject `tieredPricing` and `pricingPerEvent`.

Closes #999

*✍️ Drafted by Claude Code*
