### PR TITLE
fix!: bump proxy-agent to v8 to remove the url.parse() deprecation warning

### DIFF
--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -187,3 +187,16 @@ Two options that carried a `@deprecated` marker throughout v2 have been removed.
 `restartOnError` is gone from <ApiLink to="interface/ActorCollectionCreateOptions">`ActorCollectionCreateOptions`</ApiLink>, so <ApiLink to="class/ActorCollectionClient#create">`ActorCollectionClient.create()`</ApiLink> no longer accepts it at the top level. Pass it inside `defaultRunOptions` instead, as the deprecation notice advised.
 
 `exclusiveStartId` is gone from <ApiLink to="class/RequestQueueClient#listRequests">`listRequests()`</ApiLink> and <ApiLink to="class/RequestQueueClient#paginateRequests">`paginateRequests()`</ApiLink>. Both paginate by `cursor` alone now, and passing `exclusiveStartId` throws an `ArgumentValidationError` about an unrecognized key. In v2 the two were mutually exclusive, so the error about combining them is gone as well. Responses are unaffected, since the API still echoes `exclusiveStartId` back in the request listing.
+
+## Proxy settings from npm config are no longer read
+
+The client sends its requests through the proxy named in the standard environment variables: `HTTP_PROXY` or `HTTPS_PROXY` for the request's scheme, `ALL_PROXY` as the fallback, and `NO_PROXY` for hosts to reach directly. Those variables work as they did in v2.
+
+The `proxy` and `https-proxy` settings in `.npmrc` no longer reach the client. When a script runs under `npm run`, npm exports them as `npm_config_proxy` and `npm_config_https_proxy`, and v2 read those two variables as well. `proxy-from-env`, the package that resolves the proxy for the client's `proxy-agent`, dropped the npm lookups in the major that v3 pulls in. A proxy configured only in `.npmrc` therefore stops applying to the client's requests, and nothing warns about it. Set the standard variables instead:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:3128
+export HTTPS_PROXY=http://proxy.example.com:3128
+```
+
+The same `proxy-agent` upgrade removes the `[DEP0169] DeprecationWarning` about `url.parse()` that Node.js 24 and newer printed on the client's first request.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "async-retry": "^1.3.3",
         "axios": "^1.20.0",
         "content-type": "^1.0.5",
-        "proxy-agent": "^6.5.0",
+        "proxy-agent": "^8.0.2",
         "tslib": "^2.8.1",
         "type-fest": "^4.41.0",
         "zod": "^4.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       proxy-agent:
-        specifier: ^6.5.0
-        version: 6.5.0
+        specifier: ^8.0.2
+        version: 8.0.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -61,7 +61,7 @@ importers:
         version: 0.2.0
       '@crawlee/puppeteer':
         specifier: 4.0.0-beta.165
-        version: 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))
+        version: 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))
       '@rsbuild/core':
         specifier: ^2.2.3
         version: 2.2.3(core-js@3.50.0)
@@ -118,7 +118,7 @@ importers:
         version: 7.0.2001
       puppeteer:
         specifier: ^25.10.0
-        version: 25.10.0(proxy-agent@6.5.0)
+        version: 25.10.0(proxy-agent@8.0.2)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -3856,9 +3856,6 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -4154,6 +4151,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -4953,9 +4954,9 @@ packages:
   csv-stringify@6.8.3:
     resolution: {integrity: sha512-gIeSCvq5F4VtXV3naV3VAewLhBkiZBz+PPhTOA8H3Y8h/ELa+R1ml0GZck/4/Nzo9ep2lvOluilJ6MJlbZsKMA==}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
+  data-uri-to-buffer@8.0.0:
+    resolution: {integrity: sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==}
+    engines: {node: '>= 20'}
 
   dayjs@1.11.9:
     resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
@@ -5027,9 +5028,11 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
+  degenerator@7.0.1:
+    resolution: {integrity: sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      quickjs-wasi: ^2.2.0
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -5556,9 +5559,9 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
+  get-uri@8.0.1:
+    resolution: {integrity: sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==}
+    engines: {node: '>= 20'}
 
   github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -5811,9 +5814,9 @@ packages:
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
+  http-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
+    engines: {node: '>= 20'}
 
   http-proxy-middleware@2.0.10:
     resolution: {integrity: sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==}
@@ -5842,6 +5845,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -7069,13 +7076,15 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
+  pac-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==}
+    engines: {node: '>= 20'}
 
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
+  pac-resolver@9.0.1:
+    resolution: {integrity: sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      quickjs-wasi: ^2.2.0
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -7772,16 +7781,22 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
+
+  proxy-agent@8.0.2:
+    resolution: {integrity: sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==}
+    engines: {node: '>= 20'}
 
   proxy-chain@2.7.1:
     resolution: {integrity: sha512-LtXu0miohJYrHWJxv8wA6EoGreRcX1hxKb7qlE1pMFH+BXE7bqMvpyhzR/JvR6M5SzYKzyHFpvfmYJrZeMtwAg==}
     engines: {node: '>=14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -7847,6 +7862,9 @@ packages:
   quick-lru@7.3.0:
     resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
     engines: {node: '>=18'}
+
+  quickjs-wasi@2.2.0:
+    resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -8387,6 +8405,10 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
+
+  socks-proxy-agent@10.1.0:
+    resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
+    engines: {node: '>= 20'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -10521,14 +10543,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser-pool@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))':
+  '@crawlee/browser-pool@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))':
     dependencies:
       '@apify/timeout': 1.0.1
       '@crawlee/core': 4.0.0-beta.165
       '@crawlee/types': 4.0.0-beta.165
       '@crawlee/utils': 4.0.0-beta.165
       fingerprint-generator: 2.1.88
-      fingerprint-injector: 2.1.88(puppeteer@25.10.0(proxy-agent@6.5.0))
+      fingerprint-injector: 2.1.88(puppeteer@25.10.0(proxy-agent@8.0.2))
       lodash.merge: 4.6.2
       nanoid: 5.1.16
       p-limit: 6.2.0
@@ -10538,22 +10560,22 @@ snapshots:
       tslib: 2.8.1
       zod: 4.5.4
     optionalDependencies:
-      puppeteer: 25.10.0(proxy-agent@6.5.0)
+      puppeteer: 25.10.0(proxy-agent@8.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))':
+  '@crawlee/browser@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))':
     dependencies:
       '@apify/timeout': 1.0.1
       '@crawlee/basic': 4.0.0-beta.165
-      '@crawlee/browser-pool': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))
+      '@crawlee/browser-pool': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))
       '@crawlee/types': 4.0.0-beta.165
       '@crawlee/utils': 4.0.0-beta.165
       tslib: 2.8.1
       type-fest: 4.41.0
       zod: 4.5.4
     optionalDependencies:
-      puppeteer: 25.10.0(proxy-agent@6.5.0)
+      puppeteer: 25.10.0(proxy-agent@8.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10643,11 +10665,11 @@ snapshots:
       tough-cookie: 6.0.2
     optional: true
 
-  '@crawlee/puppeteer@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))':
+  '@crawlee/puppeteer@4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))':
     dependencies:
       '@apify/datastructures': 3.0.1
-      '@crawlee/browser': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))
-      '@crawlee/browser-pool': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@6.5.0))
+      '@crawlee/browser': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))
+      '@crawlee/browser-pool': 4.0.0-beta.165(puppeteer@25.10.0(proxy-agent@8.0.2))
       '@crawlee/core': 4.0.0-beta.165
       '@crawlee/types': 4.0.0-beta.165
       '@crawlee/utils': 4.0.0-beta.165
@@ -10657,7 +10679,7 @@ snapshots:
       tslib: 2.8.1
       zod: 4.5.4
     optionalDependencies:
-      puppeteer: 25.10.0(proxy-agent@6.5.0)
+      puppeteer: 25.10.0(proxy-agent@8.0.2)
     transitivePeerDependencies:
       - playwright
       - supports-color
@@ -13260,12 +13282,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@puppeteer/browsers@3.2.2(proxy-agent@6.5.0)':
+  '@puppeteer/browsers@3.2.2(proxy-agent@8.0.2)':
     dependencies:
       modern-tar: 0.8.5
       yargs: 18.1.0
     optionalDependencies:
-      proxy-agent: 6.5.0
+      proxy-agent: 8.0.2
 
   '@radix-ui/primitive@1.1.7': {}
 
@@ -14166,8 +14188,6 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -14513,6 +14533,8 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  agent-base@9.0.0: {}
 
   aggregate-error@3.1.0:
     dependencies:
@@ -15445,7 +15467,7 @@ snapshots:
 
   csv-stringify@6.8.3: {}
 
-  data-uri-to-buffer@6.0.2: {}
+  data-uri-to-buffer@8.0.0: {}
 
   dayjs@1.11.9: {}
 
@@ -15510,11 +15532,12 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  degenerator@5.0.1:
+  degenerator@7.0.1(quickjs-wasi@2.2.0):
     dependencies:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+      quickjs-wasi: 2.2.0
 
   delayed-stream@1.0.0: {}
 
@@ -16035,12 +16058,12 @@ snapshots:
       header-generator: 2.1.88
       tslib: 2.8.1
 
-  fingerprint-injector@2.1.88(puppeteer@25.10.0(proxy-agent@6.5.0)):
+  fingerprint-injector@2.1.88(puppeteer@25.10.0(proxy-agent@8.0.2)):
     dependencies:
       fingerprint-generator: 2.1.88
       tslib: 2.8.1
     optionalDependencies:
-      puppeteer: 25.10.0(proxy-agent@6.5.0)
+      puppeteer: 25.10.0(proxy-agent@8.0.2)
 
   flat@5.0.2: {}
 
@@ -16120,10 +16143,10 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-uri@6.0.5:
+  get-uri@8.0.1:
     dependencies:
       basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
+      data-uri-to-buffer: 8.0.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -16563,11 +16586,13 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@9.1.0:
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   http-proxy-middleware@2.0.10(@types/express@4.17.25):
@@ -16604,18 +16629,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   human-signals@2.1.0: {}
@@ -18030,23 +18057,25 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@9.1.0:
     dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
+      get-uri: 8.0.1
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
+      pac-resolver: 9.0.1(quickjs-wasi@2.2.0)
+      quickjs-wasi: 2.2.0
+      socks-proxy-agent: 10.1.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
-  pac-resolver@7.0.1:
+  pac-resolver@9.0.1(quickjs-wasi@2.2.0):
     dependencies:
-      degenerator: 5.0.1
+      degenerator: 7.0.1(quickjs-wasi@2.2.0)
       netmask: 2.1.1
+      quickjs-wasi: 2.2.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -18877,17 +18906,20 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0:
+  proxy-agent-negotiate@1.1.0: {}
+
+  proxy-agent@8.0.2:
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
+      pac-proxy-agent: 9.1.0
+      proxy-from-env: 2.1.0
+      socks-proxy-agent: 10.1.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   proxy-chain@2.7.1:
@@ -18897,8 +18929,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
-
-  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -18921,9 +18951,9 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  puppeteer-core@25.10.0(proxy-agent@6.5.0):
+  puppeteer-core@25.10.0(proxy-agent@8.0.2):
     dependencies:
-      '@puppeteer/browsers': 3.2.2(proxy-agent@6.5.0)
+      '@puppeteer/browsers': 3.2.2(proxy-agent@8.0.2)
       chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
       devtools-protocol: 0.0.1666840
       typed-query-selector: 2.12.2
@@ -18935,13 +18965,13 @@ snapshots:
       - utf-8-validate
       - yauzl
 
-  puppeteer@25.10.0(proxy-agent@6.5.0):
+  puppeteer@25.10.0(proxy-agent@8.0.2):
     dependencies:
-      '@puppeteer/browsers': 3.2.2(proxy-agent@6.5.0)
+      '@puppeteer/browsers': 3.2.2(proxy-agent@8.0.2)
       chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
       devtools-protocol: 0.0.1666840
       lilconfig: 3.1.3
-      puppeteer-core: 25.10.0(proxy-agent@6.5.0)
+      puppeteer-core: 25.10.0(proxy-agent@8.0.2)
       typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bufferutil
@@ -18978,6 +19008,8 @@ snapshots:
   quick-lru@5.1.1: {}
 
   quick-lru@7.3.0: {}
+
+  quickjs-wasi@2.2.0: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -19739,6 +19771,14 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.5
+
+  socks-proxy-agent@10.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      socks: 2.8.10
+    transitivePeerDependencies:
+      - supports-color
 
   socks-proxy-agent@8.0.5:
     dependencies:

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -66,6 +66,8 @@ describe('HttpClient', () => {
                 res.writeHead(r.statusCode!, r.headers);
                 r.pipe(res);
             });
+            // An unhandled 'error' here would take the worker down instead of failing the test.
+            upstream.on('error', () => res.destroy());
             req.pipe(upstream);
         });
         await new Promise<void>((done) => proxy.listen(0, '127.0.0.1', done));
@@ -116,8 +118,8 @@ describe('HttpClient', () => {
     });
 
     test('a request emits no deprecation warning', async () => {
-        // A deprecation Node still lists as pending only surfaces with the flag, so the check does not depend on
-        // the Node version running the suite. Each warning fires once per process, hence a fresh one.
+        // Node reports a deprecation it still lists as pending only under the flag, which keeps the check
+        // independent of the version running the suite. A fresh process, because a warning fires once per process.
         const entry = pathToFileURL(resolve(import.meta.dirname, '../dist/index.js')).href;
         const script = `
             import { ApifyClient } from ${JSON.stringify(entry)};
