### PR TITLE
fix: carry the API error body of a failed streaming request

### DIFF
--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -87,8 +87,8 @@ export class ApifyApiError extends Error {
         let responseData = response.data;
         let errorData: Record<string, unknown> | undefined;
 
-        // Some methods (e.g. downloadItems) set up forceBuffer on request response. If this request failed
-        // the body buffer needs to parse to get the correct error.
+        // A `forceBuffer` request (e.g. `downloadItems()`) and a failed streaming request, whose body `HttpClient`
+        // has read into a buffer, both arrive unparsed. Parse the body here to get at the error.
         if (isBuffer(responseData)) {
             try {
                 responseData = JSON.parse(isomorphicBufferToString(response.data, 'utf-8'));

--- a/src/apify_api_error.ts
+++ b/src/apify_api_error.ts
@@ -90,10 +90,12 @@ export class ApifyApiError extends Error {
         // A `forceBuffer` request (e.g. `downloadItems()`) and a failed streaming request, whose body `HttpClient`
         // has read into a buffer, both arrive unparsed. Parse the body here to get at the error.
         if (isBuffer(responseData)) {
+            const body = isomorphicBufferToString(response.data, 'utf-8');
             try {
-                responseData = JSON.parse(isomorphicBufferToString(response.data, 'utf-8'));
+                responseData = JSON.parse(body);
             } catch {
-                // This can happen. The data in the response body are malformed.
+                // A body that is not JSON at all, such as an HTML error page from a proxy, is kept as text.
+                responseData = body;
             }
         }
 

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -14,7 +14,7 @@ import { ApifyApiError } from './apify_api_error.js';
 import type { RequestInterceptorFunction } from './interceptors.js';
 import { InvalidResponseBodyError, requestInterceptors, responseInterceptors } from './interceptors.js';
 import type { Statistics } from './statistics.js';
-import { asArray, cast, getVersionData, isNode, isStream } from './utils.js';
+import { asArray, cast, getVersionData, isNode, isStream, streamToBuffer } from './utils.js';
 
 const { version } = getVersionData();
 
@@ -216,6 +216,12 @@ export class HttpClient {
 
                 response = await this.axios.request(config);
                 if (this._isStatusOk(response.status)) return response;
+
+                // A failed request with `responseType: 'stream'` carries the API error body in the stream. Read it
+                // so that `ApifyApiError` can parse it like any other error body.
+                if (isStream(response.data)) {
+                    response.data = await streamToBuffer(response.data);
+                }
             } catch (err) {
                 return cast(this._handleRequestError(err as AxiosError, config, stopTrying));
             }

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -9,12 +9,13 @@ import axios, { AxiosHeaders } from 'axios';
 
 import { APIFY_ENV_VARS } from '@apify/consts';
 import type { Log } from '@apify/log';
+import { concatStreamToBuffer } from '@apify/utilities';
 
 import { ApifyApiError } from './apify_api_error.js';
 import type { RequestInterceptorFunction } from './interceptors.js';
 import { InvalidResponseBodyError, requestInterceptors, responseInterceptors } from './interceptors.js';
 import type { Statistics } from './statistics.js';
-import { asArray, cast, getVersionData, isNode, isStream, streamToBuffer } from './utils.js';
+import { asArray, cast, getVersionData, isNode, isStream } from './utils.js';
 
 const { version } = getVersionData();
 
@@ -217,10 +218,11 @@ export class HttpClient {
                 response = await this.axios.request(config);
                 if (this._isStatusOk(response.status)) return response;
 
-                // A failed request with `responseType: 'stream'` carries the API error body in the stream. Read it
-                // so that `ApifyApiError` can parse it like any other error body.
+                // A failed request with `responseType: 'stream'` carries the API error body in the stream. Read
+                // it so that `ApifyApiError` can parse it like any other error body. A body that cannot be read
+                // leaves the error without a message, which beats losing the status code to a stream error.
                 if (isStream(response.data)) {
-                    response.data = await streamToBuffer(response.data);
+                    response.data = await concatStreamToBuffer(response.data).catch(() => undefined);
                 }
             } catch (err) {
                 return cast(this._handleRequestError(err as AxiosError, config, stopTrying));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -291,6 +291,17 @@ export function isStream(value: unknown): value is Readable {
     return typeof on === 'function' && typeof pipe === 'function';
 }
 
+/**
+ * Reads a binary stream to its end and returns the whole content as one buffer.
+ */
+export async function streamToBuffer(stream: Readable): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+}
+
 export function getVersionData(): { version: string } {
     if (typeof BROWSER_BUILD !== 'undefined') {
         return { version: VERSION! };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -291,17 +291,6 @@ export function isStream(value: unknown): value is Readable {
     return typeof on === 'function' && typeof pipe === 'function';
 }
 
-/**
- * Reads a binary stream to its end and returns the whole content as one buffer.
- */
-export async function streamToBuffer(stream: Readable): Promise<Buffer> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of stream) {
-        chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
-}
-
 export function getVersionData(): { version: string } {
     if (typeof BROWSER_BUILD !== 'undefined') {
         return { version: VERSION! };

--- a/test/apify_api_error.test.ts
+++ b/test/apify_api_error.test.ts
@@ -86,6 +86,23 @@ describe('ApifyApiError', () => {
         expect(error.attempt).toEqual(1);
     });
 
+    test('should carry the API error of a failed streaming request', async () => {
+        const client = new ApifyClient({ baseUrl, maxRetries: 0, ...DEFAULT_OPTIONS });
+
+        // A chained `run.log()` rethrows the 404, so the error itself is observable. Streams are Node-only, so
+        // there is no browser leg here.
+        const call = client.run('404').log().stream();
+        await expect(call).rejects.toThrow(NotFoundError);
+        await expect(call).rejects.toMatchObject({
+            name: 'NotFoundError',
+            statusCode: 404,
+            type: 'record-not-found',
+            message: 'Record with this name was not found',
+            httpMethod: 'get',
+            path: '/v2/actor-runs/404/log',
+        });
+    });
+
     test('should carry additional error data if provided', async () => {
         const datasetId = '400'; // check add_routes.js to see details of this mock
         const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);

--- a/test/apify_api_error.test.ts
+++ b/test/apify_api_error.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import type { Dictionary } from 'apify-client';
@@ -103,6 +104,41 @@ describe('ApifyApiError', () => {
         });
     });
 
+    test('should not invent a message for a failed streaming request with an empty body', async () => {
+        const client = new ApifyClient({ baseUrl, maxRetries: 0, ...DEFAULT_OPTIONS });
+
+        await expect(client.run('500').log().stream()).rejects.toMatchObject({
+            name: 'ServerError',
+            statusCode: 500,
+            message: '',
+        });
+    });
+
+    test('should keep the status code of a streaming request whose error body breaks mid-read', async () => {
+        // The connection drops after the headers, so the body read rejects. Without that rejection being
+        // swallowed, the 500 would surface as a network error instead.
+        const server = createServer((_req, res) => {
+            res.writeHead(500, { 'content-type': 'application/json' });
+            res.write('{"error":', () => res.socket?.destroy());
+        });
+        await new Promise<void>((resolve) => server.listen(0, resolve));
+        const client = new ApifyClient({
+            baseUrl: `http://localhost:${(server.address() as AddressInfo).port}`,
+            maxRetries: 0,
+            ...DEFAULT_OPTIONS,
+        });
+
+        try {
+            await expect(client.run('500').log().stream()).rejects.toMatchObject({
+                name: 'ServerError',
+                statusCode: 500,
+            });
+        } finally {
+            server.closeAllConnections();
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
     test('should carry additional error data if provided', async () => {
         const datasetId = '400'; // check add_routes.js to see details of this mock
         const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);
@@ -200,6 +236,7 @@ describe('ApifyApiError', () => {
 
             expect(error).toBeInstanceOf(NotFoundError);
             expect(error.type).toBeUndefined();
+            expect(error.message).toBe('Unexpected error: "<not json>"');
         });
     });
 });


### PR DESCRIPTION
Follow-up to #1041.

A failed request with `responseType: 'stream'` (`LogClient.stream()`, `getRecord({ stream: true })`) handed an unread `IncomingMessage` to `ApifyApiError`. `JSON.stringify` threw on its circular references, so the message read `Unexpected error: [object Object]` and the API's `type`, `message` and `data` were lost.

`HttpClient` now reads a streamed error body into a buffer before building the error, as the Python client does, using `concatStreamToBuffer` from `@apify/utilities`. A read that fails mid-body is swallowed: a raw socket error carries no status code, which would break `getRecord({ stream: true })` resolving to `undefined` on a 404. `ApifyApiError` decodes the buffer once and keeps a non-JSON body as text, so an HTML error page from a proxy is readable instead of a dump of byte values. That last part also improves `downloadItems()` and `getRecord({ buffer: true })` errors.

Known limitation, left as a follow-up: the body read sits outside the axios timeout, because axios settles a stream response at its headers. The agent's socket idle timeout bounds it, measured at 2043 ms under a 2 s client timeout, and `maxContentLength: -1` leaves it without a size cap. Tightening either needs a separate error-body budget.

Closes #1043

*✍️ Drafted by Claude Code*
