### PR TITLE
perf!: serialize requests once in batchAddRequests

### DIFF
--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -216,13 +216,9 @@ A trailing slash appears only on a field the API returns without a path, so on `
 
 A URL field whose value isn't a valid absolute URL now fails response validation and throws <ApiLink to="class/ResponseValidationError">`ResponseValidationError`</ApiLink>, the same as any other field that doesn't match the specification.
 
-## `batchAddRequests()` serializes each request once
+## `batchAddRequests()` rejects an oversized request before sending anything
 
-<ApiLink to="class/RequestQueueClient#batchAddRequests">`batchAddRequests()`</ApiLink> stringified every request twice, once to measure which batch it belonged to and once to send it. Each request is now serialized once, and the same strings are joined into the batch body. The bytes on the wire are the same. Three things around them changed.
-
-### An oversized request is rejected before any batch is sent
-
-A request too large for the payload limit still throws, and the message still names its index. What changed is when the check runs. In v2 each batch was measured as it came up, so every batch before the oversized request had already been sent by the time the call threw. v3 measures the whole input up front, so the call throws without sending anything.
+<ApiLink to="class/RequestQueueClient#batchAddRequests">`batchAddRequests()`</ApiLink> now measures the whole input before it sends the first batch. A request too large for the payload limit still throws the same error, and the message still names the request's index. What changed is that nothing has been sent by the time it throws. In v2 each batch was measured as it came up, so every batch before the oversized request had already gone out.
 
 ```js
 // In v2 the four batches before the oversized request had already been sent.
