### PR TITLE
fix!: correct Actor version, enum and setRecord input types

### DIFF
--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -131,9 +131,18 @@ The specification describes a full resource and its list item as two different s
 
 An Actor version's `sourceFiles` is a flat list that mixes files and folders, so its element type is now <ApiLink to="interface/ActorVersionSourceFile">`ActorVersionSourceFile`</ApiLink> or the new <ApiLink to="interface/ActorVersionSourceFolder">`ActorVersionSourceFolder`</ApiLink>. Code that reads `content` or `format` off an element has to tell the two apart first, by the `folder` flag only a folder carries. The `ActorVersion` union also gains a fifth variant for `SOURCE_CODE`, <ApiLink to="interface/ActorVersionSourceCode">`ActorVersionSourceCode`</ApiLink>, so an exhaustive `switch` over `sourceType` no longer compiles.
 
-### An Actor version's source type is a plain string
+### Enum-typed inputs take plain strings
 
-Fields that carry a source type, such as `ActorVersion.sourceType`, are typed as the string literals `'SOURCE_FILES' | 'GIT_REPO' | 'TARBALL' | 'GITHUB_GIST' | 'SOURCE_CODE'` rather than as the `ActorSourceType` enum. The enum stays published and its members stay assignable, so `sourceType: ActorSourceType.GitRepo` still works, and `sourceType: 'GIT_REPO'` now compiles without a cast. The other direction breaks: a variable annotated as `ActorSourceType` no longer accepts a version's `sourceType`. Annotate it as `ActorVersion['sourceType']` instead, or leave it to inference.
+Four positions that took a published enum now take that enum's values as plain string literals:
+
+- `ActorVersion.sourceType`, and with it <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> and <ApiLink to="class/ActorVersionClient#update">`update()`</ApiLink>, takes `'SOURCE_FILES' | 'GIT_REPO' | 'TARBALL' | 'GITHUB_GIST' | 'SOURCE_CODE'` instead of `ActorSourceType`.
+- A scheduled action's `type`, and with it <ApiLink to="class/ScheduleCollectionClient#create">`create()`</ApiLink> and <ApiLink to="class/ScheduleClient#update">`update()`</ApiLink>, takes `'RUN_ACTOR' | 'RUN_ACTOR_TASK'` instead of `ScheduleActions`.
+- <ApiLink to="interface/ActorCollectionListOptions">`ActorCollectionListOptions.sortBy`</ApiLink> takes `'createdAt' | 'stats.lastRunStartedAt'` instead of `ActorListSortBy`.
+- <ApiLink to="class/DatasetClient#downloadItems">`downloadItems()`</ApiLink> takes `'json' | 'jsonl' | 'xml' | 'html' | 'csv' | 'xlsx' | 'rss'` instead of `DownloadItemsFormat`.
+
+All four enums stay published and their members stay assignable, so `sourceType: ActorSourceType.GitRepo` still works, and `sourceType: 'GIT_REPO'` now compiles without a cast.
+
+The other direction breaks where the value is also read back. `const type: ActorSourceType = version.sourceType` no longer compiles. Annotate it as `ActorVersion['sourceType']` instead, or leave it to inference.
 
 ### The request-queue head splits into two item types
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -103,7 +103,7 @@ Every output type the client publishes, such as <ApiLink to="interface/Dataset">
 
 For most consumers, the change only surfaces as new compiler errors. Many fields that were typed as required are now optional (`field?: T`) or nullable (`field: T | null`) to match what the API can actually return. Recompile your project and add the null and undefined checks the compiler points out. These type corrections don't change what the client returns at runtime, only what TypeScript claimed about it before.
 
-A few fields went the other way and became required. `ActorVersion.versionNumber` is one, and `ActorVersion` is also what <ApiLink to="class/ActorVersionClient#update">`update()`</ApiLink> and <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> take, so a call that omitted the version number no longer compiles.
+A few fields went the other way and became required. `ActorVersion.versionNumber` is one, and `ActorVersion` is what <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> takes, so a call that omitted the version number no longer compiles. <ApiLink to="class/ActorVersionClient#update">`update()`</ApiLink> is unaffected. It takes `ActorVersionUpdateData`, where every field is optional, matching an endpoint that leaves untouched whatever the payload doesn't mention.
 
 A handful of fields and return types also change entirely to match the client's actual behavior:
 
@@ -130,6 +130,10 @@ The specification describes a full resource and its list item as two different s
 ### An Actor version's source files can be folders
 
 An Actor version's `sourceFiles` is a flat list that mixes files and folders, so its element type is now <ApiLink to="interface/ActorVersionSourceFile">`ActorVersionSourceFile`</ApiLink> or the new <ApiLink to="interface/ActorVersionSourceFolder">`ActorVersionSourceFolder`</ApiLink>. Code that reads `content` or `format` off an element has to tell the two apart first, by the `folder` flag only a folder carries. The `ActorVersion` union also gains a fifth variant for `SOURCE_CODE`, <ApiLink to="interface/ActorVersionSourceCode">`ActorVersionSourceCode`</ApiLink>, so an exhaustive `switch` over `sourceType` no longer compiles.
+
+### An Actor version's source type is a plain string
+
+Fields that carry a source type, such as `ActorVersion.sourceType`, are typed as the string literals `'SOURCE_FILES' | 'GIT_REPO' | 'TARBALL' | 'GITHUB_GIST' | 'SOURCE_CODE'` rather than as the `ActorSourceType` enum. The enum stays published and its members stay assignable, so `sourceType: ActorSourceType.GitRepo` still works, and `sourceType: 'GIT_REPO'` now compiles without a cast. The other direction breaks: a variable annotated as `ActorSourceType` no longer accepts a version's `sourceType`. Annotate it as `ActorVersion['sourceType']` instead, or leave it to inference.
 
 ### The request-queue head splits into two item types
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -103,7 +103,7 @@ Every output type the client publishes, such as <ApiLink to="interface/Dataset">
 
 For most consumers, the change only surfaces as new compiler errors. Many fields that were typed as required are now optional (`field?: T`) or nullable (`field: T | null`) to match what the API can actually return. Recompile your project and add the null and undefined checks the compiler points out. These type corrections don't change what the client returns at runtime, only what TypeScript claimed about it before.
 