@@ -127,7 +129,12 @@ describe('HttpClient', () => {
             console.log(JSON.stringify(warnings));
         `;
         const args = ['--pending-deprecation', '--input-type=module', '--eval', script];
-        const { stdout } = await promisify(execFile)(process.execPath, args, { env: {} });
+        // A bare environment, so a proxy configured on the machine running the suite cannot reroute the
+        // request. `SystemRoot` is the one exception, because Windows resolves no hostname without it.
+        const { SystemRoot } = process.env;
+        const { stdout } = await promisify(execFile)(process.execPath, args, {
+            env: SystemRoot ? { SystemRoot } : {},
+        });
 
         const warnings: { name: string }[] = JSON.parse(stdout);
         expect(warnings.filter(({ name }) => name === 'DeprecationWarning')).toEqual([]);

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -1,10 +1,6 @@
-import { execFile } from 'node:child_process';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import os from 'node:os';
-import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
-import { promisify } from 'node:util';
 
 import { ApifyClient } from 'apify-client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -116,28 +112,5 @@ describe('HttpClient', () => {
             vi.unstubAllEnvs();
             await new Promise<void>((done) => proxy.close(() => done()));
         }
-    });
-
-    test('a request emits no deprecation warning', async () => {
-        // Node reports a deprecation it still lists as pending only under the flag, which keeps the check
-        // independent of the version running the suite. A fresh process, because a warning fires once per process.
-        const entry = pathToFileURL(resolve(import.meta.dirname, '../dist/index.js')).href;
-        const script = `
-            import { ApifyClient } from ${JSON.stringify(entry)};
-            const warnings = [];
-            process.on('warning', ({ name, code, message }) => warnings.push({ name, code, message }));
-            await new ApifyClient({ baseUrl: ${JSON.stringify(baseUrl)}, maxRetries: 0 }).user('me').get();
-            console.log(JSON.stringify(warnings));
-        `;
-        const args = ['--pending-deprecation', '--input-type=module', '--eval', script];
-        // A bare environment, so a proxy configured on the machine running the suite cannot reroute the
-        // request. `SystemRoot` is the one exception, because Windows resolves no hostname without it.
-        const { SystemRoot } = process.env;
-        const { stdout } = await promisify(execFile)(process.execPath, args, {
-            env: SystemRoot ? { SystemRoot } : {},
-        });
-
-        const warnings: { name: string }[] = JSON.parse(stdout);
-        expect(warnings.filter(({ name }) => name === 'DeprecationWarning')).toEqual([]);
     });
 });

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -1,9 +1,14 @@
+import { execFile } from 'node:child_process';
+import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import os from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 import { ApifyClient } from 'apify-client';
 import type { Page } from 'puppeteer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Browser } from './_helper.js';
 import { mockServer } from './mock_server/server.js';
@@ -50,5 +55,50 @@ describe('HttpClient', () => {
         await expect(page.evaluate((rId) => client.task(rId).get(), resourceId)).rejects.toThrow();
         // this is failing after axios upgrade, the error is returned with a wrong name and message
         // expect(err.message).toMatch('timeout of 1000ms exceeded');
+    });
+
+    test('requests go through the proxy named in HTTP_PROXY', async () => {
+        const proxied: string[] = [];
+        // A forward proxy: the agent puts the absolute target URL on the request line, so relay it as it is.
+        const proxy = http.createServer((req, res) => {
+            proxied.push(req.url!);
+            const upstream = http.request(new URL(req.url!), { method: req.method, headers: req.headers }, (r) => {
+                res.writeHead(r.statusCode!, r.headers);
+                r.pipe(res);
+            });
+            req.pipe(upstream);
+        });
+        await new Promise<void>((done) => proxy.listen(0, '127.0.0.1', done));
+        const proxyUrl = `http://127.0.0.1:${(proxy.address() as AddressInfo).port}`;
+        // `proxy-from-env` reads the lowercase name first, and a developer machine may exempt localhost in NO_PROXY.
+        for (const name of ['HTTP_PROXY', 'http_proxy']) vi.stubEnv(name, proxyUrl);
+        for (const name of ['NO_PROXY', 'no_proxy']) vi.stubEnv(name, '');
+
+        try {
+            const res = await client.user('me').get();
+            expect(res.id).toBe('get-user');
+            expect(proxied).toEqual([`${baseUrl}/v2/users/me`]);
+        } finally {
+            vi.unstubAllEnvs();
+            await new Promise<void>((done) => proxy.close(() => done()));
+        }
+    });
+
+    test('a request emits no deprecation warning', async () => {
+        // A deprecation Node still lists as pending only surfaces with the flag, so the check does not depend on
+        // the Node version running the suite. Each warning fires once per process, hence a fresh one.
+        const entry = pathToFileURL(resolve(import.meta.dirname, '../dist/index.js')).href;
+        const script = `
+            import { ApifyClient } from ${JSON.stringify(entry)};
+            const warnings = [];
+            process.on('warning', ({ name, code, message }) => warnings.push({ name, code, message }));
+            await new ApifyClient({ baseUrl: ${JSON.stringify(baseUrl)}, maxRetries: 0 }).user('me').get();
+            console.log(JSON.stringify(warnings));
+        `;
+        const args = ['--pending-deprecation', '--input-type=module', '--eval', script];
+        const { stdout } = await promisify(execFile)(process.execPath, args, { env: {} });
+
+        const warnings: { name: string }[] = JSON.parse(stdout);
+        expect(warnings.filter(({ name }) => name === 'DeprecationWarning')).toEqual([]);
     });
 });

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -7,7 +7,6 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 import { ApifyClient } from 'apify-client';
-import type { Page } from 'puppeteer';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Browser } from './_helper.js';
@@ -28,9 +27,7 @@ describe('HttpClient', () => {
     });
 
     let client: ApifyClient;