@@ -232,9 +228,9 @@ await client.requestQueue('my-queue').batchAddRequests([...hundredRequests, over
 
 Code that treated the throw as "some of these landed" and reconciled the queue afterwards can drop the reconciliation.
 
-### A string labelled `application/json` is sent as it is
+## A string body with a JSON content type is sent as it is
 
-A string body sent with an explicit `application/json` content type now goes out verbatim. Axios used to parse it to check that it was valid JSON, and wrapped it in a JSON string literal when it wasn't.
+A string body sent with an explicit `application/json` content type now goes out verbatim. Axios used to parse it to check that it was valid JSON, and wrapped it in a JSON string literal when it wasn't. The client skips that step so that `batchAddRequests()` can send a body it has already serialized.
 
 <ApiLink to="class/KeyValueStoreClient#setRecord">`setRecord()`</ApiLink> is where you'd notice. Storing a non-JSON string under `contentType: 'application/json'` used to save `"my value"`, quotes included, and now saves `my value`, which <ApiLink to="class/KeyValueStoreClient#getRecord">`getRecord()`</ApiLink> can't parse back:
 
@@ -249,9 +245,7 @@ await client.keyValueStore('my-store').setRecord({
 
 Give a record a content type matching what it holds, such as `text/plain`, or pass the value as an object and let the client serialize it.
 
-### The protected batch helpers take serialized requests
-
-`_batchAddRequests()` and `_batchAddRequestsWithRetries()` take the serialized entries instead of the plain requests, and `_batchAddRequests()` no longer re-validates a batch the public method already validated. Both are protected, so only a subclass that overrides or calls them is affected.
+The same applies to a string input passed together with a `contentType` to <ApiLink to="class/ActorClient#start">`start()`</ApiLink>, <ApiLink to="class/ActorClient#call">`call()`</ApiLink>, or <ApiLink to="class/RunClient#metamorph">`metamorph()`</ApiLink>. v2 handed the API the string wrapped in quotes, v3 hands it over as it is.
 
 ## `versions().list()` and `envVars().list()` take no options
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -216,6 +216,43 @@ A trailing slash appears only on a field the API returns without a path, so on `
 
 A URL field whose value isn't a valid absolute URL now fails response validation and throws <ApiLink to="class/ResponseValidationError">`ResponseValidationError`</ApiLink>, the same as any other field that doesn't match the specification.
 
+## `batchAddRequests()` serializes each request once
+
+<ApiLink to="class/RequestQueueClient#batchAddRequests">`batchAddRequests()`</ApiLink> stringified every request twice, once to measure which batch it belonged to and once to send it. Each request is now serialized once, and the same strings are joined into the batch body. The bytes on the wire are the same. Three things around them changed.
+
+### An oversized request is rejected before any batch is sent
+
+A request too large for the payload limit still throws, and the message still names its index. What changed is when the check runs. In v2 each batch was measured as it came up, so every batch before the oversized request had already been sent by the time the call threw. v3 measures the whole input up front, so the call throws without sending anything.
+
+```js
+// In v2 the four batches before the oversized request had already been sent.
+// In v3 nothing is sent.
+await client.requestQueue('my-queue').batchAddRequests([...hundredRequests, oversizedRequest]);
+```
+
+Code that treated the throw as "some of these landed" and reconciled the queue afterwards can drop the reconciliation.
+
+### A string labelled `application/json` is sent as it is
+
+A string body sent with an explicit `application/json` content type now goes out verbatim. Axios used to parse it to check that it was valid JSON, and wrapped it in a JSON string literal when it wasn't.
+
+<ApiLink to="class/KeyValueStoreClient#setRecord">`setRecord()`</ApiLink> is where you'd notice. Storing a non-JSON string under `contentType: 'application/json'` used to save `"my value"`, quotes included, and now saves `my value`, which <ApiLink to="class/KeyValueStoreClient#getRecord">`getRecord()`</ApiLink> can't parse back:
+
+```js
+// v2 stored `"my value"`, v3 stores `my value`.
+await client.keyValueStore('my-store').setRecord({
+    key: 'my-key',
+    value: 'my value',
+    contentType: 'application/json',
+});
+```
+
+Give a record a content type matching what it holds, such as `text/plain`, or pass the value as an object and let the client serialize it.
+
+### The protected batch helpers take serialized requests
+
+`_batchAddRequests()` and `_batchAddRequestsWithRetries()` take the serialized entries instead of the plain requests, and `_batchAddRequests()` no longer re-validates a batch the public method already validated. Both are protected, so only a subclass that overrides or calls them is affected.
+
 ## `versions().list()` and `envVars().list()` take no options
 
 <ApiLink to="class/ActorVersionCollectionClient#list">`ActorVersionCollectionClient.list()`</ApiLink> and <ApiLink to="class/ActorEnvVarCollectionClient#list">`ActorEnvVarCollectionClient.list()`</ApiLink> now take no arguments. Neither endpoint reads `offset`, `limit` or `desc`, and both return every item in one response, so `chunkSize` had nothing to size either. The `ActorVersionCollectionListOptions` and `ActorEnvVarCollectionListOptions` types that declared those four options, deprecated since v2.21.0, are gone from the package. A call that passed an options object no longer compiles. Drop the argument and the call returns the same items as before.

--- a/docs/public-api/apify-client.api.md
+++ b/docs/public-api/apify-client.api.md
@@ -3265,9 +3265,9 @@ export class RequestQueueClient extends ResourceClient {
     constructor(options: ApiClientSubResourceOptions, userOptions?: RequestQueueUserOptions);
     addRequest(request: RequestQueueClientRequestToAdd, options?: RequestQueueClientAddRequestOptions): Promise<RequestQueueClientAddRequestResult>;
     batchAddRequests(requests: RequestQueueClientRequestToAdd[], options?: RequestQueueClientBatchAddRequestWithRetriesOptions): Promise<RequestQueueClientBatchRequestsOperationResult>;
-    protected _batchAddRequests(requests: RequestQueueClientRequestToAdd[], options?: RequestQueueClientAddRequestOptions): Promise<RequestQueueClientBatchRequestsOperationResult>;
+    protected _batchAddRequests(requests: SerializedRequestToAdd[], options?: RequestQueueClientAddRequestOptions): Promise<RequestQueueClientBatchRequestsOperationResult>;
     // (undocumented)
-    protected _batchAddRequestsWithRetries(requests: RequestQueueClientRequestToAdd[], options?: RequestQueueClientBatchAddRequestWithRetriesOptions): Promise<RequestQueueClientBatchRequestsOperationResult>;
+    protected _batchAddRequestsWithRetries(requests: SerializedRequestToAdd[], options?: RequestQueueClientBatchAddRequestWithRetriesOptions): Promise<RequestQueueClientBatchRequestsOperationResult>;
     batchDeleteRequests(requests: RequestQueueClientRequestToDelete[]): Promise<RequestQueueClientBatchDeleteRequestsResult>;
     delete(): Promise<void>;
     deleteRequest(id: string): Promise<void>;
@@ -3724,6 +3724,17 @@ interface ScheduleRePointed {
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
 type Schemas = components['schemas'];
+
+// Not exported by the entry point; reachable only as a referenced type.
+// @public
+interface SerializedRequestToAdd {
+    // (undocumented)
+    byteLength: number;
+    // (undocumented)
+    json: string;
+    // (undocumented)
+    request: RequestQueueClientRequestToAdd;
+}
 
 // @public
 export class ServerError extends ApifyApiError {

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -74,9 +74,10 @@ export class HttpClient {
                 return new URLSearchParams(formattedParams).toString();
             },
             validateStatus: null,
-            // Using interceptors for this functionality.
-            transformRequest: undefined,
-            transformResponse: undefined,
+            // Interceptors serialize requests and parse responses instead. Empty arrays rather than `undefined`,
+            // which axios fills in with its default transforms.
+            transformRequest: [],
+            transformResponse: [],
             responseType: 'arraybuffer',
             timeout: this.timeoutMillis,
             // maxBodyLength needs to be Infinity, because -1 falls back to a 10 MB default

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -31,6 +31,12 @@ export class InvalidResponseBodyError extends Error {
 }
 
 function serializeRequest(config: ApifyRequestConfig): ApifyRequestConfig {
+    // A string body with an explicit content type is already serialized and goes out as it is. The axios default
+    // transform would otherwise parse a JSON one in full just to check that it is valid, which for a body assembled
+    // from thousands of pre-serialized requests costs about as much as serializing them did.
+    const explicitContentType = config.headers?.['Content-Type'] || config.headers?.['content-type'];
+    if (typeof config.data === 'string' && explicitContentType) return config;
+
     const [defaultTransform] = axios.defaults.transformRequest as AxiosRequestTransformer[];
 
     // The function not only serializes data, but it also adds correct headers.

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -34,7 +34,8 @@ import {
     parseDateFields,
     parseResponse,
     RequestQueuePaginationIterator,
-    sliceArrayByByteLength,
+    splitIntoJsonArrayBatches,
+    utf8ByteLength,
 } from '../utils.js';
 
 const DEFAULT_PARALLEL_BATCH_ADD_REQUESTS = 5;
@@ -55,7 +56,6 @@ const newRequestSchema = z.custom<RequestQueueClientRequestToAdd>(
     'Expected a request object without an `id`',
 );
 const forefrontOptionsSchema = z.strictObject({ forefront: z.boolean().optional() });
-const batchAddRequestsSchema = z.array(newRequestSchema).min(1).max(REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION);
 const batchAddRequestsWithRetriesSchema = z.array(newRequestSchema).min(1);
 const optionalBooleanSchema = z.boolean().optional();
 const optionalNumberSchema = z.number().optional();
@@ -88,6 +88,16 @@ const paginateRequestsOptionsSchema = z.strictObject({
     cursor: z.string().optional(),
     filter: requestFilterSchema.optional(),
 });
+
+/**
+ * A request to add, serialized once up front: `byteLength` decides which batch it goes into, `json` is what the body of
+ * that batch is assembled from, and `request` is what the result bookkeeping needs.
+ */
+interface SerializedRequestToAdd {
+    request: RequestQueueClientRequestToAdd;
+    json: string;
+    byteLength: number;
+}
 
 export type {
     AllowedHttpMethods,
@@ -331,17 +341,19 @@ export class RequestQueueClient extends ResourceClient {
      * @private
      */
     protected async _batchAddRequests(
-        requests: RequestQueueClientRequestToAdd[],
+        requests: SerializedRequestToAdd[],
         options: RequestQueueClientAddRequestOptions = {},
     ): Promise<RequestQueueClientBatchRequestsOperationResult> {
-        parseArgument(requests, batchAddRequestsSchema);
         const parsed = parseArgument(options, forefrontOptionsSchema, 'RequestQueueClientAddRequestOptions');
 
         const response = await this.httpClient.call({
             url: this._url('requests/batch'),
             method: 'POST',
             timeout: Math.min(MEDIUM_TIMEOUT_MILLIS, this.timeoutMillis ?? Infinity),
-            data: requests,
+            // The body is assembled from the requests as `batchAddRequests` serialized them; the explicit content type
+            // makes the request interceptor send the string as it is instead of serializing the requests again.
+            headers: { 'content-type': 'application/json' },
+            data: `[${requests.map(({ json }) => json).join(',')}]`,
             params: this._params({
                 forefront: parsed.forefront,
                 clientKey: this.clientKey,
@@ -352,7 +364,7 @@ export class RequestQueueClient extends ResourceClient {
     }
 
     protected async _batchAddRequestsWithRetries(
-        requests: RequestQueueClientRequestToAdd[],
+        requests: SerializedRequestToAdd[],
         options: RequestQueueClientBatchAddRequestWithRetriesOptions = {},
     ): Promise<RequestQueueClientBatchRequestsOperationResult> {
         const {
@@ -385,7 +397,7 @@ export class RequestQueueClient extends ResourceClient {
                 const processedRequestsUniqueKeys = processedRequests.map(({ uniqueKey }) => uniqueKey);
                 // Requests remaining to be processed are the all that remain
                 remainingRequests = requests.filter(
-                    ({ uniqueKey }) => !processedRequestsUniqueKeys.includes(uniqueKey),
+                    ({ request }) => !processedRequestsUniqueKeys.includes(request.uniqueKey),
                 );
 
                 // Stop if all requests have been processed
@@ -401,8 +413,8 @@ export class RequestQueueClient extends ResourceClient {
                 // This ensures that this method does not throw and keeps the signature.
                 const processedRequestsUniqueKeys = processedRequests.map(({ uniqueKey }) => uniqueKey);
                 unprocessedRequests = requests
-                    .filter(({ uniqueKey }) => !processedRequestsUniqueKeys.includes(uniqueKey))
-                    .map(({ method, uniqueKey, url }) => ({ method, uniqueKey, url }));
+                    .filter(({ request }) => !processedRequestsUniqueKeys.includes(request.uniqueKey))
+                    .map(({ request: { method, uniqueKey, url } }) => ({ method, uniqueKey, url }));
 
                 break;
             }
@@ -480,12 +492,28 @@ export class RequestQueueClient extends ResourceClient {
         const payloadSizeLimitBytes =
             MAX_PAYLOAD_SIZE_BYTES - Math.ceil(MAX_PAYLOAD_SIZE_BYTES * SAFETY_BUFFER_PERCENT);
 
+        // Serialize every request once: the byte lengths decide the batch boundaries, and the same strings are joined
+        // into the batch bodies, so nothing is stringified a second time when it is sent.
+        const serializedRequests = requests.map((request, index): SerializedRequestToAdd => {
+            const json = JSON.stringify(request);
+            const byteLength = utf8ByteLength(json);
+            // Two more bytes for the brackets, which even a batch of one request carries.
+            if (byteLength + 2 > payloadSizeLimitBytes) {
+                throw new Error(
+                    `RequestQueueClient.batchAddRequests: The size of the request with index: ${index} ` +
+                        `exceeds the maximum allowed size (${payloadSizeLimitBytes} bytes).`,
+                );
+            }
+            return { request, json, byteLength };
+        });
+        const batches = splitIntoJsonArrayBatches(serializedRequests, {
+            maxCount: REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION,
+            maxByteLength: payloadSizeLimitBytes,
+        });
+
         // Keep a pool of up to `maxParallel` requests running at once
-        let i = 0;
-        while (i < requests.length) {
-            const slicedRequests = requests.slice(i, i + REQUEST_QUEUE_MAX_REQUESTS_PER_BATCH_OPERATION);
-            const requestsInBatch = sliceArrayByByteLength(slicedRequests, payloadSizeLimitBytes, i);
-            const requestPromise = this._batchAddRequestsWithRetries(requestsInBatch, options);
+        for (const batch of batches) {
+            const requestPromise = this._batchAddRequestsWithRetries(batch, options);
             executingRequests.add(requestPromise);
             // A rejection reaches the caller through the awaits below; this bookkeeping chain only has to avoid
             // turning it into an unhandled one of its own.
@@ -499,7 +527,6 @@ export class RequestQueueClient extends ResourceClient {
             if (executingRequests.size >= maxParallel) {
                 await Promise.race(executingRequests);
             }
-            i += requestsInBatch.length;
         }
         // Get results from remaining operations
         await Promise.all(executingRequests);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,30 +230,39 @@ export async function maybeCompressValue(value: unknown): Promise<CompressedValu
 }
 
 /**
- * Helper function slice the items from array to fit the max byte length.
+ * Returns the UTF-8 byte length of a string.
  */
-export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, startIndex: number): T[] {
-    const stringByteLength = (str: string) => (isNode() ? Buffer.byteLength(str) : new Blob([str]).size);
-    const arrayByteLength = stringByteLength(JSON.stringify(array));
-    if (arrayByteLength < maxByteLength) return array;
+export function utf8ByteLength(value: string): number {
+    return isNode() ? Buffer.byteLength(value) : new Blob([value]).size;
+}
 
-    const slicedArray: T[] = [];
-    let byteLength = 2; // 2 bytes for the empty array []
-    for (let i = 0; i < array.length; i++) {
-        const item = array[i];
-        const itemByteSize = stringByteLength(JSON.stringify(item));
-        if (itemByteSize > maxByteLength) {
-            throw new Error(
-                `RequestQueueClient.batchAddRequests: The size of the request with index: ${startIndex + i} ` +
-                    `exceeds the maximum allowed size (${maxByteLength} bytes).`,
-            );
+/**
+ * Splits JSON-serialized items into consecutive batches of at most `maxCount` items, each of which fits into a JSON
+ * array body - the items joined by commas between brackets - of at most `maxByteLength` bytes. The `byteLength` of an
+ * item is the UTF-8 byte length of its serialization. An item too large for a body of its own still gets one, so a
+ * caller that cannot send such an item has to reject it beforehand.
+ */
+export function splitIntoJsonArrayBatches<T extends { byteLength: number }>(
+    items: readonly T[],
+    { maxCount, maxByteLength }: { maxCount: number; maxByteLength: number },
+): T[][] {
+    const batches: T[][] = [];
+    let batch: T[] = [];
+    // One byte for the opening bracket; each item then adds its own bytes plus one for the comma or the closing
+    // bracket that follows it.
+    let byteLength = 1;
+    for (const item of items) {
+        if (batch.length > 0 && (batch.length >= maxCount || byteLength + item.byteLength + 1 > maxByteLength)) {
+            batches.push(batch);
+            batch = [];
+            byteLength = 1;
         }
-        if (byteLength + itemByteSize >= maxByteLength) break;
-        byteLength += itemByteSize;
-        slicedArray.push(item);
+        batch.push(item);
+        byteLength += item.byteLength + 1;
     }
+    if (batch.length > 0) batches.push(batch);
 
-    return slicedArray;
+    return batches;
 }
 
 export function isNode(): boolean {

--- a/test/http_client.test.ts
+++ b/test/http_client.test.ts
@@ -51,4 +51,19 @@ describe('HttpClient', () => {
         // this is failing after axios upgrade, the error is returned with a wrong name and message
         // expect(err.message).toMatch('timeout of 1000ms exceeded');
     });
+
+    test('sends a string body with an explicit content type as it is', async () => {
+        // The axios default transform would re-parse the body to validate it and trim this whitespace away.
+        const body = ' [{"uniqueKey": "key-1", "url": "http://example.com/1"}] ';
+
+        const response = await client.httpClient.call({
+            url: `${baseUrl}/v2/request-queues/some-id/requests/batch`,
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            data: body,
+        });
+
+        expect(response.config.data).toBe(body);
+        expect(mockServer.getLastRequest()?.body).toEqual(JSON.parse(body));
+    });
 });

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -467,6 +467,37 @@ describe('Request Queue methods', () => {
             expect(serializations).toEqual(new Array(requestsLength).fill(1));
         });
 
+        test('batchAddRequests() retries only the requests the API left unprocessed', async () => {
+            const requests = new Array(3)
+                .fill(0)
+                .map((_, i) => ({ url: `http://example.com/${i}`, uniqueKey: `key-${i}` }));
+            mockServer.setResponse({
+                body: {
+                    data: {
+                        processedRequests: [
+                            {
+                                requestId: 'request-0',
+                                uniqueKey: 'key-0',
+                                wasAlreadyPresent: false,
+                                wasAlreadyHandled: false,
+                            },
+                        ],
+                        unprocessedRequests: [{ url: requests[1].url, uniqueKey: 'key-1' }],
+                    },
+                },
+            });
+
+            await client.requestQueue('some-id').batchAddRequests(requests, {
+                maxUnprocessedRequestsRetries: 1,
+                minDelayBetweenUnprocessedRequestsRetriesMillis: 0,
+            });
+
+            const uniqueKeys = (req: Request) => req.body.map(({ uniqueKey }: { uniqueKey: string }) => uniqueKey);
+            const [firstAttempt, secondAttempt] = mockServer.getLastRequests(2);
+            expect(uniqueKeys(firstAttempt)).toEqual(['key-0', 'key-1', 'key-2']);
+            expect(uniqueKeys(secondAttempt)).toEqual(['key-1', 'key-2']);
+        });
+
         test('batchAddRequests() throws on a response that does not match the API schema', async () => {
             mockServer.setResponse({ body: { data: { processedRequests: 'none', unprocessedRequests: [] } } });
             const requests = [{ url: 'http://example.com/1', uniqueKey: 'key-1' }];

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -712,9 +712,12 @@ describe('Request Queue methods', () => {
                 uniqueKey: 'key-big',
             };
             const requestsWithBigRequest: typeof requests = [...requests, bigRequest];
+            const firedRequestCount = mockServer.requests.length;
             await expect(client.requestQueue(queueId).batchAddRequests(requestsWithBigRequest)).rejects.toThrow(
                 `RequestQueueClient.batchAddRequests: The size of the request with index: ${requestsWithBigRequest.length - 1}`,
             );
+            // The oversized request is rejected before any of the batches around it goes out.
+            expect(mockServer.requests).toHaveLength(firedRequestCount);
             validateRequest({ query: {}, params: { queueId }, body: false });
         });
     });

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -15,6 +15,7 @@ import { mockServer } from './mock_server/server.js';
 describe('Request Queue methods', () => {
     let baseUrl: string;
     const browser = new Browser();
+    const jsonHeaders = { 'content-type': 'application/json' };
 
     beforeAll(async () => {
         const server = await mockServer.start();
@@ -432,7 +433,7 @@ describe('Request Queue methods', () => {
                 .map((_, i) => ({ url: `http://example.com/${i}`, uniqueKey: `key-${i}` }));
 
             const res = await client.requestQueue(queueId).batchAddRequests(requests, options);
-            validateRequest({ query: options, params: { queueId }, body: requests });
+            validateRequest({ query: options, params: { queueId }, body: requests, additionalHeaders: jsonHeaders });
 
             const browserRes = await page.evaluate(
                 (id, req, opts) => {
@@ -443,7 +444,27 @@ describe('Request Queue methods', () => {
                 options,
             );
             expect(browserRes).toEqual(asBrowserResult(res));
-            validateRequest({ query: options, params: { queueId }, body: requests });
+            validateRequest({ query: options, params: { queueId }, body: requests, additionalHeaders: jsonHeaders });
+        });
+
+        test('batchAddRequests() serializes each request only once', async () => {
+            const requestsLength = 60;
+            const serializations = new Array(requestsLength).fill(0);
+            const requests = new Array(requestsLength).fill(0).map((_, i) => {
+                const request = { url: `http://example.com/${i}`, uniqueKey: `key-${i}` };
+                // `JSON.stringify` invokes `toJSON` on every object it serializes, alone or as an array item.
+                Object.defineProperty(request, 'toJSON', {
+                    value: () => {
+                        serializations[i]++;
+                        return { ...request };
+                    },
+                });
+                return request;
+            });
+
+            await client.requestQueue('some-id').batchAddRequests(requests);
+
+            expect(serializations).toEqual(new Array(requestsLength).fill(1));
         });
 
         test('batchAddRequests() throws on a response that does not match the API schema', async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -208,3 +208,48 @@ describe('utils.stringifyWebhooksToBase64()', () => {
         expect(JSON.parse(Buffer.from(base64String, 'base64').toString('utf8'))).toStrictEqual(webhooks);
     });
 });
+
+describe('utils.utf8ByteLength()', () => {
+    test('counts UTF-8 bytes, not characters', () => {
+        expect(utils.utf8ByteLength('')).toBe(0);
+        expect(utils.utf8ByteLength('abc')).toBe(3);
+        expect(utils.utf8ByteLength('ž')).toBe(2);
+        expect(utils.utf8ByteLength('😀')).toBe(4);
+    });
+});
+
+describe('utils.splitIntoJsonArrayBatches()', () => {
+    const items = (...byteLengths: number[]) => byteLengths.map((byteLength) => ({ byteLength }));
+
+    test('fills a batch up to the byte length of its JSON array body, brackets and commas included', () => {
+        // `[` + three 5-byte items + two commas + `]` is 19 bytes, so three items fit into 19 bytes but not into 18.
+        expect(utils.splitIntoJsonArrayBatches(items(5, 5, 5, 5), { maxCount: 25, maxByteLength: 19 })).toEqual([
+            items(5, 5, 5),
+            items(5),
+        ]);
+        expect(utils.splitIntoJsonArrayBatches(items(5, 5, 5, 5), { maxCount: 25, maxByteLength: 18 })).toEqual([
+            items(5, 5),
+            items(5, 5),
+        ]);
+    });
+
+    test('caps a batch at maxCount items', () => {
+        expect(utils.splitIntoJsonArrayBatches(items(1, 1, 1, 1, 1), { maxCount: 2, maxByteLength: 1000 })).toEqual([
+            items(1, 1),
+            items(1, 1),
+            items(1),
+        ]);
+    });
+
+    test('gives an item that does not fit into a body of its own a batch of its own', () => {
+        expect(utils.splitIntoJsonArrayBatches(items(1, 50, 1), { maxCount: 25, maxByteLength: 10 })).toEqual([
+            items(1),
+            items(50),
+            items(1),
+        ]);
+    });
+
+    test('returns no batches for no items', () => {
+        expect(utils.splitIntoJsonArrayBatches([], { maxCount: 25, maxByteLength: 10 })).toEqual([]);
+    });
+});


### PR DESCRIPTION
### Description

- Mirroring https://github.com/apify/apify-client-python/pull/953.
- `batchAddRequests` stringified every request twice: once in `sliceArrayByByteLength` to measure the batch, and again in the `serializeRequest` interceptor when sending. Axios then ran its default `transformRequest` on top, because `transformRequest: undefined` in the instance config falls back to the defaults, and that default validates a JSON string body by parsing it in full. Each batch body was stringified twice and parsed once more.
- Each request is now serialized once up front. The byte lengths decide the batch boundaries (commas and brackets counted, which the old measurement skipped) and the same strings are joined into the batch body, sent with an explicit `content-type: application/json`. The interceptor passes a string body with an explicit content type through untouched, and the axios instance sets `transformRequest` and `transformResponse` to `[]`. That also removes the validation re-parse for every JSON body the client sends.

### Issue

- Closes #972

### Breaking changes

- A string body declared as JSON but not valid JSON (for example `setRecord` with `contentType: 'application/json'` and a non-JSON string) is sent as it is. Axios used to double-encode it into a JSON string literal.
- A request too large for the payload limit is rejected before any batch is sent. It used to be detected only when its batch came up, with earlier batches already in flight.
- The protected `_batchAddRequests` and `_batchAddRequestsWithRetries` take the serialized entries, and `_batchAddRequests` no longer re-validates a batch the public method already validated. The API report is updated.

*✍️ Drafted by Claude Code*