-A few fields went the other way and became required. `ActorVersion.versionNumber` is one, and `ActorVersion` is what <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> takes, so a call that omitted the version number no longer compiles. <ApiLink to="class/ActorVersionClient#update">`update()`</ApiLink> is unaffected. It takes `ActorVersionUpdateData`, where every field is optional, matching an endpoint that leaves untouched whatever the payload doesn't mention.
+A few fields went the other way and became required. `ActorVersion.versionNumber` is one, and `ActorVersion` is what <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> takes, so a call that omitted the version number no longer compiles.
 
 A handful of fields and return types also change entirely to match the client's actual behavior:
 
@@ -131,18 +131,11 @@ The specification describes a full resource and its list item as two different s
 
 An Actor version's `sourceFiles` is a flat list that mixes files and folders, so its element type is now <ApiLink to="interface/ActorVersionSourceFile">`ActorVersionSourceFile`</ApiLink> or the new <ApiLink to="interface/ActorVersionSourceFolder">`ActorVersionSourceFolder`</ApiLink>. Code that reads `content` or `format` off an element has to tell the two apart first, by the `folder` flag only a folder carries. The `ActorVersion` union also gains a fifth variant for `SOURCE_CODE`, <ApiLink to="interface/ActorVersionSourceCode">`ActorVersionSourceCode`</ApiLink>, so an exhaustive `switch` over `sourceType` no longer compiles.
 
-### Enum-typed inputs take plain strings
+### Source types and scheduled-action types are plain strings
 
-Four positions that took a published enum now take that enum's values as plain string literals:
+`ActorVersion.sourceType` is typed as `'SOURCE_FILES' | 'GIT_REPO' | 'TARBALL' | 'GITHUB_GIST' | 'SOURCE_CODE'` instead of the `ActorSourceType` enum, and a scheduled action's `type` as `'RUN_ACTOR' | 'RUN_ACTOR_TASK'` instead of `ScheduleActions`. Both enums stay published and their members stay assignable, so code that writes `sourceType: ActorSourceType.GitRepo`, or switches over the enum's members, still compiles.
 
-- `ActorVersion.sourceType`, and with it <ApiLink to="class/ActorVersionCollectionClient#create">`create()`</ApiLink> and <ApiLink to="class/ActorVersionClient#update">`update()`</ApiLink>, takes `'SOURCE_FILES' | 'GIT_REPO' | 'TARBALL' | 'GITHUB_GIST' | 'SOURCE_CODE'` instead of `ActorSourceType`.
-- A scheduled action's `type`, and with it <ApiLink to="class/ScheduleCollectionClient#create">`create()`</ApiLink> and <ApiLink to="class/ScheduleClient#update">`update()`</ApiLink>, takes `'RUN_ACTOR' | 'RUN_ACTOR_TASK'` instead of `ScheduleActions`.
-- <ApiLink to="interface/ActorCollectionListOptions">`ActorCollectionListOptions.sortBy`</ApiLink> takes `'createdAt' | 'stats.lastRunStartedAt'` instead of `ActorListSortBy`.
-- <ApiLink to="class/DatasetClient#downloadItems">`downloadItems()`</ApiLink> takes `'json' | 'jsonl' | 'xml' | 'html' | 'csv' | 'xlsx' | 'rss'` instead of `DownloadItemsFormat`.
-
-All four enums stay published and their members stay assignable, so `sourceType: ActorSourceType.GitRepo` still works, and `sourceType: 'GIT_REPO'` now compiles without a cast.
-
-The other direction breaks where the value is also read back. `const type: ActorSourceType = version.sourceType` no longer compiles. Annotate it as `ActorVersion['sourceType']` instead, or leave it to inference.
+What breaks is reading the value back into a variable or parameter annotated with the enum. `const type: ActorSourceType = version.sourceType` no longer compiles. Annotate it as `ActorVersion['sourceType']` instead, or leave it to inference.
 
 ### The request-queue head splits into two item types
 

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -150,7 +150,7 @@ export interface ActorCollectionListOptions extends PaginationOptions {
     desc?: boolean;
     // (undocumented)
     my?: boolean;
-    sortBy?: ActorListSortBy;
+    sortBy?: `${ActorListSortBy}`;
 }
 
 // @public (undocumented)
@@ -2419,7 +2419,7 @@ export class DatasetClient<Data extends Record<string | number, any> = Record<st
     constructor(options: ApiClientSubResourceOptions);
     createItemsPublicUrl(options?: DatasetClientCreateItemsUrlOptions): Promise<string>;
     delete(): Promise<void>;
-    downloadItems(format: DownloadItemsFormat, options?: DatasetClientDownloadItemsOptions): Promise<Buffer>;
+    downloadItems(format: `${DownloadItemsFormat}`, options?: DatasetClientDownloadItemsOptions): Promise<Buffer>;
     get(): Promise<Dataset | undefined>;
     getStatistics(): Promise<DatasetStatistics | undefined>;
     listItems(options?: DatasetClientListItemOptions): PaginatedIterator<Data>;
@@ -3653,7 +3653,7 @@ interface ScheduleActionRunActorRePointed {
     // (undocumented)
     runOptions?: ScheduledActorRunOptions | null;
     // (undocumented)
-    type: ScheduleActions.RunActor;
+    type: `${ScheduleActions.RunActor}`;
 }
 
 // @public
