### PR TITLE
feat!: make the client's own code runtime-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The package includes a pre-built browser bundle that bundlers targeting browsers
 import { ApifyClient } from 'apify-client/browser';
 ```
 
-The client's own code needs no Node.js built-ins outside Node.js: the `node` export condition selects the Node.js implementation of the HTTP agents and request compression, and every other target gets one built on Web APIs. When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them. Log streaming, proxy support, and request compression are only available in Node.js. For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
+The client's own code needs no Node.js built-ins outside Node.js: the `node` condition selects the Node.js implementation of the HTTP agents and request compression, and every other target gets one built on Web APIs. When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them. Log streaming, proxy support, and request compression are only available in Node.js. For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,6 @@ import { ApifyClient } from 'apify-client/browser';
 
 Only two parts of the client need Node.js built-ins: the HTTP agents and request compression. The `node` condition selects the Node.js implementation of those, and every other target gets one built on Web APIs. Log streaming, proxy support, and request compression are only available in Node.js.
 
-When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them.
-
 For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
 
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ property to get only a subset of results. Other props are also available, depend
 
 ## Bundled environments
 
-The package includes a pre-built browser bundle that is automatically resolved by bundlers targeting browser environments. You can also import it explicitly via
+The package includes a pre-built browser bundle that bundlers targeting browsers resolve automatically. You can also import it explicitly:
 
 ```typescript
 import { ApifyClient } from 'apify-client/browser';
 ```
 
-For edge runtimes like Cloudflare Workers, you may need to enable Node compatibility (e.g. `node_compat = true` in `wrangler.toml`). Note that some Node-specific features (streaming, proxy support) are not available in the bundle.
+The client's own code needs no Node.js built-ins outside Node.js: the `node` export condition selects the Node.js implementation of the HTTP agents and request compression, and every other target gets one built on Web APIs. When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them. Log streaming, proxy support, and request compression are only available in Node.js. For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ The package includes a pre-built browser bundle that bundlers targeting browsers
 import { ApifyClient } from 'apify-client/browser';
 ```
 