-    let page: Page;
-    beforeEach(async () => {
-        page = await browser.getInjectedPage(baseUrl, { timeoutSecs: 1 });
+    beforeEach(() => {
         client = new ApifyClient({
             baseUrl,
             timeoutSecs: 1,
@@ -38,9 +35,8 @@ describe('HttpClient', () => {
             userAgentSuffix: ['SDK/3.1.1', 'Crawlee/3.11.5'],
         });
     });
-    afterEach(async () => {
+    afterEach(() => {
         client = null as unknown as ApifyClient;
-        page.close().catch(() => {});
     });
     test('requests timeout after timeoutSecs', async () => {
         const context = { delayMillis: 3000 };
@@ -52,9 +48,14 @@ describe('HttpClient', () => {
         expect(ua).toMatch(`(${os.platform()}; Node/${process.version})`);
         expect(ua).toMatch('isAtHome/false; SDK/3.1.1; Crawlee/3.11.5');
 
-        await expect(page.evaluate((rId) => client.task(rId).get(), resourceId)).rejects.toThrow();
-        // this is failing after axios upgrade, the error is returned with a wrong name and message
-        // expect(err.message).toMatch('timeout of 1000ms exceeded');
+        const page = await browser.getInjectedPage(baseUrl, { timeoutSecs: 1 });
+        try {
+            await expect(page.evaluate((rId) => client.task(rId).get(), resourceId)).rejects.toThrow();
+            // this is failing after axios upgrade, the error is returned with a wrong name and message
+            // expect(err.message).toMatch('timeout of 1000ms exceeded');
+        } finally {
+            page.close().catch(() => {});
+        }
     });
 
     test('requests go through the proxy named in HTTP_PROXY, and skip it for hosts in NO_PROXY', async () => {

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -57,7 +57,7 @@ describe('HttpClient', () => {
         // expect(err.message).toMatch('timeout of 1000ms exceeded');
     });
 
-    test('requests go through the proxy named in HTTP_PROXY', async () => {
+    test('requests go through the proxy named in HTTP_PROXY, and skip it for hosts in NO_PROXY', async () => {
         const proxied: string[] = [];
         // A forward proxy: the agent puts the absolute target URL on the request line, so relay it as it is.
         const proxy = http.createServer((req, res) => {
@@ -78,6 +78,37 @@ describe('HttpClient', () => {
             const res = await client.user('me').get();
             expect(res.id).toBe('get-user');
             expect(proxied).toEqual([`${baseUrl}/v2/users/me`]);
+
+            // A fresh client for the exempted host, because the first one keeps its socket to the proxy alive
+            // and would reuse it without consulting the environment again.
+            for (const name of ['NO_PROXY', 'no_proxy']) vi.stubEnv(name, 'localhost');
+            const direct = await new ApifyClient({ baseUrl, timeoutSecs: 1, maxRetries: 0 }).user('me').get();
+            expect(direct.id).toBe('get-user');
+            expect(proxied).toHaveLength(1);
+        } finally {
+            vi.unstubAllEnvs();
+            await new Promise<void>((done) => proxy.close(() => done()));
+        }
+    });
+
+    test('an https request tunnels through the proxy named in HTTPS_PROXY', async () => {
+        const tunneled: string[] = [];
+        // The tunnel is answered by dropping the socket: reaching for it at all is what separates an https
+        // origin from the plain forward-proxy path above, while speaking through it would need a certificate.
+        const proxy = http.createServer();
+        proxy.on('connect', (req, socket) => {
+            tunneled.push(req.url!);
+            socket.destroy();
+        });
+        await new Promise<void>((done) => proxy.listen(0, '127.0.0.1', done));
+        const proxyUrl = `http://127.0.0.1:${(proxy.address() as AddressInfo).port}`;
+        for (const name of ['HTTPS_PROXY', 'https_proxy']) vi.stubEnv(name, proxyUrl);
+        for (const name of ['NO_PROXY', 'no_proxy']) vi.stubEnv(name, '');
+
+        try {
+            const secure = new ApifyClient({ baseUrl: 'https://api.apify.test', timeoutSecs: 1, maxRetries: 0 });
+            await expect(secure.user('me').get()).rejects.toThrow();
+            expect(tunneled).toEqual(['api.apify.test:443']);
         } finally {
             vi.unstubAllEnvs();
             await new Promise<void>((done) => proxy.close(() => done()));


### PR DESCRIPTION
`proxy-agent@6` nests `proxy-from-env@1`, which runs every request URL through the legacy `url.parse()`. Node 24 turned that into runtime deprecation `DEP0169`, printed once per process. `proxy-agent@8` depends on `proxy-from-env@2`, which uses the WHATWG URL API. The major is ESM-only and needs Node 20+. `v3` is already native ESM on Node 22+, so no source changes.

`proxy-from-env@2` no longer reads `npm_config_proxy` and `npm_config_https_proxy`, the variables npm exports into `npm run` scripts from `.npmrc`, so a proxy configured only there stops applying to the client's requests. The v3 upgrading guide covers it.

Two new tests cover the proxy path, which nothing exercised before: the forward proxy named in `HTTP_PROXY` with a `NO_PROXY` exemption, and the CONNECT tunnel an https origin takes.

BREAKING CHANGE: proxy settings that reach the client through npm config are no longer honored. `proxy-from-env@2` reads `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` and `NO_PROXY` and no longer consults `npm_config_proxy` or `npm_config_<proto>_proxy`, so a proxy configured only in `.npmrc` stops applying to requests made from an npm script. Set the standard environment variables instead.

Closes #898

*✍️ Drafted by Claude Code*