@@ -3664,7 +3664,7 @@ export interface ScheduleActionRunActorTask extends Omit<Schemas['ScheduleAction
 // @public (undocumented)
 interface ScheduleActionRunActorTaskRePointed {
     // (undocumented)
-    type: ScheduleActions.RunActorTask;
+    type: `${ScheduleActions.RunActorTask}`;
 }
 
 // @public

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -3023,7 +3023,7 @@ export interface KeyValueStoreRecordOptions {
 }
 
 // @public
-export type KeyValueStoreRecordValue = JsonValue | Buffer | ArrayBuffer | TypedArray | Readable;
+export type KeyValueStoreRecordValue = JsonValue | ArrayBuffer | TypedArray | Readable;
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -26,6 +26,7 @@ import type { RUN_GENERAL_ACCESS } from '@apify/consts';
 import type { SetStatusMessageOptions } from '@crawlee/types';
 import type { STORAGE_GENERAL_ACCESS } from '@apify/consts';
 import { STORAGE_OWNERSHIP_FILTER } from '@apify/consts';
+import type { TypedArray } from 'type-fest';
 import type { ValueOf } from '@apify/consts';
 import type { ValueOf as ValueOf_2 } from 'type-fest';
 import type { WEBHOOK_EVENT_TYPES } from '@apify/consts';
@@ -407,14 +408,14 @@ export class ActorVersionClient extends ResourceClient {
     envVar(envVarName: string): ActorEnvVarClient;
     envVars(): ActorEnvVarCollectionClient;
     get(): Promise<FinalActorVersion | undefined>;
-    update(newFields: ActorVersion): Promise<FinalActorVersion>;
+    update(newFields: ActorVersionUpdateData): Promise<FinalActorVersion>;
 }
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
 interface ActorVersionClientNarrowings {
     // (undocumented)
-    sourceType: ActorSourceType;
+    sourceType: `${ActorSourceType}`;
 }
 
 // @public
@@ -425,13 +426,13 @@ export class ActorVersionCollectionClient extends ResourceCollectionClient {
 }
 
 // @public
-export interface ActorVersionGitHubGist extends BaseActorVersion<ActorSourceType.GitHubGist> {
+export interface ActorVersionGitHubGist extends BaseActorVersion<`${ActorSourceType.GitHubGist}`> {
     // (undocumented)
     gitHubGistUrl: NonNullable<GeneratedVersion['gitHubGistUrl']>;
 }
 
 // @public
-export interface ActorVersionGitRepo extends BaseActorVersion<ActorSourceType.GitRepo> {
+export interface ActorVersionGitRepo extends BaseActorVersion<`${ActorSourceType.GitRepo}`> {
     // (undocumented)
     gitRepoUrl: NonNullable<GeneratedVersion['gitRepoUrl']>;
 }
@@ -447,7 +448,7 @@ interface ActorVersionRePointed {
 }
 
 // @public
-export interface ActorVersionSourceCode extends BaseActorVersion<ActorSourceType.SourceCode> {
+export interface ActorVersionSourceCode extends BaseActorVersion<`${ActorSourceType.SourceCode}`> {
 }
 
 // @public
@@ -455,7 +456,7 @@ export interface ActorVersionSourceFile extends GeneratedSourceCodeFile {
 }
 
 // @public
-export interface ActorVersionSourceFiles extends BaseActorVersion<ActorSourceType.SourceFiles> {
+export interface ActorVersionSourceFiles extends BaseActorVersion<`${ActorSourceType.SourceFiles}`> {
     // (undocumented)
     sourceFiles: (ActorVersionSourceFile | ActorVersionSourceFolder)[];
 }
@@ -469,10 +470,13 @@ export interface ActorVersionSourceFolder extends GeneratedSourceCodeFolder {
 type ActorVersionSourceLocation = 'sourceFiles' | 'gitRepoUrl' | 'tarballUrl' | 'gitHubGistUrl';
 
 // @public
-export interface ActorVersionTarball extends BaseActorVersion<ActorSourceType.Tarball> {
+export interface ActorVersionTarball extends BaseActorVersion<`${ActorSourceType.Tarball}`> {
     // (undocumented)
     tarballUrl: NonNullable<GeneratedVersion['tarballUrl']>;
 }
+
+// @public
+export type ActorVersionUpdateData = Partial<ActorVersion>;
 
 // @public
 export type AllowedHttpMethods = Schemas['HttpMethod'];
@@ -635,7 +639,7 @@ interface ApifyResponse<T = any> extends AxiosResponse<T> {
 export { ArgumentValidationError }
 
 // @public
-export interface BaseActorVersion<SourceType extends ActorSourceType> extends Omit<GeneratedVersion, keyof ActorVersionClientNarrowings | keyof ActorVersionRePointed | ActorVersionSourceLocation>, ActorVersionRePointed {
+export interface BaseActorVersion<SourceType extends `${ActorSourceType}`> extends Omit<GeneratedVersion, keyof ActorVersionClientNarrowings | keyof ActorVersionRePointed | ActorVersionSourceLocation>, ActorVersionRePointed {
     // (undocumented)
     sourceType: SourceType;
 }
@@ -2969,7 +2973,7 @@ export class KeyValueStoreClient extends ResourceClient {
     getRecordPublicUrl(key: string): Promise<string>;
     listKeys(options?: KeyValueClientListKeysOptions): Promise<KeyValueClientListKeysResult> & AsyncIterable<KeyValueListItem>;
     recordExists(key: string): Promise<boolean>;
-    setRecord(record: KeyValueStoreRecord<JsonValue>, options?: KeyValueStoreRecordOptions): Promise<void>;
+    setRecord(record: KeyValueStoreRecord<KeyValueStoreRecordValue>, options?: KeyValueStoreRecordOptions): Promise<void>;
     update(newFields: KeyValueClientUpdateOptions): Promise<KeyValueStore>;
 }
 
@@ -3017,6 +3021,9 @@ export interface KeyValueStoreRecordOptions {
     // (undocumented)
     timeoutSecs?: number;
 }
+
+// @public
+export type KeyValueStoreRecordValue = JsonValue | Buffer | ArrayBuffer | TypedArray | Readable;
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)

--- a/src/models.ts
+++ b/src/models.ts
@@ -250,6 +250,10 @@ type GeneratedEnvVar = Schemas['EnvVar'];
  * Declared here rather than in `./resource_clients/actor_version` so that the version types can
  * reference it without closing an import cycle. It is re-exported from there, so the public name and
  * import path are unchanged.
+ *
+ * The fields that carry a source type are typed as `` `${ActorSourceType}` ``, the enum's values as
+ * plain string literals, rather than as the enum itself. A member stays assignable to that, so
+ * `ActorSourceType.GitRepo` keeps working, while `'GIT_REPO'` no longer needs a cast.
  */
 export enum ActorSourceType {
     SourceFiles = 'SOURCE_FILES',
@@ -288,7 +292,7 @@ export interface ActorVersionClientNarrowings {
     // The spec permits `sourceType: null`. It is deliberately not adopted: the published type is a
     // union discriminated on exactly this field, and a version with no source type carries no usable
     // source location either, so accepting the `null` would only make every variant unreachable.
-    sourceType: ActorSourceType;
+    sourceType: `${ActorSourceType}`;
 }
 
 /**
@@ -298,7 +302,7 @@ export interface ActorVersionClientNarrowings {
  * keeps a union discriminated on `sourceType` instead, because that narrows the source location down
  * to the single field which applies -- so the four are dropped here and reinstated per variant.
  */
-export interface BaseActorVersion<SourceType extends ActorSourceType>
+export interface BaseActorVersion<SourceType extends `${ActorSourceType}`>
     extends
         Omit<
             GeneratedVersion,
@@ -312,22 +316,22 @@ export interface BaseActorVersion<SourceType extends ActorSourceType>
  * An Actor version whose source code is stored on the Apify platform.
  * @since Added in 2.6.1
  */
-export interface ActorVersionSourceFiles extends BaseActorVersion<ActorSourceType.SourceFiles> {
+export interface ActorVersionSourceFiles extends BaseActorVersion<`${ActorSourceType.SourceFiles}`> {
     sourceFiles: (ActorVersionSourceFile | ActorVersionSourceFolder)[];
 }
 
 /** An Actor version built from a Git repository. */
-export interface ActorVersionGitRepo extends BaseActorVersion<ActorSourceType.GitRepo> {
+export interface ActorVersionGitRepo extends BaseActorVersion<`${ActorSourceType.GitRepo}`> {
     gitRepoUrl: NonNullable<GeneratedVersion['gitRepoUrl']>;
 }
 
 /** An Actor version built from a downloadable tarball or ZIP archive. */
-export interface ActorVersionTarball extends BaseActorVersion<ActorSourceType.Tarball> {
+export interface ActorVersionTarball extends BaseActorVersion<`${ActorSourceType.Tarball}`> {
     tarballUrl: NonNullable<GeneratedVersion['tarballUrl']>;
 }
 
 /** An Actor version built from a GitHub Gist. */
-export interface ActorVersionGitHubGist extends BaseActorVersion<ActorSourceType.GitHubGist> {
+export interface ActorVersionGitHubGist extends BaseActorVersion<`${ActorSourceType.GitHubGist}`> {
     gitHubGistUrl: NonNullable<GeneratedVersion['gitHubGistUrl']>;
 }
 
@@ -337,7 +341,7 @@ export interface ActorVersionGitHubGist extends BaseActorVersion<ActorSourceType
  * It carries no source location of its own, so it adds nothing to `BaseActorVersion`; the variant
  * exists so that `SOURCE_CODE`, which both the spec and `@apify/consts` list, is representable.
  */
-export interface ActorVersionSourceCode extends BaseActorVersion<ActorSourceType.SourceCode> {}
+export interface ActorVersionSourceCode extends BaseActorVersion<`${ActorSourceType.SourceCode}`> {}
 
 /** A version of an Actor, discriminated on where its source code comes from. */
 export type ActorVersion =

--- a/src/models.ts
+++ b/src/models.ts
@@ -250,10 +250,6 @@ type GeneratedEnvVar = Schemas['EnvVar'];
  * Declared here rather than in `./resource_clients/actor_version` so that the version types can
  * reference it without closing an import cycle. It is re-exported from there, so the public name and
  * import path are unchanged.
- *
- * The fields that carry a source type are typed as `` `${ActorSourceType}` ``, the enum's values as
- * plain string literals, rather than as the enum itself. Both spellings are therefore accepted:
- * `ActorSourceType.GitRepo` and the plain `'GIT_REPO'`.
  */
 export enum ActorSourceType {
     SourceFiles = 'SOURCE_FILES',
@@ -894,10 +890,6 @@ type GeneratedScheduleActionRunInput = Schemas['ScheduleActionRunInput'];
  * Declared here rather than in `./resource_clients/schedule` so that the action types can reference it
  * without closing an import cycle. It is re-exported from there, so the public name and import path are
  * unchanged.
- *
- * An action's `type` is typed as `` `${ScheduleActions}` ``, the enum's values as plain string literals,
- * rather than as the enum itself. Both spellings are therefore accepted: `ScheduleActions.RunActor` and
- * the plain `'RUN_ACTOR'`.
  */
 export enum ScheduleActions {
     RunActor = 'RUN_ACTOR',

--- a/src/models.ts
+++ b/src/models.ts
@@ -252,8 +252,8 @@ type GeneratedEnvVar = Schemas['EnvVar'];
  * import path are unchanged.
  *
  * The fields that carry a source type are typed as `` `${ActorSourceType}` ``, the enum's values as
- * plain string literals, rather than as the enum itself. A member stays assignable to that, so
- * `ActorSourceType.GitRepo` keeps working, while `'GIT_REPO'` no longer needs a cast.
+ * plain string literals, rather than as the enum itself. Both spellings are therefore accepted:
+ * `ActorSourceType.GitRepo` and the plain `'GIT_REPO'`.
  */
 export enum ActorSourceType {
     SourceFiles = 'SOURCE_FILES',
@@ -894,6 +894,10 @@ type GeneratedScheduleActionRunInput = Schemas['ScheduleActionRunInput'];
  * Declared here rather than in `./resource_clients/schedule` so that the action types can reference it
  * without closing an import cycle. It is re-exported from there, so the public name and import path are
  * unchanged.
+ *
+ * An action's `type` is typed as `` `${ScheduleActions}` ``, the enum's values as plain string literals,
+ * rather than as the enum itself. Both spellings are therefore accepted: `ScheduleActions.RunActor` and
+ * the plain `'RUN_ACTOR'`.
  */
 export enum ScheduleActions {
     RunActor = 'RUN_ACTOR',
@@ -911,7 +915,7 @@ export interface ScheduledActorRunInput extends GeneratedScheduleActionRunInput 
 export interface ScheduledActorRunOptions extends GeneratedTaskOptions {}
 
 export interface ScheduleActionRunActorRePointed {
-    type: ScheduleActions.RunActor;
+    type: `${ScheduleActions.RunActor}`;
     runInput?: ScheduledActorRunInput | null;
     runOptions?: ScheduledActorRunOptions | null;
 }
@@ -923,7 +927,7 @@ export interface ScheduleActionRunActor
         ScheduleActionRunActorRePointed {}
 
 export interface ScheduleActionRunActorTaskRePointed {
-    type: ScheduleActions.RunActorTask;
+    type: `${ScheduleActions.RunActorTask}`;
 }
 
 /** Scheduled action to run an Actor task. */

--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -90,6 +90,12 @@ export class ActorCollectionClient extends ResourceCollectionClient {
 }
 
 /**
+ * Field to order a list of Actors by.
+ *
+ * `ActorCollectionListOptions.sortBy` is typed as `` `${ActorListSortBy}` ``, the enum's values as plain
+ * string literals, rather than as the enum itself. Both spellings are therefore accepted:
+ * `ActorListSortBy.CREATED_AT` and the plain `'createdAt'`.
+ *
  * @since Added in 2.12.6
  */
 export enum ActorListSortBy {
@@ -111,7 +117,7 @@ export interface ActorCollectionListOptions extends PaginationOptions {
     /**
      * @since Added in 2.12.6
      */
-    sortBy?: ActorListSortBy;
+    sortBy?: `${ActorListSortBy}`;
 }
 
 export type ActorCollectionListResult = PaginatedList<ActorCollectionListItem>;

--- a/src/resource_clients/actor_collection.ts
+++ b/src/resource_clients/actor_collection.ts
@@ -92,10 +92,6 @@ export class ActorCollectionClient extends ResourceCollectionClient {
 /**
  * Field to order a list of Actors by.
  *
- * `ActorCollectionListOptions.sortBy` is typed as `` `${ActorListSortBy}` ``, the enum's values as plain
- * string literals, rather than as the enum itself. Both spellings are therefore accepted:
- * `ActorListSortBy.CREATED_AT` and the plain `'createdAt'`.
- *
  * @since Added in 2.12.6
  */
 export enum ActorListSortBy {

--- a/src/resource_clients/actor_version.ts
+++ b/src/resource_clients/actor_version.ts
@@ -122,7 +122,7 @@ export class ActorVersionClient extends ResourceClient {
  * Fields that can be changed on an existing Actor version.
  *
  * All of them are optional, because the endpoint leaves untouched whatever the payload does not
- * mention. What the version union still enforces is the pairing: a `sourceType` can only be sent
- * next to the source location it implies, never next to one of the other three.
+ * mention. The version union enforces the pairing: a `sourceType` can only be sent next to the
+ * source location it implies, never next to one of the other three.
  */
 export type ActorVersionUpdateData = Partial<ActorVersion>;

--- a/src/resource_clients/actor_version.ts
+++ b/src/resource_clients/actor_version.ts
@@ -74,7 +74,7 @@ export class ActorVersionClient extends ResourceClient {
      * @returns The updated Actor version object.
      * @see https://docs.apify.com/api/v2/act-version-put
      */
-    async update(newFields: ActorVersion): Promise<FinalActorVersion> {
+    async update(newFields: ActorVersionUpdateData): Promise<FinalActorVersion> {
         parseArgument(newFields, anyObjectSchema);
 
         return this._update(schemas.Version(), newFields);
@@ -117,3 +117,12 @@ export class ActorVersionClient extends ResourceClient {
         return new ActorEnvVarCollectionClient(this._subResourceOptions());
     }
 }
+
+/**
+ * Fields that can be changed on an existing Actor version.
+ *
+ * All of them are optional, because the endpoint leaves untouched whatever the payload does not
+ * mention. What the version union still enforces is the pairing: a `sourceType` can only be sent
+ * next to the source location it implies, never next to one of the other three.
+ */
+export type ActorVersionUpdateData = Partial<ActorVersion>;

--- a/src/resource_clients/actor_version_collection.ts
+++ b/src/resource_clients/actor_version_collection.ts
@@ -25,6 +25,8 @@ const actorVersionSchema = anyObjectSchema.optional();
  * // Create a new version
  * const newVersion = await versionsClient.create({
  *   versionNumber: '0.2',
+ *   sourceType: 'GIT_REPO',
+ *   gitRepoUrl: 'https://github.com/my-account/my-actor',
  *   buildTag: 'latest'
  * });
  * ```

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -260,7 +260,10 @@ export class DatasetClient<
      * });
      * ```
      */
-    async downloadItems(format: DownloadItemsFormat, options: DatasetClientDownloadItemsOptions = {}): Promise<Buffer> {
+    async downloadItems(
+        format: `${DownloadItemsFormat}`,
+        options: DatasetClientDownloadItemsOptions = {},
+    ): Promise<Buffer> {
         parseArgument(format, itemFormatSchema);
         const parsed = parseArgument(options, downloadItemsOptionsSchema, 'DatasetClientDownloadItemsOptions');
 
@@ -479,6 +482,10 @@ export interface DatasetClientCreateItemsUrlOptions extends Omit<
 
 /**
  * Supported formats for downloading dataset items.
+ *
+ * `downloadItems()` takes `` `${DownloadItemsFormat}` ``, the enum's values as plain string literals,
+ * rather than the enum itself. Both spellings are therefore accepted: `DownloadItemsFormat.CSV` and the
+ * plain `'csv'`.
  */
 export enum DownloadItemsFormat {
     JSON = 'json',

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -482,10 +482,6 @@ export interface DatasetClientCreateItemsUrlOptions extends Omit<
 
 /**
  * Supported formats for downloading dataset items.
- *
- * `downloadItems()` takes `` `${DownloadItemsFormat}` ``, the enum's values as plain string literals,
- * rather than the enum itself. Both spellings are therefore accepted: `DownloadItemsFormat.CSV` and the
- * plain `'csv'`.
  */
 export enum DownloadItemsFormat {
     JSON = 'json',

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -65,7 +65,7 @@ const recordSchema = z.strictObject({
             typeof value !== 'bigint' &&
             typeof value !== 'function' &&
             (typeof value !== 'number' || Number.isFinite(value)),
-        'Expected a defined, JSON-serializable value',
+        'Expected a JSON-serializable value, binary data, or a stream',
     ),
     contentType: z.string().min(1).optional(),
 });
@@ -424,11 +424,11 @@ export class KeyValueStoreClient extends ResourceClient {
      *
      * @param record - The record to store
      * @param record.key - Record key (unique identifier)
-     * @param record.value - Record value (object, string, Buffer, or Stream)
+     * @param record.value - Record value (a JSON-serializable value, Buffer, ArrayBuffer, typed array, or Readable)
      * @param record.contentType - Optional MIME type. Auto-detected if not provided:
      *                             - Objects: `'application/json; charset=utf-8'`
      *                             - Strings: `'text/plain; charset=utf-8'`
-     *                             - Buffers/Streams: `'application/octet-stream'`
+     *                             - Binary values and streams: `'application/octet-stream'`
      * @param options - Storage options
      * @param options.timeoutSecs - Timeout for the upload in seconds. Default varies by value size.
      * @param options.doNotRetryTimeouts - If `true`, don't retry on timeout errors. Default is `false`.
@@ -581,11 +581,11 @@ export interface KeyValueClientGetRecordOptions {
 /**
  * A value that `setRecord` accepts.
  *
- * Anything JSON-serializable, or raw bytes passed through to the API untouched: a `Buffer`, an
- * `ArrayBuffer`, a typed array, or a readable stream. Those are the same shapes `getRecord` hands
- * back, depending on its `buffer` and `stream` options.
+ * Anything JSON-serializable, or binary content the client uploads as bytes instead of JSON-encoding
+ * it: a `Buffer`, an `ArrayBuffer`, a typed array, or a readable stream. `Buffer` is a `Uint8Array`, so
+ * `TypedArray` covers it.
  */
-export type KeyValueStoreRecordValue = JsonValue | Buffer | ArrayBuffer | TypedArray | Readable;
+export type KeyValueStoreRecordValue = JsonValue | ArrayBuffer | TypedArray | Readable;
 
 /**
  * Represents a record (key-value pair) in a Key-Value Store.

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -1,6 +1,6 @@
 import type { Readable } from 'node:stream';
 
-import type { JsonValue } from 'type-fest';
+import type { JsonValue, TypedArray } from 'type-fest';
 import { z } from 'zod';
 
 import type { STORAGE_GENERAL_ACCESS } from '@apify/consts';
@@ -58,7 +58,7 @@ const recordSchema = z.strictObject({
     // Symbols, bigints, functions and non-finite numbers are rejected because they cannot be serialized
     // to JSON - symbols and bigints throw, functions stringify to `undefined` (an empty request body),
     // and `NaN` / `Infinity` would silently become `null`.
-    value: z.custom<JsonValue>(
+    value: z.custom<KeyValueStoreRecordValue>(
         (value) =>
             value !== undefined &&
             typeof value !== 'symbol' &&
@@ -458,7 +458,10 @@ export class KeyValueStoreClient extends ResourceClient {
      * });
      * ```
      */
-    async setRecord(record: KeyValueStoreRecord<JsonValue>, options: KeyValueStoreRecordOptions = {}): Promise<void> {
+    async setRecord(
+        record: KeyValueStoreRecord<KeyValueStoreRecordValue>,
+        options: KeyValueStoreRecordOptions = {},
+    ): Promise<void> {
         parseArgument(record, recordSchema);
         const parsed = parseArgument(options, recordOptionsSchema, 'KeyValueStoreRecordOptions');
 
@@ -574,6 +577,15 @@ export interface KeyValueClientGetRecordOptions {
      */
     signature?: string;
 }
+
+/**
+ * A value that `setRecord` accepts.
+ *
+ * Anything JSON-serializable, or raw bytes passed through to the API untouched: a `Buffer`, an
+ * `ArrayBuffer`, a typed array, or a readable stream. Those are the same shapes `getRecord` hands
+ * back, depending on its `buffer` and `stream` options.
+ */
+export type KeyValueStoreRecordValue = JsonValue | Buffer | ArrayBuffer | TypedArray | Readable;
 
 /**
  * Represents a record (key-value pair) in a Key-Value Store.

--- a/src/spec_guards.ts
+++ b/src/spec_guards.ts
@@ -341,12 +341,11 @@ export type AdapterWidthGuards = AssertAll<
         // type whose `status` is the published runtime enum, and a string-literal union is never
         // assignable to a string enum even when the members match -- `EnumGuards` pins those instead.
         OverridesStayWider<Omit<WebhookRePointed, 'condition' | 'lastDispatch'>, Schemas['Webhook']>,
-        // `type` is excluded on both action variants, and `timezone` on the schedule: the first two
-        // publish a runtime enum, and the third narrows the spec's bare `string` to the curated IANA
-        // union on purpose. `EnumGuards` pins the two `type` constants instead. `Schedule.actions` is
-        // excluded for the same reason as the two `type` constants it carries: the re-pointed element
-        // union discriminates on a runtime enum, so no assignability check can hold either way.
-        OverridesStayWider<Omit<ScheduleActionRunActorRePointed, 'type'>, Schemas['ScheduleActionRunActor']>,
+        OverridesStayWider<ScheduleRePointed, Schemas['Schedule']>,
+        OverridesStayWider<ScheduleActionRunActorRePointed, Schemas['ScheduleActionRunActor']>,
+        OverridesStayWider<ScheduleActionRunActorTaskRePointed, Schemas['ScheduleActionRunActorTask']>,
+        // `timezone` is excluded: it narrows the spec's bare `string` to the curated IANA union on
+        // purpose, argued for at the declaration.
         OverridesStayWider<UserRePointed, Schemas['UserPrivateInfo']>,
         OverridesStayWider<UserProxyRePointed, Schemas['Proxy']>,
         OverridesStayWider<EffectivePlatformFeaturesRePointed, Schemas['EffectivePlatformFeatures']>,

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -589,6 +589,31 @@ describe('Actor methods', () => {
                 expect(browserRes).toEqual(asBrowserResult(res));
                 validateRequest({ query: {}, params: { actorId }, body: actorVersion });
             });
+
+            test('create() accepts a source type spelled as a plain string', async () => {
+                const actorId = 'some-id';
+                const actorVersion = {
+                    versionNumber: '0.0',
+                    gitRepoUrl: 'https://github.com/user/repo.git',
+                    sourceType: 'GIT_REPO',
+                } as const;
+
+                const res = await client.actor(actorId).versions().create(actorVersion);
+                validateRequest({
+                    query: {},
+                    params: { actorId },
+                    body: actorVersion,
+                    endpointId: 'create-actor-version',
+                });
+
+                const browserRes = await page.evaluate(
+                    (id, opts) => client.actor(id).versions().create(opts),
+                    actorId,
+                    actorVersion,
+                );
+                expect(browserRes).toEqual(asBrowserResult(res));
+                validateRequest({ query: {}, params: { actorId }, body: actorVersion });
+            });
         });
 
         describe('version()', () => {
@@ -658,6 +683,29 @@ describe('Actor methods', () => {
                     params: { actorId: 'some-user~some-id', versionNumber },
                     body: newFields,
                 });
+            });
+
+            test('update() works with a subset of the version fields', async () => {
+                const actorId = 'some-id';
+                const versionNumber = '0.0';
+                const newFields = { buildTag: 'latest' } as const;
+
+                const res = await client.actor(actorId).version(versionNumber).update(newFields);
+                validateRequest({
+                    query: {},
+                    params: { actorId, versionNumber },
+                    body: newFields,
+                    endpointId: 'update-actor-version',
+                });
+
+                const browserRes = await page.evaluate(
+                    (id, vn, nf) => client.actor(id).version(vn).update(nf),
+                    actorId,
+                    versionNumber,
+                    newFields,
+                );
+                expect(browserRes).toEqual(asBrowserResult(res));
+                validateRequest({ query: {}, params: { actorId, versionNumber }, body: newFields });
             });
 
             test('delete() works', async () => {

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -55,8 +55,8 @@ describe('Actor methods', () => {
                 offset: 3,
                 desc: true,
                 my: true,
-                sortBy: 'createdAt' as const,
-            };
+                sortBy: 'createdAt',
+            } satisfies ActorCollectionListOptions;
             // Both spellings compile, and the enum member holds the same value.
             const withEnumMember: ActorCollectionListOptions = { ...opts, sortBy: ActorListSortBy.CREATED_AT };
             expect(withEnumMember).toEqual(opts);
@@ -670,7 +670,7 @@ describe('Actor methods', () => {
             test('update() works with a subset of the version fields', async () => {
                 const actorId = 'some-id';
                 const versionNumber = '0.0';
-                const newFields = { buildTag: 'latest' } as const;
+                const newFields = { buildTag: 'latest' };
 
                 const res = await client.actor(actorId).version(versionNumber).update(newFields);
                 validateRequest({

--- a/test/actors.test.ts
+++ b/test/actors.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'node:net';
 import { setTimeout } from 'node:timers/promises';
 
 import c from 'ansi-colors';
-import type { ActorCollectionCreateOptions } from 'apify-client';
+import type { ActorCollectionCreateOptions, ActorCollectionListOptions, ActorVersion } from 'apify-client';
 import { ActorListSortBy, ActorSourceType, ApifyClient, LoggerActorRedirect } from 'apify-client';
 import express from 'express';
 import type { Page } from 'puppeteer';
@@ -55,8 +55,11 @@ describe('Actor methods', () => {
                 offset: 3,
                 desc: true,
                 my: true,
-                sortBy: ActorListSortBy.CREATED_AT,
+                sortBy: 'createdAt' as const,
             };
+            // Both spellings compile, and the enum member holds the same value.
+            const withEnumMember: ActorCollectionListOptions = { ...opts, sortBy: ActorListSortBy.CREATED_AT };
+            expect(withEnumMember).toEqual(opts);
 
             const res = await client.actors().list(opts);
             validateRequest({
@@ -565,38 +568,17 @@ describe('Actor methods', () => {
                 });
             });
 
-            test('create() works', async () => {
-                const actorId = 'some-id';
-                const actorVersion = {
-                    versionNumber: '0.0',
-                    gitRepoUrl: 'https://github.com/user/repo.git',
-                    sourceType: ActorSourceType.GitRepo,
-                } as const;
-
-                const res = await client.actor(actorId).versions().create(actorVersion);
-                validateRequest({
-                    query: {},
-                    params: { actorId },
-                    body: actorVersion,
-                    endpointId: 'create-actor-version',
-                });
-
-                const browserRes = await page.evaluate(
-                    (id, opts) => client.actor(id).versions().create(opts),
-                    actorId,
-                    actorVersion,
-                );
-                expect(browserRes).toEqual(asBrowserResult(res));
-                validateRequest({ query: {}, params: { actorId }, body: actorVersion });
-            });
-
-            test('create() accepts a source type spelled as a plain string', async () => {
+            test('create() works with a source type given as a plain string or an enum member', async () => {
                 const actorId = 'some-id';
                 const actorVersion = {
                     versionNumber: '0.0',
                     gitRepoUrl: 'https://github.com/user/repo.git',
                     sourceType: 'GIT_REPO',
                 } as const;
+                // Both spellings compile, and the enum member holds the same value, so one round-trip
+                // covers them both.
+                const withEnumMember: ActorVersion = { ...actorVersion, sourceType: ActorSourceType.GitRepo };
+                expect(withEnumMember).toEqual(actorVersion);
 
                 const res = await client.actor(actorId).versions().create(actorVersion);
                 validateRequest({

--- a/test/datasets.test.ts
+++ b/test/datasets.test.ts
@@ -175,7 +175,9 @@ describe('Dataset methods', () => {
             mockServer.setResponse({ body, headers });
             const qs = { bom: 0, format: 'csv', delimiter: ';', fields: 'a,b', omit: 'c,d' };
 
-            const format = DownloadItemsFormat.CSV;
+            // Both spellings compile, and the enum member holds the same value.
+            const format = 'csv' as const;
+            expect(format).toEqual(DownloadItemsFormat.CSV);
             const options = {
                 bom: false,
                 fields: ['a', 'b'],

--- a/test/key_value_stores.test.ts
+++ b/test/key_value_stores.test.ts
@@ -529,7 +529,7 @@ describe('Key-Value Store methods', () => {
                 'content-type': 'application/octet-stream',
             };
 
-            const res = await client.keyValueStore(storeId).setRecord({ key, value: value as any });
+            const res = await client.keyValueStore(storeId).setRecord({ key, value });
             expect(res).toBeUndefined();
             validateRequest({ params: { storeId, key }, body: value, additionalHeaders: expectedHeaders });
 
@@ -537,7 +537,7 @@ describe('Key-Value Store methods', () => {
                 async (id, k, d) => {
                     const encoder = new TextEncoder();
                     const v = encoder.encode(d);
-                    return client.keyValueStore(id).setRecord({ key: k, value: v } as any);
+                    return client.keyValueStore(id).setRecord({ key: k, value: v });
                 },
                 storeId,
                 key,

--- a/test/key_value_stores.test.ts
+++ b/test/key_value_stores.test.ts
@@ -482,7 +482,7 @@ describe('Key-Value Store methods', () => {
             const call = client.keyValueStore('some-id').setRecord({ key: 'some-key', value: value as any });
 
             await expect(call).rejects.toThrow(ArgumentValidationError);
-            await expect(call).rejects.toThrow('Expected a defined, JSON-serializable value');
+            await expect(call).rejects.toThrow('Expected a JSON-serializable value, binary data, or a stream');
         });
 
         test('setRecord() works with custom timeout options', async () => {
@@ -545,6 +545,47 @@ describe('Key-Value Store methods', () => {
             );
             expect(browserRes).toBeUndefined();
             validateRequest({ params: { storeId, key }, body: value, additionalHeaders: expectedHeaders });
+        });
+
+        test('setRecord() works with an ArrayBuffer', async () => {
+            const key = 'some-key';
+            const storeId = 'some-id';
+            const data = 'special chars \u{1F916}\u2705';
+            const value = new TextEncoder().encode(data);
+            const expectedHeaders = {
+                'content-type': 'application/octet-stream',
+            };
+
+            const res = await client.keyValueStore(storeId).setRecord({ key, value: value.buffer });
+            expect(res).toBeUndefined();
+            validateRequest({ params: { storeId, key }, body: Buffer.from(data), additionalHeaders: expectedHeaders });
+
+            const browserRes = await page.evaluate(
+                async (id, k, d) => {
+                    const encoded = new TextEncoder().encode(d);
+                    return client.keyValueStore(id).setRecord({ key: k, value: encoded.buffer });
+                },
+                storeId,
+                key,
+                data,
+            );
+            expect(browserRes).toBeUndefined();
+            validateRequest({ params: { storeId, key }, body: Buffer.from(data), additionalHeaders: expectedHeaders });
+        });
+
+        test('setRecord() works with a readable stream', async () => {
+            const key = 'some-key';
+            const storeId = 'some-id';
+            const data = 'special chars \u{1F916}\u2705';
+            const value = Readable.from([Buffer.from(data)]);
+            const expectedHeaders = {
+                'content-type': 'application/octet-stream',
+            };
+
+            // Streams are Node-only, so there is no browser leg here.
+            const res = await client.keyValueStore(storeId).setRecord({ key, value });
+            expect(res).toBeUndefined();
+            validateRequest({ params: { storeId, key }, body: Buffer.from(data), additionalHeaders: expectedHeaders });
         });
 
         test('setRecord() works with pre-stringified JSON', async () => {

--- a/test/schedules.test.ts
+++ b/test/schedules.test.ts
@@ -1,6 +1,7 @@
 import type { AddressInfo } from 'node:net';
 
-import { ApifyClient } from 'apify-client';
+import type { ScheduleCreateOrUpdateData } from 'apify-client';
+import { ApifyClient, ScheduleActions } from 'apify-client';
 import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
@@ -38,7 +39,17 @@ describe('Schedule methods', () => {
 
     describe('schedules()', () => {
         test('create() works', async () => {
-            const schedule = { name: 'my-schedule', cronExpression: '0 0 * * *' };
+            const schedule: ScheduleCreateOrUpdateData = {
+                name: 'my-schedule',
+                cronExpression: '0 0 * * *',
+                actions: [{ type: 'RUN_ACTOR', actorId: 'some-actor-id' }],
+            };
+            // Both spellings compile, and the enum member holds the same value.
+            const withEnumMember: ScheduleCreateOrUpdateData = {
+                ...schedule,
+                actions: [{ type: ScheduleActions.RunActor, actorId: 'some-actor-id' }],
+            };
+            expect(withEnumMember).toEqual(schedule);
 
             const res = await client.schedules().create(schedule);
             validateRequest({ query: {}, params: {}, body: schedule, endpointId: 'create-schedule' });


### PR DESCRIPTION
### Description

Three of the five bullets in #526 were still open on `v3`. `ActorVersionSourceFile.folder` and the newer build fields (`buildNumber`, `stats.computeUnits`, `stats.imageSizeBytes`) were already fixed there; these three were not.

- Inputs that took a published enum now take that enum's values as plain string literals, so `sourceType: 'GIT_REPO'` compiles without a cast. Four positions are affected: `ActorVersion.sourceType`, a scheduled action's `type`, `ActorCollectionListOptions.sortBy`, and the format `downloadItems()` takes. All four enums stay published and their members stay assignable, and the version union still rejects a source location that doesn't match the declared type.
- `setRecord()` takes `KeyValueStoreRecordValue`, which covers the buffers, typed arrays and streams the runtime has always uploaded. The existing buffer tests carried `as any` for exactly that reason, and those casts are gone. `Buffer` isn't spelled out in the union, because it's a `Uint8Array` and `TypedArray` already covers it.
- `ActorVersionClient.update()` takes `ActorVersionUpdateData`, a partial version. The spec posts `CreateOrUpdateVersionRequest` with every field optional, and the endpoint documents that it leaves untouched whatever the payload omits, so `update({ buildTag: 'latest' })`, the method's own JSDoc example, now compiles. `create()` keeps the full union, since the API requires `versionNumber` and `sourceType` there.

### Issue

Closes #526

### Breaking changes

- A variable annotated as `ActorSourceType`, `ScheduleActions`, `ActorListSortBy` or `DownloadItemsFormat` no longer accepts the matching value read off a client. Annotate it as `ActorVersion['sourceType']`, and so on, or leave it to inference. `setRecord()` also rejects an unsupported value with a new message, `Expected a JSON-serializable value, binary data, or a stream`.
- The v3 upgrading guide and the public API report are updated to match.

*✍️ Drafted by Claude Code*