-The client's own code needs no Node.js built-ins outside Node.js: the `node` condition selects the Node.js implementation of the HTTP agents and request compression, and every other target gets one built on Web APIs. When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them. Log streaming, proxy support, and request compression are only available in Node.js. For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
+Only two parts of the client need Node.js built-ins: the HTTP agents and request compression. The `node` condition selects the Node.js implementation of those, and every other target gets one built on Web APIs. Log streaming, proxy support, and request compression are only available in Node.js.
+
+When you bundle the ES module build yourself, the `@apify/log` and `@apify/utilities` dependencies still need polyfills for `events`, `process`, `stream`, and `buffer`. On Cloudflare Workers, the `nodejs_compat` compatibility flag provides them.
+
+For details, see [Bundled environments](https://docs.apify.com/api/client/js/docs/concepts/bundled-environments).
 
 ## API Reference
 

--- a/docs/02_concepts/05_bundled-environments.md
+++ b/docs/02_concepts/05_bundled-environments.md
@@ -25,7 +25,9 @@ The bundle includes polyfills for the Node.js built-ins the client's dependencie
 
 ## Bundling the ES module build yourself
 
-The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a single module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, every other target gets the Web API one. A bundler targeting a browser, Cloudflare Workers, or another edge runtime therefore never sees `node:zlib`, `node:os`, `node:net`, or `proxy-agent`.
+The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a single module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, every other target gets the Web API one. A bundler targeting a browser, Cloudflare Workers, or another edge runtime therefore never sees `node:zlib`, `node:os`, `node:util`, or `proxy-agent`.
+
+Reaching the ES module build takes a bundler that doesn't set the `browser` condition, which resolves `apify-client` to the pre-built bundle. esbuild's `neutral` platform sets no conditions, and webpack and Vite let you list them through `resolve.conditionNames` and `resolve.conditions`.
 
 Two dependencies still import Node.js built-ins:
 

--- a/docs/02_concepts/05_bundled-environments.md
+++ b/docs/02_concepts/05_bundled-environments.md
@@ -5,18 +5,40 @@ sidebar_label: Bundled environments
 description: 'Use the Apify API client for JavaScript in browsers, Cloudflare Workers, and other edge runtimes.'
 ---
 
+import ApiLink from '@theme/ApiLink';
+
 :::warning Non-Node.js environments
 
-This applies only to non-Node.js environments (browsers, Cloudflare Workers, edge runtimes). If you're running on Node.js, you can skip this section.
+This page applies only to non-Node.js environments (browsers, Cloudflare Workers, edge runtimes). If you're running on Node.js, you can skip it.
 
 :::
 
-The package ships a pre-built browser bundle that is automatically resolved when your bundler targets a browser environment. If it isn't picked up automatically, you can import it directly:
+## Browser bundle
+
+The package ships a pre-built browser bundle at `dist/bundle.js`. A bundler that targets the browser picks it up through the `browser` condition of the package's `exports` field. If yours doesn't, import it directly:
 
 ```js
 import { ApifyClient } from 'apify-client/browser';
 ```
 
-For Cloudflare Workers or other edge runtimes that don't provide Node built-ins, you may need to enable Node compatibility in your runtime config (e.g. `node_compat = true`.
+The bundle includes polyfills for the Node.js built-ins the client's dependencies import, so it needs no polyfill configuration.
 
-Note that some Node-specific features (streaming APIs, proxy) are not available in the browser bundle.
+## Bundling the ES module build yourself
+
+The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a single module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, every other target gets the Web API one. A bundler targeting a browser, Cloudflare Workers, or another edge runtime therefore never sees `node:zlib`, `node:os`, `node:net`, or `proxy-agent`.
+
+Two dependencies still import Node.js built-ins:
+
+- `@apify/log` imports `node:events` and reads `process.env`.
+- `@apify/utilities` imports `node:stream` and `node:crypto`, and uses `Buffer`.
+
+Until [apify/apify-shared-js#537](https://github.com/apify/apify-shared-js/issues/537) removes them, bundling the ES module build for a non-Node.js target needs polyfills for `events`, `process`, `stream`, and `buffer`. The `node:crypto` import can resolve to an empty module, because only deprecated functions the client doesn't call use it. On Cloudflare Workers, the [`nodejs_compat`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) compatibility flag provides all of them.
+
+## Features that need Node.js
+
+These features rely on Node.js APIs and aren't available in the browser bundle or in the Web API runtime:
+
+- Log streaming with <ApiLink to="class/LogClient#stream">`LogClient.stream()`</ApiLink> and <ApiLink to="class/RunClient#getStreamedLog">`RunClient.getStreamedLog()`</ApiLink>, and the `stream` option of <ApiLink to="class/KeyValueStoreClient#getRecord">`KeyValueStoreClient.getRecord()`</ApiLink>, which all return a Node.js `Readable` stream.
+- Proxy support through the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
+- Request body compression.
+- The `User-Agent` header, which browsers don't let a page set.

--- a/docs/02_concepts/05_bundled-environments.md
+++ b/docs/02_concepts/05_bundled-environments.md
@@ -34,7 +34,7 @@ Two dependencies still import Node.js built-ins:
 - `@apify/log` imports `node:events` and reads `process.env`.
 - `@apify/utilities` imports `node:stream` and `node:crypto`, and uses `Buffer`.
 
-Until [apify/apify-shared-js#537](https://github.com/apify/apify-shared-js/issues/537) removes them, bundling the ES module build for a non-Node.js target needs polyfills for `events`, `process`, `stream`, and `buffer`. The `node:crypto` import can resolve to an empty module, because only deprecated functions the client doesn't call use it. On Cloudflare Workers, the [`nodejs_compat`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) compatibility flag provides all of them.
+Until [apify/apify-shared-js#537](https://github.com/apify/apify-shared-js/issues/537) removes them, bundling the ES module build for a non-Node.js target needs polyfills for `events`, `process`, `stream`, and `buffer`. The `node:crypto` import can resolve to an empty module, because the client only calls the helpers that `@apify/utilities` builds on Web Crypto. On Cloudflare Workers, the [`nodejs_compat`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) compatibility flag provides all of them.
 
 ## Features that need Node.js
 

--- a/docs/02_concepts/05_bundled-environments.md
+++ b/docs/02_concepts/05_bundled-environments.md
@@ -21,20 +21,13 @@ The package ships a pre-built browser bundle at `dist/bundle.js`. A bundler that
 import { ApifyClient } from 'apify-client/browser';
 ```
 
-The bundle includes polyfills for the Node.js built-ins the client's dependencies import, so it needs no polyfill configuration.
+The bundle is self-contained and needs no polyfill configuration.
 
 ## Bundling the ES module build yourself
 
 The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a single module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, every other target gets the Web API one. A bundler targeting a browser, Cloudflare Workers, or another edge runtime therefore never sees `node:zlib`, `node:os`, `node:util`, or `proxy-agent`.
 
 Reaching the ES module build takes a bundler that doesn't set the `browser` condition, which resolves `apify-client` to the pre-built bundle. esbuild's `neutral` platform sets no conditions, and webpack and Vite let you list them through `resolve.conditionNames` and `resolve.conditions`.
-
-Two dependencies still import Node.js built-ins:
-
-- `@apify/log` imports `node:events` and reads `process.env`.
-- `@apify/utilities` imports `node:stream` and `node:crypto`, and uses `Buffer`.
-
-Until [apify/apify-shared-js#537](https://github.com/apify/apify-shared-js/issues/537) removes them, bundling the ES module build for a non-Node.js target needs polyfills for `events`, `process`, `stream`, and `buffer`. The `node:crypto` import can resolve to an empty module, because the client only calls the helpers that `@apify/utilities` builds on Web Crypto. On Cloudflare Workers, the [`nodejs_compat`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) compatibility flag provides all of them.
 
 ## Features that need Node.js
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -178,9 +178,11 @@ Two return types change as a result of describing what the endpoints really retu
 
 ## The client's own code no longer needs Node.js
 
-The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, and every other target gets the Web API one, so a bundler targeting a browser or an edge runtime no longer pulls `node:zlib`, `node:os`, `node:net`, or `proxy-agent` out of the client. Two dependencies still import Node.js built-ins, so bundling the ES module build for a non-Node.js target still needs a few polyfills. For details, see [Bundled environments](../02_concepts/05_bundled-environments.md).
+The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, and every other target gets the Web API one, so a bundler targeting a browser or an edge runtime no longer pulls `node:zlib`, `node:os`, `node:util`, or `proxy-agent` out of the client. Two dependencies still import Node.js built-ins, so bundling the ES module build for a non-Node.js target still needs a few polyfills. For details, see [Bundled environments](../02_concepts/05_bundled-environments.md).
 
 On Node.js nothing changes. The features that need it, log streaming and the `stream` record option, proxy support and request compression, work as before.
+
+The pick happens when the import is resolved rather than at runtime, so a Node.js application bundled for a browser or a neutral target gets the Web API implementation and loses those features. The client used to sniff the runtime and recover. The bundler's target now decides.
 
 ### Response bodies are decoded by `TextDecoder`
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -317,27 +317,37 @@ export HTTPS_PROXY=http://proxy.example.com:3128
 
 The same `proxy-agent` upgrade removes the `[DEP0169] DeprecationWarning` about `url.parse()` that Node.js 24 and newer printed on the client's first request.
 
-## The client's own code no longer needs Node.js
+## Node.js-only features follow the bundler's target
 
-The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, and every other target gets the Web API one, so a bundler targeting a browser or an edge runtime no longer pulls `node:zlib`, `node:os`, `node:util`, or `proxy-agent` out of the client. Two dependencies still import Node.js built-ins, so bundling the ES module build for a non-Node.js target still needs a few polyfills. For details, see [Bundled environments](../02_concepts/05_bundled-environments.md).
+Four features need Node.js APIs: log streaming with <ApiLink to="class/LogClient#stream">`LogClient.stream()`</ApiLink> and <ApiLink to="class/RunClient#getStreamedLog">`RunClient.getStreamedLog()`</ApiLink>, the `stream` option of <ApiLink to="class/KeyValueStoreClient#getRecord">`KeyValueStoreClient.getRecord()`</ApiLink>, proxy support, and request body compression.
 
-On Node.js nothing changes. The features that need it, log streaming and the `stream` record option, proxy support and request compression, work as before.
+In v2 the client detected the runtime when one of them was used, so a Node.js application bundled for a browser or a neutral target kept them all. In v3 the implementation is picked when the import is resolved, so the bundler's conditions decide. Without the `node` condition, `getRecord({ stream: true })` throws, `getStreamedLog()` returns `undefined`, and requests go out unproxied, uncompressed, and without the client's `User-Agent` header.
 
-The pick happens when the import is resolved rather than at runtime, so a Node.js application bundled for a browser or a neutral target gets the Web API implementation and loses those features. The client used to sniff the runtime and recover. The bundler's target now decides.
+Enable the `node` condition when you bundle for Node.js. esbuild sets it through `platform: 'node'`, webpack through `resolve.conditionNames`, and Vite through `resolve.conditions`.
 
-A test runner that resolves the `browser` condition decides the same way. Jest's `jsdom` environment resolves it, so a Node.js test suite running under it gets the Web API implementation unless you set `testEnvironmentOptions.customExportConditions` to `['node']`.
+A test runner that resolves the `browser` condition decides the same way. Jest's `jsdom` environment resolves it, so a Node.js test suite running under it loses them unless you list the `node` condition:
+
+```js
+// jest.config.js
+export default {
+    testEnvironment: 'jsdom',
+    testEnvironmentOptions: { customExportConditions: ['node'] },
+};
+```
+
+Running on Node.js without a bundler is unaffected, and the pre-built browser bundle behaves as it did in v2. For what bundling for a non-Node.js target takes, see [Bundled environments](../02_concepts/05_bundled-environments.md).
 
 ### Response bodies are decoded by `TextDecoder`
 
-The client used to decode a response body with `Buffer` in Node.js and with `TextDecoder` in the browser, and now uses `TextDecoder` everywhere. The two don't agree on which charsets they support, or on what a few of the shared ones mean, so a `content-type` header carrying a charset can be handled differently:
+In Node.js, v2 decoded response bodies with `Buffer` and v3 decodes them with `TextDecoder`. The two support different charsets, so a `content-type` header carrying one can be handled differently:
 
-- A charset `TextDecoder` knows and `Buffer` doesn't, such as `iso-8859-1`, now decodes to a string. It used to be handed back as raw bytes.
-- A charset `Buffer` knows and `TextDecoder` doesn't, such as `hex` or `base64`, is now handed back as raw bytes. It used to be decoded as if the body were in that encoding, which mangled it.
-- `ascii` is a label both of them know but read differently. `Buffer` masked every byte down to seven bits, and `TextDecoder` treats the label as an alias for `windows-1252`, so a byte above `0x7F` now decodes to the character that encoding gives it.
-- A leading UTF-8 byte order mark is stripped from every decoded body. A JSON body carrying one now parses instead of throwing, and a `text/*` record such as a BOM-prefixed CSV comes back without it.
+- `iso-8859-1` and other charsets only `TextDecoder` knows decode to a string, where v2 handed back raw bytes.
+- `hex` and `base64`, which only `Buffer` knows, come back as raw bytes, where v2 decoded the body as if it were in that encoding.
+- `ascii` is read as an alias for `windows-1252`, so a byte above `0x7F` decodes to the character that encoding gives it, where v2 masked the byte down to seven bits.
+- A leading UTF-8 byte order mark is stripped from every decoded body, so a JSON body carrying one parses instead of throwing, and a `text/*` record such as a BOM-prefixed CSV comes back without it.
 
-Apart from the byte order mark, a body with no charset or with a UTF-8 one is unaffected, and that covers everything the Apify API sends.
+Code that depended on one of these has to convert the value itself. A body with no charset or with a UTF-8 one is unaffected, apart from the byte order mark, and that covers everything the Apify API sends.
 
-### Request compression accepts more body types
+### Request compression covers more body types
 
-Request bodies were compressed only when they were a string or a `Buffer`. A `Uint8Array`, another typed array, or an `ArrayBuffer` is now compressed too, so a request that carries one gains a `content-encoding` header it didn't have before. The API has always accepted both encodings the client sends, `br` and `gzip`.
+v2 compressed a request body only when it was a string or a `Buffer`. A `Uint8Array`, another typed array, or an `ArrayBuffer` is compressed as well once it reaches the same 1 kB threshold, so a request carrying one gains a `content-encoding` header. The API accepts both encodings the client sends, `br` and `gzip`, so nothing needs to change on your side.

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -288,15 +288,18 @@ On Node.js nothing changes. The features that need it, log streaming and the `st
 
 The pick happens when the import is resolved rather than at runtime, so a Node.js application bundled for a browser or a neutral target gets the Web API implementation and loses those features. The client used to sniff the runtime and recover. The bundler's target now decides.
 
+A test runner that resolves the `browser` condition decides the same way. Jest's `jsdom` environment resolves it, so a Node.js test suite running under it gets the Web API implementation unless you set `testEnvironmentOptions.customExportConditions` to `['node']`.
+
 ### Response bodies are decoded by `TextDecoder`
 
-The client used to decode a response body with `Buffer` in Node.js and with `TextDecoder` in the browser, and now uses `TextDecoder` everywhere. The two support different charsets, so a `content-type` header carrying one the other doesn't know is handled differently:
+The client used to decode a response body with `Buffer` in Node.js and with `TextDecoder` in the browser, and now uses `TextDecoder` everywhere. The two don't agree on which charsets they support, or on what a few of the shared ones mean, so a `content-type` header carrying a charset can be handled differently:
 
 - A charset `TextDecoder` knows and `Buffer` doesn't, such as `iso-8859-1`, now decodes to a string. It used to be handed back as raw bytes.
 - A charset `Buffer` knows and `TextDecoder` doesn't, such as `hex` or `base64`, is now handed back as raw bytes. It used to be decoded as if the body were in that encoding, which mangled it.
-- A leading UTF-8 byte order mark is stripped, so a JSON body carrying one parses instead of throwing.
+- `ascii` is a label both of them know but read differently. `Buffer` masked every byte down to seven bits, and `TextDecoder` treats the label as an alias for `windows-1252`, so a byte above `0x7F` now decodes to the character that encoding gives it.
+- A leading UTF-8 byte order mark is stripped from every decoded body. A JSON body carrying one now parses instead of throwing, and a `text/*` record such as a BOM-prefixed CSV comes back without it.
 
-Bodies with no charset, or with a UTF-8 one, are unaffected, which covers everything the Apify API sends.
+Apart from the byte order mark, a body with no charset or with a UTF-8 one is unaffected, and that covers everything the Apify API sends.
 
 ### Request compression accepts more body types
 

--- a/docs/04_upgrading/upgrading_v3.md
+++ b/docs/04_upgrading/upgrading_v3.md
@@ -175,3 +175,23 @@ Two return types change as a result of describing what the endpoints really retu
 
 - <ApiLink to="class/ScheduleClient#getLog">`ScheduleClient.getLog()`</ApiLink> was typed as a `string`, even though the endpoint returns the log as a list of entries. It's now typed as <ApiLink to="interface/ScheduleInvoked">`ScheduleInvoked[]`</ApiLink>, each entry carrying `message`, `level` and `createdAt`.
 - <ApiLink to="interface/TaskPublicConfig">`TaskPublicConfig`</ApiLink> now follows the specification: `publishedAt` is optional and read-only, and `categorization`, which the specification doesn't describe, is gone from the type.
+
+## The client's own code no longer needs Node.js
+
+The client's own code runs on Web APIs. The parts that need Node.js built-ins, the keep-alive HTTP agents with proxy support and request body compression, live in a module that the `#runtime` entry of the package's `imports` field selects at bundle time. The `node` condition gets the Node.js implementation, and every other target gets the Web API one, so a bundler targeting a browser or an edge runtime no longer pulls `node:zlib`, `node:os`, `node:net`, or `proxy-agent` out of the client. Two dependencies still import Node.js built-ins, so bundling the ES module build for a non-Node.js target still needs a few polyfills. For details, see [Bundled environments](../02_concepts/05_bundled-environments.md).
+
+On Node.js nothing changes. The features that need it, log streaming and the `stream` record option, proxy support and request compression, work as before.
+
+### Response bodies are decoded by `TextDecoder`
+
+The client used to decode a response body with `Buffer` in Node.js and with `TextDecoder` in the browser, and now uses `TextDecoder` everywhere. The two support different charsets, so a `content-type` header carrying one the other doesn't know is handled differently:
+
+- A charset `TextDecoder` knows and `Buffer` doesn't, such as `iso-8859-1`, now decodes to a string. It used to be handed back as raw bytes.
+- A charset `Buffer` knows and `TextDecoder` doesn't, such as `hex` or `base64`, is now handed back as raw bytes. It used to be decoded as if the body were in that encoding, which mangled it.
+- A leading UTF-8 byte order mark is stripped, so a JSON body carrying one parses instead of throwing.
+
+Bodies with no charset, or with a UTF-8 one, are unaffected, which covers everything the Apify API sends.
+
+### Request compression accepts more body types
+
+Request bodies were compressed only when they were a string or a `Buffer`. A `Uint8Array`, another typed array, or an `ArrayBuffer` is now compressed too, so a request that carries one gains a `content-encoding` header it didn't have before. The API has always accepted both encodings the client sends, `br` and `gzip`.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "types": "dist/index.d.ts",
     "browser": "dist/bundle.js",
     "unpkg": "dist/bundle.js",
+    "imports": {
+        "#runtime": {
+            "node": "./dist/runtime/node.js",
+            "default": "./dist/runtime/web.js"
+        }
+    },
     "exports": {
         "./package.json": "./package.json",
         "./browser": "./dist/bundle.js",

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -70,9 +70,7 @@ export default defineConfig({
         },
     },
     mode: 'production',
-    // The client's own code needs no polyfills. These are for `@apify/log` (`node:events`, `process.env`)
-    // and `@apify/utilities` (`node:stream`, `Buffer`), see https://github.com/apify/apify-shared-js/issues/537.
-    // `@apify/utilities` also imports `node:crypto`, but the client only calls the helpers it builds on
-    // Web Crypto, so the import resolves to an empty module instead of a polyfill.
+    // The client's own code needs no polyfills, so these cover its dependencies. `node:crypto` is excluded,
+    // because the client only calls the helpers built on Web Crypto.
     plugins: [pluginNodePolyfill({ overrides: { crypto: false } })],
 });

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,18 +1,7 @@
-import { defineConfig, rspack } from '@rsbuild/core';
+import { defineConfig } from '@rsbuild/core';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
-import { version } from './package.json';
-
 const MAX_BUNDLE_BYTES = 360 * 1024;
-
-const nodeOnlyModules = /^proxy-agent$/;
-const unusedInBrowserBuiltins = ['os', 'zlib', 'util'];
-const builtinAliases = Object.fromEntries(
-    unusedInBrowserBuiltins.flatMap((m) => [
-        [m, false],
-        [`node:${m}`, false],
-    ]),
-);
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -20,10 +9,15 @@ export default defineConfig({
         entry: {
             Apify: './src/index.ts',
         },
-        define: {
-            VERSION: JSON.stringify(version),
-            BROWSER_BUILD: true,
+    },
+    resolve: {
+        alias: {
+            // The `imports` field of `package.json` maps this to `dist`; bundle the source instead.
+            '#runtime': './src/runtime/web.ts',
         },
+        // `tsconfig.json` maps `#runtime` to the Node.js implementation for type-checking, and the default
+        // strategy lets that mapping win over the alias.
+        aliasStrategy: 'prefer-alias',
     },
     output: {
         distPath: { js: '.' },
@@ -61,7 +55,7 @@ export default defineConfig({
                 ...config.optimization,
                 splitChunks: false,
             };
-            // A regression guard, not a target: the bundle sits at ~335 kB, so this only fails the
+            // A regression guard, not a target: the bundle sits at ~325 kB, so this only fails the
             // build on an unnoticed jump. A `zod` minor is the likeliest cause, since it is a runtime
             // dependency on a caret range - bumping this constant is the expected response. The
             // generated response schemas growing with the OpenAPI specification is the other.
@@ -72,18 +66,13 @@ export default defineConfig({
                 // The source map is many times the size of the bundle and ships separately.
                 assetFilter: (filename) => filename === 'bundle.js',
             };
-            config.plugins = [...(config.plugins ?? []), new rspack.IgnorePlugin({ resourceRegExp: nodeOnlyModules })];
-            config.resolve = {
-                ...config.resolve,
-                alias: {
-                    ...config.resolve?.alias,
-                    ...builtinAliases,
-                },
-            };
             config.devtool = 'source-map';
         },
     },
     mode: 'production',
-    // @apify/utilities dynamically imports `crypto` on missing `SubtleCrypto` (but browsers have it).
+    // The client's own code needs no polyfills. These are for `@apify/log` (`node:events`, `process.env`)
+    // and `@apify/utilities` (`node:stream`, `Buffer`), see https://github.com/apify/apify-shared-js/issues/537.
+    // `@apify/utilities` also imports `node:crypto`, but only its deprecated synchronous functions use it,
+    // so the import resolves to an empty module instead of a polyfill.
     plugins: [pluginNodePolyfill({ overrides: { crypto: false } })],
 });

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
-const MAX_BUNDLE_BYTES = 360 * 1024;
+const MAX_BUNDLE_BYTES = 350 * 1024;
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -72,7 +72,7 @@ export default defineConfig({
     mode: 'production',
     // The client's own code needs no polyfills. These are for `@apify/log` (`node:events`, `process.env`)
     // and `@apify/utilities` (`node:stream`, `Buffer`), see https://github.com/apify/apify-shared-js/issues/537.
-    // `@apify/utilities` also imports `node:crypto`, but only its deprecated synchronous functions use it,
-    // so the import resolves to an empty module instead of a polyfill.
+    // `@apify/utilities` also imports `node:crypto`, but the client only calls the helpers it builds on
+    // Web Crypto, so the import resolves to an empty module instead of a polyfill.
     plugins: [pluginNodePolyfill({ overrides: { crypto: false } })],
 });

--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -1,7 +1,6 @@
 import type { AxiosResponse } from 'axios';
 import type { LiteralUnion } from 'type-fest';
 
-import { isomorphicBufferToString } from './body_parser.js';
 import type { ApifyApiErrorType } from './models.js';
 import { isBuffer } from './utils.js';
 
@@ -91,7 +90,7 @@ export class ApifyApiError extends Error {
         // the body buffer needs to parse to get the correct error.
         if (isBuffer(responseData)) {
             try {
-                responseData = JSON.parse(isomorphicBufferToString(response.data, 'utf-8'));
+                responseData = JSON.parse(new TextDecoder().decode(response.data));
             } catch {
                 // This can happen. The data in the response body are malformed.
             }

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -32,7 +32,7 @@ import { WebhookCollectionClient } from './resource_clients/webhook_collection.j
 import { WebhookDispatchClient } from './resource_clients/webhook_dispatch.js';
 import { WebhookDispatchCollectionClient } from './resource_clients/webhook_dispatch_collection.js';
 import { Statistics } from './statistics.js';
-import { parseArgument } from './utils.js';
+import { getEnv, parseArgument } from './utils.js';
 
 const DEFAULT_TIMEOUT_SECS = 360;
 
@@ -554,7 +554,7 @@ export class ApifyClient {
      * @since Added in 2.7.0
      */
     async setStatusMessage(message: string, options?: SetStatusMessageOptions): Promise<void> {
-        const runId = process.env[ACTOR_ENV_VARS.RUN_ID];
+        const runId = getEnv(ACTOR_ENV_VARS.RUN_ID);
         if (!runId) {
             throw new Error(`Environment variable ${ACTOR_ENV_VARS.RUN_ID} is not set!`);
         }

--- a/src/body_parser.ts
+++ b/src/body_parser.ts
@@ -1,67 +1,56 @@
 import contentTypeParser from 'content-type';
 import type { JsonArray, JsonObject } from 'type-fest';
 
-import { isNode } from './utils.js';
-
 const CONTENT_TYPE_JSON = 'application/json';
 const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}`, 'i'), /^application\/.*xml$/i, /^text\//i];
 
 /**
- * Parses a Buffer or ArrayBuffer using the provided content type header.
+ * Parses a binary response body using the provided content type header.
  *
  * - application/json is returned as a parsed object.
  * - application/*xml and text/* are returned as strings.
  * - everything else is returned as original body.
  *
  * If the header includes a charset, the body will be stringified only
- * if the charset represents a known encoding to Node.js or Browser.
+ * if the charset is an encoding `TextDecoder` knows.
  */
 export function maybeParseBody(
-    body: Buffer | ArrayBuffer,
+    body: ArrayBuffer | ArrayBufferView,
     contentTypeHeader: string,
-): string | Buffer | ArrayBuffer | JsonObject | JsonArray {
-    let contentType;
-    let charset: BufferEncoding;
+): string | ArrayBuffer | ArrayBufferView | JsonObject | JsonArray {
+    let contentType: string;
+    let charset: string | undefined;
     try {
         const result = contentTypeParser.parse(contentTypeHeader);
         contentType = result.type;
-        charset = result.parameters.charset as BufferEncoding;
+        charset = result.parameters.charset;
     } catch {
         // can't parse, keep original body
         return body;
     }
 
-    // If we can't successfully parse it, we return
+    if (!isContentTypeStringifiable(contentType)) return body;
+
+    // If we can't successfully decode it, we return
     // the original buffer rather than a mangled string.
-    if (!areDataStringifiable(contentType, charset)) return body;
-    const dataString = isomorphicBufferToString(body, charset);
+    const decoder = createDecoder(charset);
+    if (!decoder) return body;
+    const dataString = decoder.decode(body);
 
     return contentType === CONTENT_TYPE_JSON ? JSON.parse(dataString) : dataString;
 }
 
-export function isomorphicBufferToString(buffer: Buffer | ArrayBuffer, encoding: BufferEncoding): string {
-    if (buffer.constructor.name !== ArrayBuffer.name) {
-        return buffer.toString(encoding);
+function createDecoder(charset?: string): TextDecoder | undefined {
+    try {
+        // No charset: hope that it's utf-8.
+        return new TextDecoder(charset || 'utf-8');
+    } catch {
+        // `TextDecoder` throws a `RangeError` for a label it does not know.
+        return undefined;
     }
-
-    // Browser decoding only works with UTF-8.
-    const utf8decoder = new TextDecoder();
-    return utf8decoder.decode(new Uint8Array(buffer));
-}
-
-function isCharsetStringifiable(charset: string) {
-    if (!charset) return true; // hope that it's utf-8
-    if (isNode()) return Buffer.isEncoding(charset);
-    const normalizedCharset = charset.toLowerCase().replace('-', '');
-    // Browsers only support decoding utf-8 buffers.
-    return normalizedCharset === 'utf8';
 }
 
 function isContentTypeStringifiable(contentType: string) {
     if (!contentType) return false; // keep buffer
     return STRINGIFIABLE_CONTENT_TYPE_RXS.some((rx) => rx.test(contentType));
-}
-
-function areDataStringifiable(contentType: string, charset: string) {
-    return isContentTypeStringifiable(contentType) && isCharsetStringifiable(charset);
 }

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -43,8 +43,6 @@ export class HttpClient {
 
     private httpAgentsPromise?: Promise<void>;
 
-    private userAgentSuffix?: string | string[];
-
     constructor(options: HttpClientOptions) {
         const { token } = options;
         this.stats = options.apifyClientStats;
@@ -54,7 +52,6 @@ export class HttpClient {
         this.timeoutMillis = options.timeoutSecs * 1000;
         this.logger = options.logger;
         this.workflowKey = options.workflowKey || getEnv(APIFY_ENV_VARS.WORKFLOW_KEY);
-        this.userAgentSuffix = options.userAgentSuffix;
         this._onRequestRetry = this._onRequestRetry.bind(this);
 
         this.axios = axios.create({
@@ -105,8 +102,8 @@ export class HttpClient {
             const isAtHome = !!getEnv(APIFY_ENV_VARS.IS_AT_HOME);
             let userAgent = `ApifyClient/${version} (${runtime.platform}); isAtHome/${isAtHome}`;
 
-            if (this.userAgentSuffix) {
-                userAgent += `; ${asArray(this.userAgentSuffix).join('; ')}`;
+            if (options.userAgentSuffix) {
+                userAgent += `; ${asArray(options.userAgentSuffix).join('; ')}`;
             }
 
             this.axios.defaults.headers['User-Agent'] = userAgent;

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -14,9 +14,7 @@ import type { RequestInterceptorFunction } from './interceptors.js';
 import { InvalidResponseBodyError, requestInterceptors, responseInterceptors } from './interceptors.js';
 import { runtime } from '#runtime';
 import type { Statistics } from './statistics.js';
-import { asArray, cast, getEnv, getVersionData, isStream } from './utils.js';
-
-const { version } = getVersionData();
+import { asArray, cast, getEnv, isStream, version } from './utils.js';
 
 const RATE_LIMIT_EXCEEDED_STATUS_CODE = 429;
 

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -1,6 +1,5 @@
 import type http from 'node:http';
 import type https from 'node:https';
-import type { Socket } from 'node:net';
 
 import type { RetryFunction } from 'async-retry';
 import retry from 'async-retry';
@@ -13,8 +12,9 @@ import type { Log } from '@apify/log';
 import { ApifyApiError } from './apify_api_error.js';
 import type { RequestInterceptorFunction } from './interceptors.js';
 import { InvalidResponseBodyError, requestInterceptors, responseInterceptors } from './interceptors.js';
+import { runtime } from '#runtime';
 import type { Statistics } from './statistics.js';
-import { asArray, cast, getVersionData, isNode, isStream } from './utils.js';
+import { asArray, cast, getEnv, getVersionData, isStream } from './utils.js';
 
 const { version } = getVersionData();
 
@@ -41,7 +41,7 @@ export class HttpClient {
 
     workflowKey?: string;
 
-    private nodeInitPromise?: Promise<void>;
+    private httpAgentsPromise?: Promise<void>;
 
     private userAgentSuffix?: string | string[];
 
@@ -53,7 +53,7 @@ export class HttpClient {
         this.userProvidedRequestInterceptors = options.requestInterceptors;
         this.timeoutMillis = options.timeoutSecs * 1000;
         this.logger = options.logger;
-        this.workflowKey = options.workflowKey || process.env[APIFY_ENV_VARS.WORKFLOW_KEY];
+        this.workflowKey = options.workflowKey || getEnv(APIFY_ENV_VARS.WORKFLOW_KEY);
         this.userAgentSuffix = options.userAgentSuffix;
         this._onRequestRetry = this._onRequestRetry.bind(this);
 
@@ -100,76 +100,41 @@ export class HttpClient {
             this.axios.defaults.headers.Authorization = `Bearer ${token}`;
         }
 
+        // Browsers do not let a page set the header, so it is only sent where the runtime describes its platform.
+        if (runtime.platform) {
+            const isAtHome = !!getEnv(APIFY_ENV_VARS.IS_AT_HOME);
+            let userAgent = `ApifyClient/${version} (${runtime.platform}); isAtHome/${isAtHome}`;
+
+            if (this.userAgentSuffix) {
+                userAgent += `; ${asArray(this.userAgentSuffix).join('; ')}`;
+            }
+
+            this.axios.defaults.headers['User-Agent'] = userAgent;
+        }
+
         requestInterceptors.forEach((i) => this.axios.interceptors.request.use(i as any));
         this.userProvidedRequestInterceptors.forEach((i) => this.axios.interceptors.request.use(i as any));
         responseInterceptors.forEach((i) => this.axios.interceptors.response.use(i as any));
     }
 
-    private async ensureNodeInit(): Promise<void> {
-        if (!isNode()) return;
+    private async ensureHttpAgents(): Promise<void> {
+        this.httpAgentsPromise ??= this.initHttpAgents();
 
-        this.nodeInitPromise ??= this.initNode();
-
-        return this.nodeInitPromise;
+        return this.httpAgentsPromise;
     }
 
-    private async initNode(): Promise<void> {
-        if (!isNode()) return;
+    private async initHttpAgents(): Promise<void> {
+        const agents = await runtime.createHttpAgents({ timeoutMillis: this.timeoutMillis });
+        if (!agents) return;
 
-        const [{ ProxyAgent }, os] = await Promise.all([import('proxy-agent'), import('node:os')]);
-
-        // We want to keep sockets alive for better performance.
-        // Enhanced agent configuration based on agentkeepalive best practices:
-        // - Nagle's algorithm disabled for lower latency
-        // - Free socket timeout to prevent socket leaks
-        // - LIFO scheduling to reuse recent sockets
-        // - Socket TTL for connection freshness
-        const agentOptions: http.AgentOptions & { scheduling?: 'lifo' | 'fifo' } = {
-            keepAlive: true,
-            // Timeout for inactive sockets
-            // Prevents socket leaks from idle connections
-            timeout: this.timeoutMillis,
-            // Keep alive timeout for free sockets (15 seconds)
-            // Node.js will close unused sockets after this period
-            keepAliveMsecs: 15_000,
-            // Maximum number of sockets per host
-            maxSockets: 256,
-            maxFreeSockets: 256,
-            // LIFO scheduling - reuse most recently used sockets for better performance
-            scheduling: 'lifo',
-        };
-
-        // Use ProxyAgent which automatically detects proxy from environment variables
-        // and supports CONNECT tunneling
-        const proxyAgent = new ProxyAgent(agentOptions);
-        this.httpAgent = proxyAgent;
-        this.httpsAgent = proxyAgent;
-
-        // Disable Nagle's algorithm for lower latency
-        // This sends data immediately instead of buffering small packets
-        const setNoDelay = (socket: Socket) => {
-            socket.setNoDelay(true);
-        };
-
-        this.httpAgent.on('socket', setNoDelay);
-        this.httpsAgent.on('socket', setNoDelay);
-
+        this.httpAgent = agents.httpAgent;
+        this.httpsAgent = agents.httpsAgent;
         this.axios.defaults.httpAgent = this.httpAgent;
         this.axios.defaults.httpsAgent = this.httpsAgent;
-
-        // Works only in Node. Cannot be set in browser
-        const isAtHome = !!process.env[APIFY_ENV_VARS.IS_AT_HOME];
-        let userAgent = `ApifyClient/${version} (${os.platform()}; Node/${process.version}); isAtHome/${isAtHome}`;
-
-        if (this.userAgentSuffix) {
-            userAgent += `; ${asArray(this.userAgentSuffix).join('; ')}`;
-        }
-
-        this.axios.defaults.headers['User-Agent'] = userAgent;
     }
 
     async call<T = any>(config: ApifyRequestConfig): Promise<ApifyResponse<T>> {
-        await this.ensureNodeInit();
+        await this.ensureHttpAgents();
         this.stats.calls++;
         const makeRequest = this._createRequestHandler(config);
 

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -5,7 +5,7 @@ import type { JsonObject } from 'type-fest';
 
 import { maybeParseBody } from './body_parser.js';
 import type { ApifyRequestConfig, ApifyResponse } from './http_client.js';
-import { isNode, maybeCompressValue } from './utils.js';
+import { maybeCompressValue } from './utils.js';
 
 /**
  * This error exists for the quite common situation, where only a partial JSON response is received and
@@ -100,8 +100,8 @@ function parseResponseData(response: ApifyResponse): ApifyResponse {
         return response;
     }
 
-    const isBufferEmpty = isNode() ? !response.data.length : !response.data.byteLength;
-    if (isBufferEmpty) {
+    // A `Buffer` from the Node.js adapter and an `ArrayBuffer` from the browser ones both carry `byteLength`.
+    if (!response.data.byteLength) {
         // undefined is better than an empty buffer
         response.data = undefined;
         return response;

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -18,12 +18,12 @@ import {
 import type { ApifyRequestConfig } from '../http_client.js';
 import type { KeyValueClientListKeysResult, KeyValueListItem, KeyValueStore } from '../models.js';
 import * as schemas from '../schemas.js';
+import { runtime } from '#runtime';
 import {
     anyObjectSchema,
     applyQueryParamsToUrl,
     catchNotFoundOrThrow,
     isBuffer,
-    isNode,
     isStream,
     parseArgument,
     parseResponse,
@@ -373,7 +373,7 @@ export class KeyValueStoreClient extends ResourceClient {
         parseArgument(key, keySchema);
         const parsed = parseArgument(options, getRecordOptionsSchema, 'KeyValueClientGetRecordOptions');
 
-        if (parsed.stream && !isNode()) {
+        if (parsed.stream && !runtime.isNode) {
             throw new Error('The stream option can only be used in Node.js environment.');
         }
 

--- a/src/resource_clients/log.ts
+++ b/src/resource_clients/log.ts
@@ -10,7 +10,7 @@ import type { ApifyApiError } from '../apify_api_error.js';
 import type { ApiClientSubResourceOptions } from '../base/api_client.js';
 import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyRequestConfig } from '../http_client.js';
-import { cast, catchNotFoundOrThrow } from '../utils.js';
+import { cast, catchNotFoundOrThrow, concatBytes } from '../utils.js';
 
 /**
  * Client for accessing Actor run or build logs.
@@ -149,7 +149,8 @@ export class LoggerActorRedirect extends Logger {
  */
 export class StreamedLog {
     private destinationLog: Log;
-    private streamBuffer: Buffer[] = [];
+    private streamBuffer: Uint8Array[] = [];
+    private decoder = new TextDecoder();
     private splitMarker = /(?:\n|^)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)/g;
     private relevancyTimeLimit: Date | null;
 
@@ -205,7 +206,7 @@ export class StreamedLog {
         try {
             const lastChunkRemainder = await this.logStreamChunks(logStream);
             // Process whatever is left when exiting. Maybe it is incomplete, maybe it is last log without EOL.
-            const lastMessage = Buffer.from(lastChunkRemainder).toString().trim();
+            const lastMessage = this.decoder.decode(lastChunkRemainder).trim();
             if (lastMessage.length) {
                 this.destinationLog.info(lastMessage);
             }
@@ -229,7 +230,7 @@ export class StreamedLog {
             previousChunkRemainder = chunkWithPreviousRemainder.slice(lastCompleteMessageIndex);
 
             // Push complete part of the chunk to the buffer
-            this.streamBuffer.push(Buffer.from(chunkWithPreviousRemainder.slice(0, lastCompleteMessageIndex)));
+            this.streamBuffer.push(chunkWithPreviousRemainder.slice(0, lastCompleteMessageIndex));
             this.logBufferContent();
 
             // Keep processing the new data until stopped
@@ -244,7 +245,7 @@ export class StreamedLog {
      * Parse the buffer and log complete messages.
      */
     private logBufferContent(): void {
-        const allParts = Buffer.concat(this.streamBuffer).toString().split(this.splitMarker).slice(1);
+        const allParts = this.decoder.decode(concatBytes(this.streamBuffer)).split(this.splitMarker).slice(1);
         // Parse the buffer parts into complete messages
         const messageMarkers = allParts.filter((_, i) => i % 2 === 0);
         const messageContents = allParts.filter((_, i) => i % 2 !== 0);

--- a/src/resource_clients/run.ts
+++ b/src/resource_clients/run.ts
@@ -8,7 +8,8 @@ import type { ApiClientOptionsWithOptionalResourcePath } from '../base/api_clien
 import { ResourceClient } from '../base/resource_client.js';
 import type { ApifyResponse } from '../http_client.js';
 import * as schemas from '../schemas.js';
-import { anyObjectSchema, isNode, parseArgument, parseResponse } from '../utils.js';
+import { runtime } from '#runtime';
+import { anyObjectSchema, parseArgument, parseResponse } from '../utils.js';
 import type { ActorRun } from './actor.js';
 import { DatasetClient } from './dataset.js';
 import { KeyValueStoreClient } from './key_value_store.js';
@@ -439,7 +440,7 @@ export class RunClient extends ResourceClient {
     async getStreamedLog(options: GetStreamedLogOptions = {}): Promise<StreamedLog | undefined> {
         const { fromStart = true } = options;
         let { toLog } = options;
-        if (toLog === null || !isNode()) {
+        if (toLog === null || !runtime.isNode) {
             // Explicitly no logging or not in Node.js
             return undefined;
         }

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -6,13 +6,8 @@ import { brotliCompress, constants, gzip } from 'node:zlib';
 
 import type { Runtime } from './types.js';
 
-const brotliCompressAsync = promisify(brotliCompress);
-const gzipAsync = promisify(gzip);
-
-const BROTLI_OPTIONS = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
-
 /**
- * The Node.js implementation of {@link Runtime}. Deno and Bun resolve the `node` export condition too and
+ * The Node.js implementation of {@link Runtime}. Deno and Bun resolve the `node` condition too and
  * provide the built-ins it uses.
  */
 export const runtime: Runtime = {
@@ -22,14 +17,18 @@ export const runtime: Runtime = {
 
     async compress(data) {
         try {
-            return { data: await brotliCompressAsync(data, BROTLI_OPTIONS), encoding: 'br' };
+            // Everything brotli needs belongs inside the fallback chain: `promisify()` throws for a missing
+            // function and `constants` need not carry the brotli parameters. At module scope either would fail
+            // the whole import instead of falling through to gzip.
+            const options = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
+            return { data: await promisify(brotliCompress)(data, options), encoding: 'br' };
         } catch {
             // Runtimes that only provide a partial `node:zlib` (Node.js compatibility shims) may not implement
             // brotli, but usually do implement gzip.
         }
 
         try {
-            return { data: await gzipAsync(data), encoding: 'gzip' };
+            return { data: await promisify(gzip)(data), encoding: 'gzip' };
         } catch {
             return undefined;
         }
@@ -41,11 +40,6 @@ export const runtime: Runtime = {
         const { ProxyAgent } = await import('proxy-agent');
 
         // We want to keep sockets alive for better performance.
-        // Enhanced agent configuration based on agentkeepalive best practices:
-        // - Nagle's algorithm disabled for lower latency
-        // - Free socket timeout to prevent socket leaks
-        // - LIFO scheduling to reuse recent sockets
-        // - Socket TTL for connection freshness
         const agentOptions: http.AgentOptions & { scheduling?: 'lifo' | 'fifo' } = {
             keepAlive: true,
             // Timeout for inactive sockets

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -1,0 +1,75 @@
+import type http from 'node:http';
+import type { Socket } from 'node:net';
+import os from 'node:os';
+import { promisify } from 'node:util';
+import { brotliCompress, constants, gzip } from 'node:zlib';
+
+import type { Runtime } from './types.js';
+
+const brotliCompressAsync = promisify(brotliCompress);
+const gzipAsync = promisify(gzip);
+
+const BROTLI_OPTIONS = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
+
+/**
+ * The Node.js implementation of {@link Runtime}. Deno and Bun resolve the `node` export condition too and
+ * provide the built-ins it uses.
+ */
+export const runtime: Runtime = {
+    isNode: true,
+
+    platform: `${os.platform()}; Node/${process.version}`,
+
+    async compress(data) {
+        try {
+            return { data: await brotliCompressAsync(data, BROTLI_OPTIONS), encoding: 'br' };
+        } catch {
+            // Runtimes that only provide a partial `node:zlib` (Node.js compatibility shims) may not implement
+            // brotli, but usually do implement gzip.
+        }
+
+        try {
+            return { data: await gzipAsync(data), encoding: 'gzip' };
+        } catch {
+            return undefined;
+        }
+    },
+
+    async createHttpAgents({ timeoutMillis }) {
+        // Loaded on the first request rather than with the client: the proxy support pulls in a sizeable
+        // dependency tree that a client which never sends a request should not pay for.
+        const { ProxyAgent } = await import('proxy-agent');
+
+        // We want to keep sockets alive for better performance.
+        // Enhanced agent configuration based on agentkeepalive best practices:
+        // - Nagle's algorithm disabled for lower latency
+        // - Free socket timeout to prevent socket leaks
+        // - LIFO scheduling to reuse recent sockets
+        // - Socket TTL for connection freshness
+        const agentOptions: http.AgentOptions & { scheduling?: 'lifo' | 'fifo' } = {
+            keepAlive: true,
+            // Timeout for inactive sockets
+            // Prevents socket leaks from idle connections
+            timeout: timeoutMillis,
+            // Keep alive timeout for free sockets (15 seconds)
+            // Node.js will close unused sockets after this period
+            keepAliveMsecs: 15_000,
+            // Maximum number of sockets per host
+            maxSockets: 256,
+            maxFreeSockets: 256,
+            // LIFO scheduling - reuse most recently used sockets for better performance
+            scheduling: 'lifo',
+        };
+
+        // ProxyAgent picks the proxy up from the environment variables and supports CONNECT tunneling.
+        const agent = new ProxyAgent(agentOptions);
+
+        // Disable Nagle's algorithm for lower latency
+        // This sends data immediately instead of buffering small packets
+        agent.on('socket', (socket: Socket) => {
+            socket.setNoDelay(true);
+        });
+
+        return { httpAgent: agent, httpsAgent: agent };
+    },
+};

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -17,9 +17,9 @@ export const runtime: Runtime = {
 
     async compress(data) {
         try {
-            // Everything brotli needs belongs inside the fallback chain: `promisify()` throws for a missing
-            // function and `constants` need not carry the brotli parameters. At module scope either would fail
-            // the whole import instead of falling through to gzip.
+            // `promisify()` belongs inside the fallback chain: a partial `node:zlib` can export
+            // `brotliCompress` without implementing it, and `promisify(undefined)` throws. At module scope
+            // that would fail the whole import instead of falling through to gzip.
             const options = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
             return { data: await promisify(brotliCompress)(data, options), encoding: 'br' };
         } catch {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,50 @@
+import type http from 'node:http';
+import type https from 'node:https';
+
+/**
+ * A request body compressed for transport, with the `content-encoding` value that declares it.
+ * @internal
+ */
+export interface CompressedValue {
+    data: Uint8Array;
+    encoding: 'br' | 'gzip';
+}
+
+/**
+ * The agents axios's Node.js adapter sends requests through.
+ * @internal
+ */
+export interface HttpAgents {
+    httpAgent: http.Agent;
+    httpsAgent: https.Agent;
+}
+
+/**
+ * The runtime-specific part of the client. `#runtime` resolves to the Node.js implementation under the `node`
+ * export condition and to the Web API one everywhere else (see the `imports` field of `package.json`), so a
+ * bundler targeting a browser or an edge runtime never sees the Node.js built-ins the Node.js one uses.
+ * @internal
+ */
+export interface Runtime {
+    /**
+     * Whether the client runs on Node.js, or on a runtime that provides its API such as Deno or Bun. The
+     * features that need a Node.js `Readable` response - log streaming and the `stream` record option - are
+     * gated on it.
+     */
+    isNode: boolean;
+    /**
+     * The platform part of the `User-Agent` header, or `undefined` where the runtime does not let a client
+     * set that header (browsers).
+     */
+    platform: string | undefined;
+    /**
+     * Compresses a request body, or resolves to `undefined` where compression is not available. Compression
+     * is a best-effort optimization, so it never throws.
+     */
+    compress(data: Uint8Array): Promise<CompressedValue | undefined>;
+    /**
+     * Creates the agents axios's Node.js adapter sends requests through, or resolves to `undefined` where
+     * axios does not use agents.
+     */
+    createHttpAgents(options: { timeoutMillis: number }): Promise<HttpAgents | undefined>;
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -27,7 +27,8 @@ export interface HttpAgents {
  */
 export interface Runtime {
     /**
-     * Whether the client runs on Node.js, or on a runtime that provides its API such as Deno or Bun. The
+     * Whether the Node.js implementation was selected, which the `node` condition settles when `#runtime` is
+     * resolved - so a Node.js application bundled for a browser or a neutral target reports `false`. The
      * features that need a Node.js `Readable` response - log streaming and the `stream` record option - are
      * gated on it.
      */

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -21,8 +21,8 @@ export interface HttpAgents {
 
 /**
  * The runtime-specific part of the client. `#runtime` resolves to the Node.js implementation under the `node`
- * export condition and to the Web API one everywhere else (see the `imports` field of `package.json`), so a
- * bundler targeting a browser or an edge runtime never sees the Node.js built-ins the Node.js one uses.
+ * condition and to the Web API one everywhere else (see the `imports` field of `package.json`), so a bundler
+ * targeting a browser or an edge runtime never sees the Node.js built-ins the Node.js one uses.
  * @internal
  */
 export interface Runtime {

--- a/src/runtime/web.ts
+++ b/src/runtime/web.ts
@@ -1,0 +1,22 @@
+import type { Runtime } from './types.js';
+
+/**
+ * The {@link Runtime} for browsers and edge runtimes, built on Web APIs only.
+ */
+export const runtime: Runtime = {
+    isNode: false,
+
+    // Browsers do not let a page set the `User-Agent` header.
+    platform: undefined,
+
+    // No request compression: brotli has no Web API, and a `content-encoding` request header is not on the
+    // list of headers the Apify API allows in a cross-origin request, so a browser would fail the preflight.
+    async compress() {
+        return undefined;
+    },
+
+    // The XHR and fetch adapters of axios do not use agents.
+    async createHttpAgents() {
+        return undefined;
+    },
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,8 @@ import type { ApifyApiError } from './apify_api_error.js';
 import { NotFoundError } from './apify_api_error.js';
 import { parseArgument } from '@apify/validations';
 import type { ApifyResponse } from './http_client.js';
+import type { CompressedValue } from './runtime/types.js';
+import { runtime } from '#runtime';
 import { ResponseValidationError } from './response_validation_error.js';
 import type {
     RequestQueueClientListRequestsOptions,
@@ -153,87 +155,72 @@ export function parseDateFields(
  */
 export function stringifyWebhooksToBase64(webhooks?: readonly WebhookUpdateData[]): string | undefined {
     if (!webhooks) return;
-    const webhooksJson = JSON.stringify(webhooks);
-    if (isNode()) {
-        return Buffer.from(webhooksJson, 'utf8').toString('base64');
-    }
-    const encoder = new TextEncoder();
-    const uint8Array = encoder.encode(webhooksJson);
-    return btoa(String.fromCharCode(...uint8Array));
+    return bytesToBase64(new TextEncoder().encode(JSON.stringify(webhooks)));
 }
 
-let brotliCompressPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
-
 /**
- * Brotli-compress the provided value.
+ * Encodes bytes as base64. `btoa()` takes a binary string, and the bytes are turned into one in slices,
+ * because spreading them all into a single `String.fromCharCode()` call overflows the argument limit on
+ * inputs of a few tens of kilobytes.
  */
-async function brotliValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
-    if (!brotliCompressPromisified) {
-        const { promisify } = await import('node:util');
-        const { brotliCompress, constants } = await import('node:zlib');
-        const compress = promisify(brotliCompress);
-        const options = { params: { [constants.BROTLI_PARAM_QUALITY]: 6 } };
-        brotliCompressPromisified = async (input) => compress(input, options);
+export function bytesToBase64(bytes: Uint8Array): string {
+    const SLICE_LENGTH = 0x8000;
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += SLICE_LENGTH) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + SLICE_LENGTH));
     }
-
-    return brotliCompressPromisified(value);
+    return btoa(binary);
 }
 
-let gzipPromisified: ((arg: string | Buffer<ArrayBufferLike>) => Promise<Buffer>) | undefined;
-
 /**
- * Gzip-compress the provided value.
+ * Concatenates byte chunks into one array.
  */
-async function gzipValue(value: string | Buffer<ArrayBufferLike>): Promise<Buffer> {
-    if (!gzipPromisified) {
-        const { promisify } = await import('node:util');
-        const { gzip } = await import('node:zlib');
-        gzipPromisified = promisify(gzip);
+export function concatBytes(chunks: Uint8Array[]): Uint8Array {
+    const result = new Uint8Array(chunks.reduce((length, chunk) => length + chunk.length, 0));
+    let offset = 0;
+    for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.length;
     }
-
-    return gzipPromisified(value);
-}
-
-export interface CompressedValue {
-    data: Buffer;
-    encoding: 'br' | 'gzip';
+    return result;
 }
 
 /**
- * Compress the passed value using brotli, falling back to gzip. Returns undefined if the data is
- * too small / wrong type, or if neither algorithm is available.
+ * Views a request body as bytes: a string is UTF-8 encoded, binary values are viewed in place. Anything else
+ * - a stream, a `Blob`, form data - is `undefined`.
+ */
+function toBytes(value: unknown): Uint8Array | undefined {
+    if (typeof value === 'string') return new TextEncoder().encode(value);
+    if (ArrayBuffer.isView(value)) return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    if (value instanceof ArrayBuffer) return new Uint8Array(value);
+    return undefined;
+}
+
+/**
+ * Compresses the passed value with the runtime's best available algorithm. Returns `undefined` if the data
+ * is too small, is not a string or binary value, or if the runtime does not offer compression.
  */
 export async function maybeCompressValue(value: unknown): Promise<CompressedValue | undefined> {
-    if (!isNode()) return undefined;
-
     // Request compression is not that important so let's
     // skip it instead of throwing for unsupported types.
-    if (typeof value !== 'string' && !Buffer.isBuffer(value)) return undefined;
+    const bytes = toBytes(value);
+    if (!bytes || bytes.byteLength < MIN_COMPRESS_BYTES) return undefined;
 
-    const areDataLargeEnough = Buffer.byteLength(value) >= MIN_COMPRESS_BYTES;
-    if (!areDataLargeEnough) return undefined;
+    return runtime.compress(bytes);
+}
 
-    try {
-        return { data: await brotliValue(value), encoding: 'br' };
-    } catch {
-        // Runtimes that only provide a partial `node:zlib` (bundler polyfills, edge runtimes with
-        // Node compatibility shims) may not implement brotli, but usually do implement gzip.
-    }
-
-    try {
-        return { data: await gzipValue(value), encoding: 'gzip' };
-    } catch {
-        // Same reasoning as above: compression is a best-effort optimization, so skip it instead
-        // of failing the request.
-        return undefined;
-    }
+/**
+ * Reads an environment variable, on runtimes that have them.
+ */
+export function getEnv(name: string): string | undefined {
+    return typeof process !== 'undefined' ? process.env?.[name] : undefined;
 }
 
 /**
  * Helper function slice the items from array to fit the max byte length.
  */
 export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, startIndex: number): T[] {
-    const stringByteLength = (str: string) => (isNode() ? Buffer.byteLength(str) : new Blob([str]).size);
+    const stringByteLength = (str: string) => new TextEncoder().encode(str).byteLength;
     const arrayByteLength = stringByteLength(JSON.stringify(array));
     if (arrayByteLength < maxByteLength) return array;
 
@@ -256,11 +243,6 @@ export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, sta
     return slicedArray;
 }
 
-export function isNode(): boolean {
-    if (typeof BROWSER_BUILD !== 'undefined') return false;
-    return !!(typeof process !== 'undefined' && process.versions && process.versions.node);
-}
-
 export function isBuffer(value: unknown): value is Buffer | ArrayBuffer | TypedArray {
     // Tag checks rather than `instanceof`, to also match buffers from another realm. `isView()`
     // additionally covers `DataView`, which is not raw binary content.
@@ -279,11 +261,8 @@ export function isStream(value: unknown): value is Readable {
 }
 
 export function getVersionData(): { version: string } {
-    if (typeof BROWSER_BUILD !== 'undefined') {
-        return { version: VERSION! };
-    }
-
-    return packageJson;
+    // Only the version, so a bundler can drop the rest of the manifest.
+    return { version: packageJson.version };
 }
 
 /**
@@ -336,11 +315,6 @@ export class RequestQueuePaginationIterator {
             nextExclusiveStartId = undefined; // see comment above - delete it for any page after the first one, and paginate with cursor
         }
     }
-}
-
-declare global {
-    export const BROWSER_BUILD: boolean | undefined;
-    export const VERSION: string | undefined;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ import type { WebhookUpdateData } from './resource_clients/webhook.js';
 import packageJson from '../package.json' with { type: 'json' };
 
 const MIN_COMPRESS_BYTES = 1024;
+const textEncoder = new TextEncoder();
 
 export { parseArgument };
 
@@ -155,7 +156,7 @@ export function parseDateFields(
  */
 export function stringifyWebhooksToBase64(webhooks?: readonly WebhookUpdateData[]): string | undefined {
     if (!webhooks) return;
-    return bytesToBase64(new TextEncoder().encode(JSON.stringify(webhooks)));
+    return bytesToBase64(textEncoder.encode(JSON.stringify(webhooks)));
 }
 
 /**
@@ -190,7 +191,7 @@ export function concatBytes(chunks: Uint8Array[]): Uint8Array {
  * - a stream, a `Blob`, form data - is `undefined`.
  */
 function toBytes(value: unknown): Uint8Array | undefined {
-    if (typeof value === 'string') return new TextEncoder().encode(value);
+    if (typeof value === 'string') return textEncoder.encode(value);
     if (ArrayBuffer.isView(value)) return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
     if (value instanceof ArrayBuffer) return new Uint8Array(value);
     return undefined;
@@ -220,7 +221,7 @@ export function getEnv(name: string): string | undefined {
  * Helper function slice the items from array to fit the max byte length.
  */
 export function sliceArrayByByteLength<T>(array: T[], maxByteLength: number, startIndex: number): T[] {
-    const stringByteLength = (str: string) => new TextEncoder().encode(str).byteLength;
+    const stringByteLength = (str: string) => textEncoder.encode(str).byteLength;
     const arrayByteLength = stringByteLength(JSON.stringify(array));
     if (arrayByteLength < maxByteLength) return array;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,9 @@ import packageJson from '../package.json' with { type: 'json' };
 const MIN_COMPRESS_BYTES = 1024;
 const textEncoder = new TextEncoder();
 
+// Only the version, so a bundler can drop the rest of the manifest.
+export const { version } = packageJson;
+
 export { parseArgument };
 
 /**
@@ -272,11 +275,6 @@ export function isStream(value: unknown): value is Readable {
     if (value === null || typeof value !== 'object') return false;
     const { on, pipe } = value as Partial<Readable>;
     return typeof on === 'function' && typeof pipe === 'function';
-}
-
-export function getVersionData(): { version: string } {
-    // Only the version, so a bundler can drop the rest of the manifest.
-    return { version: packageJson.version };
 }
 
 /**

--- a/test/body_parser.test.ts
+++ b/test/body_parser.test.ts
@@ -19,6 +19,19 @@ describe('maybeParseBody()', () => {
         expect(maybeParseBody(body, 'text/plain; charset=iso-8859-1')).toBe('café');
     });
 
+    test('reads the ascii charset as windows-1252, so a byte above 0x7F decodes to its character', () => {
+        const body = new Uint8Array([0x63, 0x61, 0x66, 0xe9]);
+        expect(maybeParseBody(body, 'text/plain; charset=ascii')).toBe('café');
+    });
+
+    test('strips a leading byte order mark from a JSON body, which would otherwise fail to parse', () => {
+        expect(maybeParseBody(encode('﻿{"a":1}'), 'application/json')).toEqual({ a: 1 });
+    });
+
+    test('strips a leading byte order mark from a text body', () => {
+        expect(maybeParseBody(encode('﻿a,b\n1,2'), 'text/csv; charset=utf-8')).toBe('a,b\n1,2');
+    });
+
     test('accepts an ArrayBuffer, which the browser adapters of axios return', () => {
         const bytes = encode('{"a":1}');
         const body = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
@@ -28,6 +41,11 @@ describe('maybeParseBody()', () => {
     test('keeps the body binary when the charset is unknown', () => {
         const body = encode('hello');
         expect(maybeParseBody(body, 'text/plain; charset=x-unknown')).toBe(body);
+    });
+
+    test.each(['hex', 'base64'])('keeps the body binary for the %s charset, which only Buffer knows', (charset) => {
+        const body = encode('6869');
+        expect(maybeParseBody(body, `text/plain; charset=${charset}`)).toBe(body);
     });
 
     test('keeps a binary content type as it is', () => {

--- a/test/body_parser.test.ts
+++ b/test/body_parser.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { maybeParseBody } from '../src/body_parser.js';
+
+const encode = (text: string) => new TextEncoder().encode(text);
+
+describe('maybeParseBody()', () => {
+    test('parses a JSON body', () => {
+        expect(maybeParseBody(encode('{"a":1}'), 'application/json; charset=utf-8')).toEqual({ a: 1 });
+    });
+
+    test('decodes text and XML bodies to strings', () => {
+        expect(maybeParseBody(encode('hello'), 'text/plain')).toBe('hello');
+        expect(maybeParseBody(encode('<a/>'), 'application/xml')).toBe('<a/>');
+    });
+
+    test('decodes a body in a charset other than UTF-8', () => {
+        const body = new Uint8Array([0x63, 0x61, 0x66, 0xe9]);
+        expect(maybeParseBody(body, 'text/plain; charset=iso-8859-1')).toBe('café');
+    });
+
+    test('accepts an ArrayBuffer, which the browser adapters of axios return', () => {
+        const bytes = encode('{"a":1}');
+        const body = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        expect(maybeParseBody(body, 'application/json')).toEqual({ a: 1 });
+    });
+
+    test('keeps the body binary when the charset is unknown', () => {
+        const body = encode('hello');
+        expect(maybeParseBody(body, 'text/plain; charset=x-unknown')).toBe(body);
+    });
+
+    test('keeps a binary content type as it is', () => {
+        const body = new Uint8Array([1, 2, 3]);
+        expect(maybeParseBody(body, 'image/png')).toBe(body);
+    });
+
+    test('keeps the body when the content type header cannot be parsed', () => {
+        const body = encode('hello');
+        expect(maybeParseBody(body, 'nonsense')).toBe(body);
+    });
+});

--- a/test/runs.test.ts
+++ b/test/runs.test.ts
@@ -384,6 +384,11 @@ describe('Run methods', () => {
             validateRequest({ query: {}, params: { runId } });
         });
 
+        test('getStreamedLog() returns undefined outside Node.js', async () => {
+            const browserRes = await page.evaluate((rId) => client.run(rId).getStreamedLog(), 'redirect-run-id');
+            expect(browserRes).toBeUndefined();
+        });
+
         test.each(['dataset', 'keyValueStore', 'requestQueue', 'log'] as const)(
             '%s().get() throws on 404 status code',
             async (method) => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,9 +2,11 @@ import { readFile } from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
 import { resolve } from 'node:path';
+import type * as Zlib from 'node:zlib';
+import { gunzipSync } from 'node:zlib';
 
 import { build } from 'esbuild';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { runtime as nodeRuntime } from '../src/runtime/node.js';
 import { runtime as webRuntime } from '../src/runtime/web.js';
@@ -20,6 +22,25 @@ describe('Node.js runtime', () => {
         const compressed = await nodeRuntime.compress(data);
         expect(compressed?.encoding).toBe('br');
         expect(compressed!.data.byteLength).toBeLessThan(data.byteLength);
+    });
+
+    test('falls back to gzip where `node:zlib` does not implement brotli', async () => {
+        vi.resetModules();
+        vi.doMock('node:zlib', async () => {
+            const zlib = await vi.importActual<typeof Zlib>('node:zlib');
+            return { ...zlib, brotliCompress: undefined };
+        });
+
+        try {
+            const { runtime } = await import('../src/runtime/node.js');
+            const data = new TextEncoder().encode('x'.repeat(2048));
+            const compressed = await runtime.compress(data);
+            expect(compressed?.encoding).toBe('gzip');
+            expect(gunzipSync(compressed!.data)).toEqual(Buffer.from(data));
+        } finally {
+            vi.doUnmock('node:zlib');
+            vi.resetModules();
+        }
     });
 
     test('creates one keep-alive agent for both http and https', async () => {
@@ -55,7 +76,7 @@ describe('#runtime resolution', () => {
      * resolves to the pre-built bundle instead. Dependencies stay external, and with them the Node.js built-ins
      * that `@apify/log` and `@apify/utilities` still import.
      */
-    async function bundleClient(options: { platform: 'browser' | 'node'; conditions?: string[] }) {
+    async function bundleClient(options: { platform: 'browser' | 'neutral' | 'node'; conditions?: string[] }) {
         const { metafile } = await build({
             absWorkingDir: root,
             entryPoints: ['dist/index.js'],
@@ -74,7 +95,12 @@ describe('#runtime resolution', () => {
         return metafile.inputs;
     }
 
-    const targets: { target: string; platform: 'browser' | 'node'; conditions?: string[]; expected: string }[] = [
+    const targets: {
+        target: string;
+        platform: 'browser' | 'neutral' | 'node';
+        conditions?: string[];
+        expected: string;
+    }[] = [
         { target: 'a browser', platform: 'browser', expected: 'web' },
         {
             target: 'Cloudflare Workers',
@@ -82,6 +108,8 @@ describe('#runtime resolution', () => {
             conditions: ['workerd', 'worker', 'browser'],
             expected: 'web',
         },
+        // The target the documentation points at for reaching the ES module build, since it sets no conditions.
+        { target: 'a neutral runtime', platform: 'neutral', expected: 'web' },
         { target: 'Node.js', platform: 'node', expected: 'node' },
     ];
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,0 +1,99 @@
+import http from 'node:http';
+import os from 'node:os';
+import { resolve } from 'node:path';
+
+import { build } from 'esbuild';
+import { describe, expect, test } from 'vitest';
+
+import { runtime as nodeRuntime } from '../src/runtime/node.js';
+import { runtime as webRuntime } from '../src/runtime/web.js';
+
+describe('Node.js runtime', () => {
+    test('describes the platform for the User-Agent header', () => {
+        expect(nodeRuntime.isNode).toBe(true);
+        expect(nodeRuntime.platform).toBe(`${os.platform()}; Node/${process.version}`);
+    });
+
+    test('compresses with brotli', async () => {
+        const data = new TextEncoder().encode('x'.repeat(2048));
+        const compressed = await nodeRuntime.compress(data);
+        expect(compressed?.encoding).toBe('br');
+        expect(compressed!.data.byteLength).toBeLessThan(data.byteLength);
+    });
+
+    test('creates one keep-alive agent for both http and https', async () => {
+        const agents = await nodeRuntime.createHttpAgents({ timeoutMillis: 1000 });
+        // `options` is where an agent keeps its constructor options; the Node.js types leave it undeclared.
+        const agent = agents!.httpAgent as http.Agent & { options: http.AgentOptions };
+        expect(agent).toBeInstanceOf(http.Agent);
+        expect(agents!.httpsAgent).toBe(agent);
+        expect(agent.options).toMatchObject({ keepAlive: true, timeout: 1000 });
+        agent.destroy();
+    });
+});
+
+describe('Web API runtime', () => {
+    test('offers no platform, compression or agents', async () => {
+        expect(webRuntime.isNode).toBe(false);
+        expect(webRuntime.platform).toBeUndefined();
+        await expect(webRuntime.compress(new Uint8Array(4096))).resolves.toBeUndefined();
+        await expect(webRuntime.createHttpAgents({ timeoutMillis: 1000 })).resolves.toBeUndefined();
+    });
+});
+
+/**
+ * Unlike the tests above, these run against the built `dist`, since the `imports` field of `package.json` maps
+ * `#runtime` to files in it.
+ */
+describe('#runtime resolution', () => {
+    const root = resolve(import.meta.dirname, '..');
+
+    /**
+     * Bundles the built package the way a bundler for the given target would and returns the modules it pulled
+     * in. Dependencies stay external, and with them the Node.js built-ins that `@apify/log` and
+     * `@apify/utilities` still import.
+     */
+    async function bundleClient(options: { platform: 'browser' | 'node'; conditions?: string[] }) {
+        const { metafile } = await build({
+            absWorkingDir: root,
+            entryPoints: ['dist/index.js'],
+            bundle: true,
+            write: false,
+            metafile: true,
+            format: 'esm',
+            platform: options.platform,
+            conditions: options.conditions,
+            packages: 'external',
+            // A consumer's bundler never sees this repository's `tsconfig.json`, whose `paths` map `#runtime`
+            // to the Node.js source for type-checking.
+            tsconfigRaw: {},
+            logLevel: 'silent',
+        });
+        return metafile.inputs;
+    }
+
+    const targets: { target: string; platform: 'browser' | 'node'; conditions?: string[]; expected: string }[] = [
+        { target: 'a browser', platform: 'browser', expected: 'web' },
+        {
+            target: 'Cloudflare Workers',
+            platform: 'browser',
+            conditions: ['workerd', 'worker', 'browser'],
+            expected: 'web',
+        },
+        { target: 'Node.js', platform: 'node', expected: 'node' },
+    ];
+
+    test.each(targets)('a bundler targeting $target gets the $expected implementation', async (options) => {
+        const inputs = await bundleClient(options);
+        const implementations = Object.keys(inputs).filter((path) => /^dist\/runtime\/(node|web)\.js$/.test(path));
+        expect(implementations).toEqual([`dist/runtime/${options.expected}.js`]);
+    });
+
+    test('the Web API build imports no Node.js built-in', async () => {
+        const inputs = await bundleClient({ platform: 'browser' });
+        const builtins = Object.entries(inputs).flatMap(([path, input]) =>
+            input.imports.filter((i) => i.path.startsWith('node:')).map((i) => `${path} -> ${i.path}`),
+        );
+        expect(builtins).toEqual([]);
+    });
+});

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
 import { resolve } from 'node:path';
@@ -49,9 +50,10 @@ describe('#runtime resolution', () => {
     const root = resolve(import.meta.dirname, '..');
 
     /**
-     * Bundles the built package the way a bundler for the given target would and returns the modules it pulled
-     * in. Dependencies stay external, and with them the Node.js built-ins that `@apify/log` and
-     * `@apify/utilities` still import.
+     * Bundles the ES module build for the given target and returns the modules it pulled in. The entry point is
+     * `dist/index.js` rather than the package name, because the `browser` condition of the `exports` field
+     * resolves to the pre-built bundle instead. Dependencies stay external, and with them the Node.js built-ins
+     * that `@apify/log` and `@apify/utilities` still import.
      */
     async function bundleClient(options: { platform: 'browser' | 'node'; conditions?: string[] }) {
         const { metafile } = await build({
@@ -95,5 +97,12 @@ describe('#runtime resolution', () => {
             input.imports.filter((i) => i.path.startsWith('node:')).map((i) => `${path} -> ${i.path}`),
         );
         expect(builtins).toEqual([]);
+    });
+
+    test('the pre-built browser bundle got the Web API implementation', async () => {
+        const bundle = await readFile(resolve(root, 'dist/bundle.js'), 'utf8');
+        // A property access no other module makes, and one a minifier keeps. rsbuild resolves `#runtime` through
+        // an alias, so a resolution regression there would otherwise only show up as a bundle size jump.
+        expect(bundle).not.toContain('BROTLI_PARAM_QUALITY');
     });
 });

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -73,8 +73,8 @@ describe('#runtime resolution', () => {
     /**
      * Bundles the ES module build for the given target and returns the modules it pulled in. The entry point is
      * `dist/index.js` rather than the package name, because the `browser` condition of the `exports` field
-     * resolves to the pre-built bundle instead. Dependencies stay external, and with them the Node.js built-ins
-     * that `@apify/log` and `@apify/utilities` still import.
+     * resolves to the pre-built bundle instead. Dependencies stay external, so the inputs cover the client's
+     * own code alone.
      */
     async function bundleClient(options: { platform: 'browser' | 'neutral' | 'node'; conditions?: string[] }) {
         const { metafile } = await build({

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,7 +12,8 @@
         "allowImportingTsExtensions": true,
         "paths": {
             // The entry file, not the `../src` directory: `nodenext` has no directory index lookup.
-            "apify-client": ["../src/index.ts"]
+            "apify-client": ["../src/index.ts"],
+            "#runtime": ["../src/runtime/node.ts"]
         }
     },
     "include": [".", "../src/**/*"],

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 
 import type { WebhookUpdateData } from 'apify-client';
 import { ApifyApiError } from 'apify-client';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import * as utils from '../src/utils.js';
 
@@ -181,11 +181,14 @@ describe('utils.concatBytes()', () => {
 });
 
 describe('utils.getEnv()', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
     test('reads an environment variable', () => {
+        expect(utils.getEnv('APIFY_CLIENT_TEST_VARIABLE')).toBeUndefined();
         vi.stubEnv('APIFY_CLIENT_TEST_VARIABLE', 'value');
         expect(utils.getEnv('APIFY_CLIENT_TEST_VARIABLE')).toBe('value');
-        vi.unstubAllEnvs();
-        expect(utils.getEnv('APIFY_CLIENT_TEST_VARIABLE')).toBeUndefined();
     });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 
 import type { WebhookUpdateData } from 'apify-client';
 import { ApifyApiError } from 'apify-client';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import * as utils from '../src/utils.js';
 
@@ -135,8 +135,9 @@ describe('utils.maybeCompressValue()', () => {
         expect(await utils.maybeCompressValue('small')).toBeUndefined();
     });
 
-    test('returns undefined for non-string non-Buffer values', async () => {
+    test('returns undefined for non-string non-binary values', async () => {
         expect(await utils.maybeCompressValue({ foo: 'bar' })).toBeUndefined();
+        expect(await utils.maybeCompressValue(Readable.from(['x'.repeat(2048)]))).toBeUndefined();
     });
 
     test('compresses large string using brotli in Node.js', async () => {
@@ -144,17 +145,47 @@ describe('utils.maybeCompressValue()', () => {
         const result = await utils.maybeCompressValue(largeValue);
         expect(result).not.toBeUndefined();
         expect(result!.encoding).toBe('br');
-        expect(result!.data).toBeInstanceOf(Buffer);
-        expect(result!.data.length).toBeLessThan(Buffer.byteLength(largeValue));
+        expect(result!.data).toBeInstanceOf(Uint8Array);
+        expect(result!.data.byteLength).toBeLessThan(Buffer.byteLength(largeValue));
     });
 
-    test('compresses large Buffer using brotli in Node.js', async () => {
-        const largeValue = Buffer.alloc(2048, 'a');
-        const result = await utils.maybeCompressValue(largeValue);
+    test.each([
+        { kind: 'Buffer', value: Buffer.alloc(2048, 'a') },
+        { kind: 'Uint8Array', value: new Uint8Array(2048).fill(0x61) },
+        { kind: 'ArrayBuffer', value: new Uint8Array(2048).fill(0x61).buffer },
+    ])('compresses a large $kind using brotli in Node.js', async ({ value }) => {
+        const result = await utils.maybeCompressValue(value);
         expect(result).not.toBeUndefined();
         expect(result!.encoding).toBe('br');
-        expect(result!.data).toBeInstanceOf(Buffer);
-        expect(result!.data.length).toBeLessThan(largeValue.length);
+        expect(result!.data).toBeInstanceOf(Uint8Array);
+        expect(result!.data.byteLength).toBeLessThan(2048);
+    });
+});
+
+describe('utils.bytesToBase64()', () => {
+    test('matches the Node.js encoding for an input longer than one slice', () => {
+        const bytes = new Uint8Array(100_000).map((_, i) => i * 7919);
+        expect(utils.bytesToBase64(bytes)).toBe(Buffer.from(bytes).toString('base64'));
+    });
+
+    test('encodes an empty input', () => {
+        expect(utils.bytesToBase64(new Uint8Array())).toBe('');
+    });
+});
+
+describe('utils.concatBytes()', () => {
+    test('joins the chunks in order', () => {
+        const chunks = [new Uint8Array([1, 2]), new Uint8Array(), new Uint8Array([3])];
+        expect(utils.concatBytes(chunks)).toEqual(new Uint8Array([1, 2, 3]));
+    });
+});
+
+describe('utils.getEnv()', () => {
+    test('reads an environment variable', () => {
+        vi.stubEnv('APIFY_CLIENT_TEST_VARIABLE', 'value');
+        expect(utils.getEnv('APIFY_CLIENT_TEST_VARIABLE')).toBe('value');
+        vi.unstubAllEnvs();
+        expect(utils.getEnv('APIFY_CLIENT_TEST_VARIABLE')).toBeUndefined();
     });
 });
 
@@ -206,5 +237,12 @@ describe('utils.stringifyWebhooksToBase64()', () => {
 
         expect(base64String).toBe(Buffer.from(JSON.stringify(webhooks), 'utf8').toString('base64'));
         expect(JSON.parse(Buffer.from(base64String, 'base64').toString('utf8'))).toStrictEqual(webhooks);
+    });
+
+    test('encodes multi-byte characters in a payload longer than one base64 slice', () => {
+        const webhooks: WebhookUpdateData[] = [{ description: 'Příliš žluťoučký kůň '.repeat(4000) }];
+        const base64String = utils.stringifyWebhooksToBase64(webhooks)!;
+
+        expect(base64String).toBe(Buffer.from(JSON.stringify(webhooks), 'utf8').toString('base64'));
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
         "sourceMap": false,
         "paths": {
             // `#runtime` is a package.json subpath import that Node.js and bundlers resolve to `dist`. Type-checking
-            // goes straight to the source of the Node.js implementation; the Web API one implements the same interface.
+            // goes straight to the source of the Node.js implementation, and the Web API one implements the same
+            // interface. A bundler that reads this mapping picks the Node.js implementation whatever it targets, and
+            // some do so by default, so bundling the client from inside this repository has to override it: see
+            // `aliasStrategy` in `rsbuild.config.ts` and `tsconfigRaw` in `test/runtime.test.ts`.
             "#runtime": ["./src/runtime/node.ts"]
         }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,12 @@
         "rootDir": "src",
         "skipLibCheck": true,
         "declarationMap": false,
-        "sourceMap": false
+        "sourceMap": false,
+        "paths": {
+            // `#runtime` is a package.json subpath import that Node.js and bundlers resolve to `dist`. Type-checking
+            // goes straight to the source of the Node.js implementation; the Web API one implements the same interface.
+            "#runtime": ["./src/runtime/node.ts"]
+        }
     },
     "include": ["./src/**/*"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     resolve: {
         alias: {
             'apify-client': resolve(import.meta.dirname, 'src'),
+            '#runtime': resolve(import.meta.dirname, 'src/runtime/node.ts'),
         },
     },
     test: {


### PR DESCRIPTION
## Description

The client's own code imports no Node.js built-in. The Node-only parts, keep-alive HTTP agents with proxy support and request body compression, live in `src/runtime/node.ts`, with a Web API twin in `src/runtime/web.ts`. The `#runtime` entry in `imports` picks between them: the `node` condition resolves to the Node.js module, everything else to the Web API one, so a bundler targeting a browser or an edge runtime never sees `node:zlib`, `node:os`, `node:util` or `proxy-agent`. Node.js, Bun and Deno keep today's behavior.

Base64 encoding, byte counting, log chunk joining and response decoding go through `TextEncoder`, `TextDecoder` and `btoa`, so the `isNode()` sniff and the `BROWSER_BUILD` and `VERSION` globals are gone. rsbuild also needs `aliasStrategy: 'prefer-alias'`, so the `tsconfig.json` `paths` entry stops beating the `#runtime` alias. The bundle is 324 kB, down from 335 kB.

## Issues

- Closes #753. 
- `@apify/log` and `@apify/utilities` still import `node:events`, `node:stream` and `node:crypto`, so bundling the ES module build for a non-Node.js target needs polyfills for `events`, `process`, `stream` and `buffer`; tracked in apify/apify-shared-js#537.

## Testing

- `test/runtime.test.ts` covers both implementations and bundles `dist` with esbuild to assert that browser, Cloudflare Workers, neutral and Node.js targets each resolve `#runtime` to the right file, and that the Web API build imports no `node:` module.

## Breaking changes

- `TextDecoder` decodes response bodies instead of `Buffer`, so a `content-type` charset can be handled differently: `iso-8859-1` and similar decode to a string, `hex` and `base64` come back as raw bytes, `ascii` is read as `windows-1252`, and a leading UTF-8 BOM is stripped.
- Request compression now accepts `Uint8Array` and `ArrayBuffer` bodies, which gain a `content-encoding` header.
- Anything asking for the `browser` condition gets the Web API implementation even on Node.js. Jest's `jsdom` environment does, so a suite running under it loses log streaming, the `stream` record option, proxy support and compression unless `testEnvironmentOptions.customExportConditions` is set to `['node']`.

The v3 upgrading guide covers all of these.

*✍️ Drafted by Claude Code*
